### PR TITLE
Add a 50% chance to invert the constructed path, based on entropy

### DIFF
--- a/src/blockchain_poc_path.erl
+++ b/src/blockchain_poc_path.erl
@@ -78,7 +78,13 @@ build(Hash, Target, Gateways) ->
                     lager:error("path: ~p", [Path3]),
                     {error, path_too_small};
                 true ->
-                    {ok, Path3}
+                    blockchain_utils:rand_from_hash(Hash),
+                    case rand:uniform(2) of
+                        1 ->
+                            {ok, Path3};
+                        2 ->
+                            {ok, lists:reverse(Path3)}
+                    end
             end
     end.
 


### PR DESCRIPTION
The goal here is to add some extra randomness into the mix so we don't
always select the highest scoring nodes in the regional network as the
start of the path, sometimes we play the path backwards too.