### PR TITLE
Add the start of support for DNS seed nodes

### DIFF
--- a/src/blockchain_app.erl
+++ b/src/blockchain_app.erl
@@ -27,6 +27,12 @@ start(_StartType, _StartArgs) ->
     NumConsensusMembers = application:get_env(blockchain, num_consensus_members, 7),
     Port = application:get_env(blockchain, port, 0),
     SeedNodes = application:get_env(blockchain, seed_nodes, []),
+    SeedNodeDNS = application:get_env(blockchain, seed_node_dns, []),
+
+    % look up the DNS record and add any resulting addresses to the SeedNodes
+    % no need to do any checks here as any bad combination results in an empty list
+    SeedAddresses = string:tokens(lists:flatten([string:prefix(X, "blockchain-seed-nodes=") || [X] <- inet_res:lookup(SeedNodeDNS, in, txt), string:prefix(X, "blockchain-seed-nodes=") /= nomatch]), ","),
+    SeedNodes ++ SeedAddresses,
 
     Args = [
             {base_dir, BaseDir},


### PR DESCRIPTION
This PR adds support for an optional `seed_node_dns` record to be passed in to the core library. It accepts a DNS entry, ie: `seed.helium.foundation`, and expects that domain to contain a `TXT` record that is formatted as follows:

`blockchain-seed-nodes=<multiaddr1>,<multiaddr2>,...`

If it finds such a record it adds it to the existing `SeedNodes` list.

We should think about how to sign this or do something that validates the authenticity of the `TXT` record in case of DNS hijacking or similar.