### PR TITLE
Refactor HTLC transactions

### DIFF
--- a/src/blockchain_app.erl
+++ b/src/blockchain_app.erl
@@ -31,13 +31,12 @@ start(_StartType, _StartArgs) ->
 
     % look up the DNS record and add any resulting addresses to the SeedNodes
     % no need to do any checks here as any bad combination results in an empty list
-    SeedAddresses = string:tokens(lists:flatten([string:prefix(X, "blockchain-seed-nodes=") || [X] <- inet_res:lookup(SeedNodeDNS, in, txt), string:prefix(X, "blockchain-seed-nodes=") /= nomatch]), ","),
-    SeedNodes ++ SeedAddresses,
+    SeedAddresses = string:tokens(lists:flatten([string:prefix(X, "blockchain-seed-nodes=") || [X] <- inet_res:lookup(SeedNodeDNS, in, txt), string:prefix(X, "blockchain-seed-nodes=") /= nomatch]), ","),    
 
     Args = [
             {base_dir, BaseDir},
             {num_consensus_members, NumConsensusMembers},
-            {seed_nodes, SeedNodes},
+            {seed_nodes, SeedNodes ++ SeedAddresses},
             {key, Key},
             {port, Port}
            ],

--- a/src/blockchain_ledger.erl
+++ b/src/blockchain_ledger.erl
@@ -51,7 +51,7 @@
 
 -record(ledger, {
     current_height = undefined :: undefined | pos_integer()
-    ,transaction_fee = 1 :: non_neg_integer()
+    ,transaction_fee = 0 :: non_neg_integer()
     ,consensus_members = [] :: [libp2p_crypto:address()]
     ,active_gateways = #{} :: active_gateways()
     ,entries = #{} :: entries()

--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -23,8 +23,8 @@
     ,spend/3
     ,payment_txn/5
     ,submit_txn/2
-    ,create_htlc_txn/5
-    ,redeem_htlc_txn/2
+    ,create_htlc_txn/6
+    ,redeem_htlc_txn/3
     ,add_gateway_request/1
     ,add_gateway_txn/1
     ,assert_location_request/2
@@ -146,17 +146,17 @@ payment_txn(PrivKey, Address, Recipient, Amount, Fee) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec create_htlc_txn(libp2p_crypto:address(), libp2p_crypto:address(), non_neg_integer(), binary(), non_neg_integer()) -> ok.
-create_htlc_txn(Payee, Address, Amount, Hashlock, Timelock) -> 
-    gen_server:cast(?SERVER, {create_htlc_txn, Payee, Address, Amount, Hashlock, Timelock}).
+-spec create_htlc_txn(libp2p_crypto:address(), libp2p_crypto:address(), non_neg_integer(), non_neg_integer(), binary(), non_neg_integer()) -> ok.
+create_htlc_txn(Payee, Address, Amount, Fee, Hashlock, Timelock) -> 
+    gen_server:cast(?SERVER, {create_htlc_txn, Payee, Address, Amount, Fee, Hashlock, Timelock}).
 
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec redeem_htlc_txn(libp2p_crypto:address(), binary()) -> ok.
-redeem_htlc_txn(Address, Preimage) ->
-    gen_server:cast(?SERVER, {redeem_htlc_txn, Address, Preimage}).
+-spec redeem_htlc_txn(libp2p_crypto:address(), binary(), non_neg_integer()) -> ok.
+redeem_htlc_txn(Address, Preimage, Fee) ->
+    gen_server:cast(?SERVER, {redeem_htlc_txn, Address, Preimage, Fee}).
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -405,16 +405,16 @@ handle_cast({payment_txn, PrivKey, Address, Recipient, Amount, Fee}, #state{bloc
     SignedPaymentTxn = blockchain_txn_payment:sign(PaymentTxn, SigFun),
     ok = send_txn(payment_txn, SignedPaymentTxn, State),
     {noreply, State};
-handle_cast({create_htlc_txn, Payee, Address, Amount, Hashlock, Timelock}, #state{swarm=Swarm}=State) ->
+handle_cast({create_htlc_txn, Payee, Address, Amount, Fee, Hashlock, Timelock}, #state{swarm=Swarm}=State) ->
     Payer = libp2p_swarm:address(Swarm),
-    CreateTxn = blockchain_txn_create_htlc:new(Payer, Payee, Address, Hashlock, Timelock, Amount),
+    CreateTxn = blockchain_txn_create_htlc:new(Payer, Payee, Address, Hashlock, Timelock, Amount, Fee),
     {ok, _PubKey, SigFun} = libp2p_swarm:keys(Swarm),
     SignedCreateTxn = blockchain_txn_create_htlc:sign(CreateTxn, SigFun),
     ok = send_txn(create_htlc_txn, SignedCreateTxn, State),
     {noreply, State};
-handle_cast({redeem_htlc_txn, Address, Preimage}, #state{swarm=Swarm}=State) ->
+handle_cast({redeem_htlc_txn, Address, Preimage, Fee}, #state{swarm=Swarm}=State) ->
     Payee = libp2p_swarm:address(Swarm),
-    RedeemTxn = blockchain_txn_redeem_htlc:new(Payee, Address, Preimage),
+    RedeemTxn = blockchain_txn_redeem_htlc:new(Payee, Address, Preimage, Fee),
     {ok, _PubKey, SigFun} = libp2p_swarm:keys(Swarm),
     SignedRedeemTxn = blockchain_txn_redeem_htlc:sign(RedeemTxn, SigFun),
     ok = send_txn(redeem_htlc_txn, SignedRedeemTxn, State),

--- a/src/cli/blockchain_cli_ledger.erl
+++ b/src/cli/blockchain_cli_ledger.erl
@@ -108,7 +108,8 @@ ledger_create_htlc_cmd() ->
                                        {payee, [{shortname, "p"}, {longname, "payee"}]},
                                        {value, [{shortname, "v", {longname, "value"}}]},
                                        {hashlock, [{shortname, "h"}, {longname, "hashlock"}]},
-                                       {timelock, [{shortname, "t"}, {longname, "timelock"}]}
+                                       {timelock, [{shortname, "t"}, {longname, "timelock"}]},
+                                       {fee, [{shortname, "f"}, {longname, "fee"}]}
                                       ], fun ledger_create_htlc/3]
     ].
 
@@ -124,7 +125,9 @@ ledger_create_htlc_usage() ->
       "  -h, --hashlock <sha256hash>\n",
       "  A SHA256 digest of a secret value (called a preimage) that locks this contract\n",
       "  -t, --timelock <blockheight>\n",
-      "  A specific blockheight after which the payer (you) can redeem their tokens\n"
+      "  A specific blockheight after which the payer (you) can redeem their tokens\n",
+      "  -f --fee <fee>\n",
+      "  The fee for the miners\n"
      ]
     ].
 
@@ -147,7 +150,8 @@ ledger_create_htlc_helper(Flags, Address) ->
     Amount = list_to_integer(clean(proplists:get_value(value, Flags))),
     Hashlock = blockchain_util:hex_to_bin(list_to_binary(clean(proplists:get_value(hashlock, Flags)))),
     Timelock = list_to_integer(clean(proplists:get_value(timelock, Flags))),
-    blockchain_worker:create_htlc_txn(Payee, Address, Amount, Hashlock, Timelock).
+    Fee = list_to_integer(clean(proplists:get_value(fee, Flags))),
+    blockchain_worker:create_htlc_txn(Payee, Address, Amount, Hashlock, Timelock, Fee).
 
 %%--------------------------------------------------------------------
 %% ledger redeem
@@ -156,7 +160,8 @@ ledger_redeem_htlc_cmd() ->
     [
      [["ledger", "redeem_htlc"], '_', [
                                        {address, [{shortname, "a"}, {longname, "address"}]},
-                                       {preimage, [{shortname, "p"}, {longname, "preimage"}]}
+                                       {preimage, [{shortname, "p"}, {longname, "preimage"}]},
+                                       {fee, [{shortname, "f"}, {longname, "fee"}]}
                                       ], fun ledger_redeem_htlc/3]
     ].
 
@@ -167,7 +172,9 @@ ledger_redeem_htlc_usage() ->
       "  -a, --address <address>\n",
       "  The address of the Hashed TimeLock Contract to redeem from\n",
       "  -p --preimage <preimage>\n",
-      "  The preimage used to create the Hashlock for this contract address\n"
+      "  The preimage used to create the Hashlock for this contract address\n",
+      "  -f --fee <fee>\n",
+      "  The fee for the miners\n"
      ]
     ].
 
