### PR TITLE
Fix extension scripts: avoid warning on serial console, have exit status

### DIFF
--- a/scripts/extensions/ledger
+++ b/scripts/extensions/ledger
@@ -1,5 +1,6 @@
 #!/bin/sh
 if [ -t 0 ] ; then
-    export CLIQUE_COLUMNS=`stty size | cut -d ' ' -f 2`
+    export CLIQUE_COLUMNS=`stty size 2>/dev/null | cut -d ' ' -f 2`
 fi
 relx_nodetool rpc blockchain_console command ledger $@
+exit $?

--- a/scripts/extensions/peer
+++ b/scripts/extensions/peer
@@ -1,5 +1,6 @@
 #!/bin/sh
 if [ -t 0 ] ; then
-    export CLIQUE_COLUMNS=`stty size | cut -d ' ' -f 2`
+    export CLIQUE_COLUMNS=`stty size 2>/dev/null | cut -d ' ' -f 2`
 fi
 relx_nodetool rpc blockchain_console command peer $@
+exit $?

--- a/scripts/extensions/trace
+++ b/scripts/extensions/trace
@@ -1,5 +1,6 @@
 #!/bin/sh
 if [ -t 0 ] ; then
-    export CLIQUE_COLUMNS=`stty size | cut -d ' ' -f 2`
+    export CLIQUE_COLUMNS=`stty size 2>/dev/null | cut -d ' ' -f 2`
 fi
 relx_nodetool rpc blockchain_console command trace $@
+exit $?

--- a/scripts/extensions/txn
+++ b/scripts/extensions/txn
@@ -1,5 +1,6 @@
 #!/bin/sh
 if [ -t 0 ] ; then
-    export CLIQUE_COLUMNS=`stty size | cut -d ' ' -f 2`
+    export CLIQUE_COLUMNS=`stty size 2>/dev/null | cut -d ' ' -f 2`
 fi
 relx_nodetool rpc blockchain_console command txn $@
+exit $?


### PR DESCRIPTION
Extension scripts are expected to call exit themselves, or the runner
script will exit with code 1. This breaks using the blockchain extension
commands in shell scripts. To fix this we exit with the exit code of the
RPC call (if the RPC call does not return with ok, the exit status
will be non-zero).