### PR TITLE
Dont add genesis block if its unknown

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -213,7 +213,7 @@ blocks(#blockchain{db=DB, blocks=BlocksCF}) ->
 -spec add_block(blockchain_block:block(), blockchain()) -> ok | {error, any()}.
 add_block(Block, Blockchain) ->
     Hash = blockchain_block:hash_block(Block),
-    {ok, GenesisHash} = blockchain:genesis_hash(Block),
+    {ok, GenesisHash} = blockchain:genesis_hash(Blockchain),
     case blockchain_block:is_genesis(Block) of
         true when Hash =:= GenesisHash ->
             ok;


### PR DESCRIPTION
This doesn't change the sync behavior at all, just adds a guard to not add the genesis block again.

We should probably keep the sync behavior as is, since it acts as a check for unknown genesis blocks, which we found with the current testnet.