### PR TITLE
support for elections

### DIFF
--- a/src/blockchain_election.erl
+++ b/src/blockchain_election.erl
@@ -1,0 +1,20 @@
+-module(blockchain_election).
+
+-export([
+         new_group/2
+        ]).
+
+
+new_group(Ledger, Hash) ->
+    Gateways0 = blockchain_ledger_v1:active_gateways(Ledger),
+    Gateways = maps:keys(Gateways0),
+    lager:info("gateways ~p", [Gateways]),
+        <<I1:86/integer, I2:85/integer, I3:85/integer>> = Hash,
+    rand:seed(exs1024, {I1, I2, I3}),
+
+    %% guarantee that we have a deterministic starting order
+    Nodes = lists:sort(Gateways),
+    %% for now, just randomize the node order
+    Shuf0 = [{rand:uniform(10000000), Node} || Node <- Nodes],
+    Shuf = lists:sort(Shuf0),
+    [Node || {_, Node} <- Shuf].


### PR DESCRIPTION
this PR adds a second verifiction phase (for when the consensus group
is new, we can now validate that first block where the new group adds
itself), and also the deterministic election code to make sure that
for any given hash we can figure out what our consensus group is.