### PR TITLE
Reorder new protobuff txn types so they're only appended

### DIFF
--- a/src/transactions/blockchain_txn.proto
+++ b/src/transactions/blockchain_txn.proto
@@ -17,19 +17,19 @@ import "v1/blockchain_txn_poc_receipts_v1.proto";
 
 message txn {
     oneof txn {
-        txn_coinbase_v1 coinbase = 1;
-        txn_security_coinbase_v1 security_coinbase = 2;
-        txn_oui_v1 oui = 3;
-        txn_routing_v1 routing = 4;
+        txn_add_gateway_v1 add_gateway = 1;
+        txn_assert_location_v1 assert_location = 2;
+        txn_coinbase_v1 coinbase = 3;
+        txn_create_htlc_v1 create_htlc = 4;
         txn_gen_gateway_v1 gen_gateway = 5;
-        txn_payment_v1 payment = 6;
-        txn_security_exchange_v1 security_exchange = 7;
-        txn_consensus_group_v1 consensus_group = 8;
-        txn_add_gateway_v1 add_gateway = 9;
-        txn_assert_location_v1 assert_location = 10;
-        txn_create_htlc_v1 create_htlc = 11;
-        txn_redeem_htlc_v1 redeem_htlc = 12;
-        txn_poc_request_v1 poc_request = 13;
-        txn_poc_receipts_v1 poc_receipts = 14;
+        txn_consensus_group_v1 consensus_group = 6;
+        txn_oui_v1 oui = 7;
+        txn_payment_v1 payment = 8;
+        txn_poc_receipts_v1 poc_receipts = 9;
+        txn_poc_request_v1 poc_request = 10;
+        txn_redeem_htlc_v1 redeem_htlc = 11;
+        txn_security_coinbase_v1 security_coinbase = 12;
+        txn_routing_v1 routing = 13;
+        txn_security_exchange_v1 security_exchange = 14;
     }
 }


### PR DESCRIPTION
They're now appended to the list we had at https://github.com/helium/blockchain-core/blob/3188bb106d04ff1bd29e367f511a164eb0d628c9/src/transactions/blockchain_txn.proto