@@ -185,7 +192,8 @@ ledger_redeem_htlc(_CmdBase, _Keys, Flags) ->
 ledger_redeem_htlc_helper(Flags) ->
     Address = libp2p_crypto:b58_to_address(clean(proplists:get_value(address, Flags))),
     Preimage = list_to_binary(clean(proplists:get_value(preimage, Flags))),
-    blockchain_worker:redeem_htlc_txn(Address, Preimage).
+    Fee = list_to_integer(clean(proplists:get_value(fee, Flags))),
+    blockchain_worker:redeem_htlc_txn(Address, Preimage, Fee).
 
 %%--------------------------------------------------------------------
 %% ledger add gateway_request

--- a/src/transactions/blockchain_transactions.erl
+++ b/src/transactions/blockchain_transactions.erl
@@ -154,7 +154,9 @@ absorb(blockchain_txn_payment, Txn, Ledger0) ->
     end;
 absorb(blockchain_txn_create_htlc, Txn, Ledger0) ->
     Amount = blockchain_txn_create_htlc:amount(Txn),
-    case Amount >= 0 of
+    Fee = blockchain_txn_create_htlc:fee(Txn),
+    MinerFee = blockchain_ledger:transaction_fee(Ledger0),
+    case (Amount >= 0) andalso (Fee >= MinerFee) of
         false ->
             lager:error("amount < 0 for CreateHTLCTxn: ~p", [Txn]),
             {error, invalid_transaction};
