### PR TITLE
Add print function to blockchain_ledger_gateway

### DIFF
--- a/src/cli/blockchain_cli_ledger.erl
+++ b/src/cli/blockchain_cli_ledger.erl
@@ -328,23 +328,9 @@ ledger_gateways(_CmdBase, [], []) ->
     R = [format_ledger_gateway_entry(G) || G <- maps:to_list(Gateways)],
     [clique_status:table(R)].
 
-format_ledger_gateway_entry({GatewayAddr, {gw_info,
-                                           OwnerAddr,
-                                           Location,
-                                           LastPOCChallenge,
-                                           Nonce,
-                                           Score}}) ->
-    %% NOTE: Location is an H3 Index
-    IndexToStr = fun(undefined) -> "undefined";
-                    (I) -> I
-                 end,
-    [{gateway_address, libp2p_crypto:address_to_p2p(GatewayAddr)},
-     {owner_address, libp2p_crypto:address_to_p2p(OwnerAddr)},
-     {location, IndexToStr(Location)},
-     {last_poc_challenge, LastPOCChallenge},
-     {nonce, Nonce},
-     {score, Score}
-    ].
+format_ledger_gateway_entry({GatewayAddr, Gateway}) ->
+    [{gateway_address, libp2p_crypto:address_to_p2p(GatewayAddr)} |
+     blockchain_ledger_gateway:print(Gateway)].
 
 %%--------------------------------------------------------------------
 %% ledger assert_loc_request

--- a/src/ledger/blockchain_ledger.erl
+++ b/src/ledger/blockchain_ledger.erl
@@ -189,7 +189,7 @@ update_transaction_fee(Ledger=#ledger{transaction_fee=Fee}) ->
             ?MODULE:current_height(Ledger) div 1000;
         false ->
             Fee
-    end,    
+    end,
     Ledger#ledger{transaction_fee=NewFee}.
 
 %%--------------------------------------------------------------------

--- a/src/ledger/blockchain_ledger_gateway.erl
+++ b/src/ledger/blockchain_ledger_gateway.erl
@@ -12,6 +12,7 @@
     ,last_poc_challenge/1, last_poc_challenge/2
     ,nonce/1, nonce/2
     ,score/1, score/2
+    ,print/1
 ]).
 
 -include("blockchain.hrl").
@@ -125,6 +126,24 @@ score(Gateway) ->
 -spec score(float(), gateway()) -> gateway().
 score(Score, Gateway) ->
     Gateway#gateway{score=Score}.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec print(gateway()) -> list().
+print(Gateway) ->
+    %% TODO: This is annoying but it makes printing happy on the CLI
+    UndefinedHandleFunc = fun(undefined) -> "undefined";
+                            (I) -> I
+                         end,
+    [
+     {owner_address, libp2p_crypto:address_to_p2p(owner_address(Gateway))},
+     {location, UndefinedHandleFunc(location(Gateway))},
+     {last_poc_challenge, UndefinedHandleFunc(last_poc_challenge(Gateway))},
+     {nonce, nonce(Gateway)},
+     {score, score(Gateway)}
+    ].
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests


### PR DESCRIPTION
The previous refactor broke the `ledger gateways` command, this fixes it.