### PR TITLE
Use probability curve to weight edges

### DIFF
--- a/src/blockchain_poc_path.erl
+++ b/src/blockchain_poc_path.erl
@@ -193,7 +193,7 @@ neighbors(Address, Gateways) ->
 %% @end
 %%--------------------------------------------------------------------
 edge_weight(Gw1, Gw2) ->
-    1 - abs(blockchain_ledger_gateway_v1:score(Gw1) -  blockchain_ledger_gateway_v1:score(Gw2)).
+    1 - abs(prob_fun(blockchain_ledger_gateway_v1:score(Gw1)) -  prob_fun(blockchain_ledger_gateway_v1:score(Gw2))).
 
 %%--------------------------------------------------------------------
 %% @doc


### PR DESCRIPTION
Because the scoring system is probability based, and we have a spike of
uncertainty around 0.25, use the same curve as we do for target
selection to weight the edges of the graph. This should ensure that the
path should go from nodes with high confidence scores to nodes with low
confidence scores.

It might be even better to use a different curve that inverts the
parabola for the 'low' side, but this should at least be an improvement.