@@ -165,7 +167,7 @@ absorb(blockchain_txn_create_htlc, Txn, Ledger0) ->
                     Payee = blockchain_txn_create_htlc:payee(Txn),
                     Entry = blockchain_ledger:find_entry(Payer, blockchain_ledger:entries(Ledger0)),
                     Nonce = blockchain_ledger:payment_nonce(Entry) + 1,
-                    case blockchain_ledger:debit_account(Payer, Amount, Nonce, Ledger0) of
+                    case blockchain_ledger:debit_account(Payer, Amount + Fee, Nonce, Ledger0) of
                         {error, _Reason}=Error ->
                             Error;
                         Ledger1 ->
@@ -188,47 +190,61 @@ absorb(blockchain_txn_create_htlc, Txn, Ledger0) ->
             end
     end;
 absorb(blockchain_txn_redeem_htlc, Txn, Ledger0) ->
-    case blockchain_txn_redeem_htlc:is_valid(Txn) of
-        true ->
-            Address = blockchain_txn_redeem_htlc:address(Txn),
-            case blockchain_ledger:find_htlc(Address, blockchain_ledger:htlcs(Ledger0)) of
-                {error, _Reason}=Error ->
-                    Error;
-                HTLC ->
-                    Redeemer = blockchain_txn_redeem_htlc:payee(Txn),
-                    Payer = blockchain_ledger:htlc_payer(HTLC),
-                    Payee = blockchain_ledger:htlc_payee(HTLC),
-                    %% if the Creator of the HTLC is not the redeemer, continue to check for pre-image
-                    %% otherwise check that the timelock has expired which allows the Creator to redeem
-                    case Payer =:= Redeemer of
-                        false ->
-                            %% check that the address trying to redeem matches the HTLC
-                            case Redeemer =:= Payee of
-                                true ->
-                                    Hashlock = blockchain_ledger:htlc_hashlock(HTLC),
-                                    Preimage = blockchain_txn_redeem_htlc:preimage(Txn),
-                                    case (crypto:hash(sha256, Preimage) =:= Hashlock) of
-                                        true ->
-                                            {ok, blockchain_ledger:redeem_htlc(Address, Payee, Ledger0)};
-                                        false ->
-                                            {error, invalid_preimage}
-                                    end;
-                                false ->
-                                    {error, invalid_payee}
-                            end;
-                        true ->
-                            Timelock = blockchain_ledger:htlc_timelock(HTLC),
-                            Height = blockchain_ledger:current_height(Ledger0),
-                            case Timelock >= Height of
-                                true ->
-                                    {error, timelock_not_expired};
-                                false ->
-                                    {ok, blockchain_ledger:redeem_htlc(Address, Payee, Ledger0)}
-                            end
-                    end
-            end;
+    Fee = blockchain_txn_redeem_htlc:fee(Txn),
+    MinerFee = blockchain_ledger:transaction_fee(Ledger0),
+    case (Fee >= MinerFee) of
         false ->
