### PR TITLE
Switch from 4 byte layer data to 2 byte layer data

### DIFF
--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -336,10 +336,10 @@ create_secret_hash(_Secret, 0, Acc) ->
     Acc;
 create_secret_hash(Secret, X, []) ->
     Bin = crypto:hash(sha256, Secret),
-    <<Hash:4/binary, _/binary>> = Bin,
+    <<Hash:2/binary, _/binary>> = Bin,
     create_secret_hash(Bin, X-1, [Hash]);
 create_secret_hash(Secret, X, Acc) ->
-    Bin = <<Hash:4/binary, _/binary>> = crypto:hash(sha256, Secret),
+    Bin = <<Hash:2/binary, _/binary>> = crypto:hash(sha256, Secret),
     create_secret_hash(Bin, X-1, [Hash|Acc]).
 
 %% @doc Validate the proof of coverage receipt path.


### PR DESCRIPTION
This should reduce the time on air of our challenge packets but still be
hard enough to guess successfully (1 in 65,536 chance of guessing the
layer data correctly).