### PR TITLE
don't crash on bad validator

### DIFF
--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -110,7 +110,7 @@ validate([], Valid,  Invalid, Ledger) ->
     {lists:reverse(Valid), Invalid};
 validate([Txn | Tail], Valid, Invalid, Ledger) ->
     Type = ?MODULE:type(Txn),
-    case Type:is_valid(Txn, Ledger) of
+    case catch Type:is_valid(Txn, Ledger) of
         ok ->
             case ?MODULE:absorb(Txn, Ledger) of
                 ok ->


### PR DESCRIPTION
this was keeping the testnet from starting because it couldn't filter out bad transactions.