-            {error, bad_signature}
+            {error, insufficient_fee};
+        true ->
+            case blockchain_txn_redeem_htlc:is_valid(Txn) of
+                true ->
+                    Address = blockchain_txn_redeem_htlc:address(Txn),
+                    case blockchain_ledger:find_htlc(Address, blockchain_ledger:htlcs(Ledger0)) of
+                        {error, _Reason}=Error ->
+                            Error;
+                        HTLC ->
+                            Redeemer = blockchain_txn_redeem_htlc:payee(Txn),
+                            Payer = blockchain_ledger:htlc_payer(HTLC),
+                            Payee = blockchain_ledger:htlc_payee(HTLC),
+                            Entry = blockchain_ledger:find_entry(Redeemer, blockchain_ledger:entries(Ledger0)),
+                            Nonce = blockchain_ledger:payment_nonce(Entry) + 1,
+                            case blockchain_ledger:debit_account(Redeemer, Fee, Nonce, Ledger0) of
+                                {error, _Reason}=Error ->
+                                    Error;
+                                Ledger1 ->
+                                    %% if the Creator of the HTLC is not the redeemer, continue to check for pre-image
+                                    %% otherwise check that the timelock has expired which allows the Creator to redeem
+                                    case Payer =:= Redeemer of
+                                        false ->
+                                            %% check that the address trying to redeem matches the HTLC
+                                            case Redeemer =:= Payee of
+                                                true ->
+                                                    Hashlock = blockchain_ledger:htlc_hashlock(HTLC),
+                                                    Preimage = blockchain_txn_redeem_htlc:preimage(Txn),
+                                                    case (crypto:hash(sha256, Preimage) =:= Hashlock) of
+                                                        true ->
+                                                            {ok, blockchain_ledger:redeem_htlc(Address, Payee, Ledger1)};
+                                                        false ->
+                                                            {error, invalid_preimage}
+                                                    end;
+                                                false ->
+                                                    {error, invalid_payee}
+                                            end;
+                                        true ->
+                                            Timelock = blockchain_ledger:htlc_timelock(HTLC),
+                                            Height = blockchain_ledger:current_height(Ledger1),
+                                            case Timelock >= Height of
+                                                true ->
+                                                    {error, timelock_not_expired};
+                                                false ->
+                                                    {ok, blockchain_ledger:redeem_htlc(Address, Payee, Ledger1)}
+                                            end
+                                    end
+                                end
+                    end;
+                false ->
+                    {error, bad_signature}
+        end
     end;
 absorb(blockchain_txn_poc_request, Txn, Ledger0) ->
     case blockchain_txn_poc_request:is_valid(Txn) of

--- a/src/transactions/blockchain_txn_create_htlc.erl
+++ b/src/transactions/blockchain_txn_create_htlc.erl
@@ -11,7 +11,7 @@
 -behavior(blockchain_txn).
 
 -export([
-    new/6
+    new/7
     ,hash/1
     ,payer/1
     ,payee/1
@@ -19,6 +19,7 @@
     ,hashlock/1
     ,timelock/1
     ,amount/1
+    ,fee/1
     ,signature/1
     ,sign/2
     ,is_valid/1
@@ -36,6 +37,7 @@
     ,hashlock :: binary()
     ,timelock :: integer()
     ,amount :: integer()
+    ,fee :: non_neg_integer()
     ,signature :: binary()
 }).
 
@@ -46,8 +48,8 @@
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec new(libp2p_crypto:address(), libp2p_crypto:address(), libp2p_crypto:address(), binary(), integer(), integer()) -> txn_create_htlc().
-new(Payer, Payee, Address, Hashlock, Timelock, Amount) ->
+-spec new(libp2p_crypto:address(), libp2p_crypto:address(), libp2p_crypto:address(), binary(), integer(), integer(), non_neg_integer()) -> txn_create_htlc().
+new(Payer, Payee, Address, Hashlock, Timelock, Amount, Fee) ->
     #txn_create_htlc{
         payer=Payer
         ,payee=Payee
@@ -55,6 +57,7 @@ new(Payer, Payee, Address, Hashlock, Timelock, Amount) ->
         ,hashlock=Hashlock
         ,timelock=Timelock
         ,amount=Amount
+        ,fee=Fee
         ,signature = <<>>
     }.
 
@@ -119,6 +122,14 @@ amount(Txn) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+-spec fee(txn_create_htlc()) -> non_neg_integer().
+fee(Txn) ->
+    Txn#txn_create_htlc.fee.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
 -spec signature(txn_create_htlc()) -> binary().
 signature(Txn) ->
     Txn#txn_create_htlc.signature.
@@ -164,41 +175,46 @@ new_test() ->
         ,hashlock= <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>
         ,timelock=0
         ,amount=666
+        ,fee=1
         ,signature= <<>>
     },
-    ?assertEqual(Tx, new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666)).
+    ?assertEqual(Tx, new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1)).
 
 payer_test() ->
-    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666),
+    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
     ?assertEqual(<<"payer">>, payer(Tx)).
 
 payee_test() ->
-    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666),
+    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
     ?assertEqual(<<"payee">>, payee(Tx)).
 
 address_test() ->
-    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666),
+    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
     ?assertEqual(<<"address">>, address(Tx)).
 
 amount_test() ->
-    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666),
+    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
     ?assertEqual(666, amount(Tx)).
 
+fee_test() ->
+    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
+    ?assertEqual(1, fee(Tx)).
+
 hashlock_test() ->
-    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666),
+    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
     ?assertEqual(<<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, hashlock(Tx)).
 
 timelock_test() ->
-    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666),
+    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
     ?assertEqual(0, timelock(Tx)).
 
 signature_test() ->
-    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666),
+    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
     ?assertEqual(<<>>, signature(Tx)).
 
 sign_test() ->
     {PrivKey, PubKey} = libp2p_crypto:generate_keys(),
-    Tx0 = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666),
+    Tx0 = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     Tx1 = sign(Tx0, SigFun),
     Sig1 = signature(Tx1),
@@ -207,18 +223,18 @@ sign_test() ->
  is_valid_test() ->
     {PrivKey, PubKey} = libp2p_crypto:generate_keys(),
     Payer = libp2p_crypto:pubkey_to_address(PubKey),
-    Tx0 = new(Payer, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666),
+    Tx0 = new(Payer, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     Tx1 = sign(Tx0, SigFun),
     ?assert(is_valid(Tx1)),
     {_, PubKey2} = libp2p_crypto:generate_keys(),
     Payer2 = libp2p_crypto:pubkey_to_address(PubKey2),
-    Tx2 = new(Payer2, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666),
+    Tx2 = new(Payer2, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
     Tx3 = sign(Tx2, SigFun),
     ?assertNot(is_valid(Tx3)).
 
 is_test() ->
-    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666),
+    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
     ?assert(is(Tx)).
 
 -endif.

--- a/src/transactions/blockchain_txn_redeem_htlc.erl
+++ b/src/transactions/blockchain_txn_redeem_htlc.erl
@@ -8,11 +8,12 @@
 -behavior(blockchain_txn).
 
 -export([
-    new/3
+    new/4
     ,hash/1
     ,payee/1
     ,address/1
     ,preimage/1
+    ,fee/1
     ,signature/1
     ,sign/2
     ,is_valid/1
@@ -27,6 +28,7 @@
     payee :: libp2p_crypto:address()
     ,address :: libp2p_crypto:address()
     ,preimage :: undefined | binary()
+    ,fee :: non_neg_integer()
     ,signature :: binary()
 }).
 
@@ -37,12 +39,13 @@
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec new(libp2p_crypto:address(), libp2p_crypto:address(), binary()) -> txn_redeem_htlc().
-new(Payee, Address, PreImage) ->
+-spec new(libp2p_crypto:address(), libp2p_crypto:address(), binary(), non_neg_integer()) -> txn_redeem_htlc().
+new(Payee, Address, PreImage, Fee) ->
     #txn_redeem_htlc{
         payee=Payee
         ,address=Address
         ,preimage=PreImage
+        ,fee=Fee
         ,signature= <<>>
     }.
 
@@ -78,6 +81,14 @@ address(Txn) ->
 -spec preimage(txn_redeem_htlc()) -> binary().
 preimage(Txn) ->
     Txn#txn_redeem_htlc.preimage.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec fee(txn_redeem_htlc()) -> non_neg_integer().
+fee(Txn) ->
+    Txn#txn_redeem_htlc.fee.
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -125,37 +136,42 @@ new_test() ->
         payee= <<"payee">>
         ,address= <<"address">>
         ,preimage= <<"yolo">>
+        ,fee= 1
         ,signature= <<>>
     },
-    ?assertEqual(Tx, new(<<"payee">>, <<"address">>, <<"yolo">>)).
+    ?assertEqual(Tx, new(<<"payee">>, <<"address">>, <<"yolo">>, 1)).
 
 payee_test() ->
-    Tx = new(<<"payee">>, <<"address">>, <<"yolo">>),
+    Tx = new(<<"payee">>, <<"address">>, <<"yolo">>, 1),
     ?assertEqual(<<"payee">>, payee(Tx)).
 
 address_test() ->
-    Tx = new(<<"payee">>, <<"address">>, <<"yolo">>),
+    Tx = new(<<"payee">>, <<"address">>, <<"yolo">>, 1),
     ?assertEqual(<<"address">>, address(Tx)).
 
 preimage_test() ->
-    Tx = new(<<"payee">>, <<"address">>, <<"yolo">>),
+    Tx = new(<<"payee">>, <<"address">>, <<"yolo">>, 1),
     ?assertEqual(<<"yolo">>, preimage(Tx)).
+
+fee_test() ->
+    Tx = new(<<"payee">>, <<"address">>, <<"yolo">>, 1),
+    ?assertEqual(1, fee(Tx)).
 
 is_valid_test() ->
     {PrivKey, PubKey} = libp2p_crypto:generate_keys(),
     Payee = libp2p_crypto:pubkey_to_address(PubKey),
-    Tx0 = new(Payee, <<"address">>, <<"yolo">>),
+    Tx0 = new(Payee, <<"address">>, <<"yolo">>, 1),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     Tx1 = sign(Tx0, SigFun),
     ?assert(is_valid(Tx1)),
     {_, PubKey2} = libp2p_crypto:generate_keys(),
     Payee2 = libp2p_crypto:pubkey_to_address(PubKey2),
-    Tx2 = new(Payee2, <<"address">>, <<"yolo">>),
+    Tx2 = new(Payee2, <<"address">>, <<"yolo">>, 1),
     Tx3 = sign(Tx2, SigFun),
     ?assertNot(is_valid(Tx3)).
 
 is_test() ->
-    Tx = new(<<"payee">>, <<"address">>, <<"yolo">>),
+    Tx = new(<<"payee">>, <<"address">>, <<"yolo">>, 1),
     ?assert(is(Tx)).
 
 -endif.

--- a/test/blockchain_simple_SUITE.erl
+++ b/test/blockchain_simple_SUITE.erl
@@ -111,10 +111,15 @@ htlc_payee_redeem(_Config) ->
     HTLCAddress = crypto:strong_rand_bytes(32),
     % Create a Hashlock
     Hashlock = crypto:hash(sha256, <<"sharkfed">>),
-    CreateTx = blockchain_txn_create_htlc:new(Payer, Payee, HTLCAddress, Hashlock, 3, 2500),
+    CreateTx = blockchain_txn_create_htlc:new(Payer, Payee, HTLCAddress, Hashlock, 3, 2500, 0),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     SignedCreateTx = blockchain_txn_create_htlc:sign(CreateTx, SigFun),
-    Block = test_utils:create_block(ConsensusMembers, [SignedCreateTx]),
+    % send some money to the payee so they have enough to pay the fee for redeeming
+    Tx = blockchain_txn_payment:new(Payer, Payee, 100, 0, 2),
+    SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
+    SignedTx = blockchain_txn_payment:sign(Tx, SigFun),
+
+    Block = test_utils:create_block(ConsensusMembers, [SignedCreateTx, SignedTx]),
     ok = blockchain_worker:add_block(Block, self()),
     ChainDir = blockchain:dir(blockchain_worker:blockchain()),
 
@@ -124,7 +129,7 @@ htlc_payee_redeem(_Config) ->
 
     % Check that the Payer balance has been reduced by 2500
     NewEntry0 = blockchain_ledger:find_entry(Payer, blockchain_ledger:entries(blockchain_worker:ledger())),
-    ?assertEqual(Balance - 2500, blockchain_ledger:balance(NewEntry0)),
+    ?assertEqual(Balance - 2600, blockchain_ledger:balance(NewEntry0)),
 
     % Check that the HLTC address exists and has the correct balance, hashlock and timelock
     % NewHTLC0 = blockchain_ledger:find_htlc(HTLCAddress, blockchain_worker:ledger()),
@@ -135,7 +140,7 @@ htlc_payee_redeem(_Config) ->
 
     % Try and redeem
     RedeemSigFun = libp2p_crypto:mk_sig_fun(PayeePrivKey),
-    RedeemTx = blockchain_txn_redeem_htlc:new(Payee, HTLCAddress, <<"sharkfed">>),
+    RedeemTx = blockchain_txn_redeem_htlc:new(Payee, HTLCAddress, <<"sharkfed">>, 0),
     SignedRedeemTx = blockchain_txn_redeem_htlc:sign(RedeemTx, RedeemSigFun),
     Block2 = test_utils:create_block(ConsensusMembers, [SignedRedeemTx]),
     ok = blockchain_worker:add_block(Block2, self()),
@@ -148,7 +153,7 @@ htlc_payee_redeem(_Config) ->
 
     % Check that the Payee now owns 2500
     NewEntry1 = blockchain_ledger:find_entry(Payee, blockchain_ledger:entries(blockchain_worker:ledger())),
-    ?assertEqual(2500, blockchain_ledger:balance(NewEntry1)),
+    ?assertEqual(2600, blockchain_ledger:balance(NewEntry1)),
 
     % Make sure blockchain saved on file =  in memory
     Chain = blockchain_worker:blockchain(),
@@ -180,7 +185,7 @@ htlc_payer_redeem(_Config) ->
     HTLCAddress = crypto:strong_rand_bytes(32),
     % Create a Hashlock
     Hashlock = crypto:hash(sha256, <<"sharkfed">>),
-    CreateTx = blockchain_txn_create_htlc:new(Payer, Payer, HTLCAddress, Hashlock, 3, 2500),
+    CreateTx = blockchain_txn_create_htlc:new(Payer, Payer, HTLCAddress, Hashlock, 3, 2500, 0),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     SignedCreateTx = blockchain_txn_create_htlc:sign(CreateTx, SigFun),
     Block = test_utils:create_block(ConsensusMembers, [SignedCreateTx]),
@@ -215,7 +220,7 @@ htlc_payer_redeem(_Config) ->
     ?assertEqual(4, blockchain_worker:height()),
 
     % Try and redeem
-    RedeemTx = blockchain_txn_redeem_htlc:new(Payer, HTLCAddress, <<"sharkfed">>),
+    RedeemTx = blockchain_txn_redeem_htlc:new(Payer, HTLCAddress, <<"sharkfed">>, 0),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     SignedRedeemTx = blockchain_txn_redeem_htlc:sign(RedeemTx, SigFun),
     Block4 = test_utils:create_block(ConsensusMembers, [SignedRedeemTx]),


### PR DESCRIPTION
This PR does the following:

- requires a `payee` for HTLC transactions, and only the `payee` can redeem the HTLC with the correct preimage (or the payer if the time lock has expired)
- removes the `nonce` from the HTLC; there was no need for it
- automatically generate an HTLC address when using the CLI, and return it once the `create_htlc` command is run
- updates the tests #tdd 