### PR TITLE
Revert "take recent signatures into account when calculating which old group member to eject"

### DIFF
--- a/src/transactions/v1/blockchain_txn_consensus_group_v1.erl
+++ b/src/transactions/v1/blockchain_txn_consensus_group_v1.erl
@@ -37,7 +37,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
-% monthly_reward          50000 * 1000000  In bones
+% monthly_reward          50000 * 1000000  In bones 
 % securities_percent      0.35
 % dc_percent              0.25 Unused for now so give to POC
 % poc_challengees_percent 0.19 + 0.16
@@ -141,9 +141,10 @@ is_valid(Txn, Chain) ->
                         true ->
                             Proof = binary_to_term(Proof0),
                             EffectiveHeight = TxnHeight + Delay,
+                            {ok, OldLedger} = blockchain:ledger_at(EffectiveHeight, Chain),
                             {ok, Block} = blockchain:get_block(EffectiveHeight, Chain),
                             Hash = blockchain_block:hash_block(Block),
-                            verify_proof(Proof, Members, Hash, EffectiveHeight, Chain);
+                            verify_proof(Proof, Members, Hash, OldLedger);
                         _ ->
                             {error, {duplicate_group, ?MODULE:height(Txn), Height}}
                     end
@@ -216,10 +217,10 @@ absorb(Txn, Chain) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
-verify_proof(Proof, Members, Hash, Height, Chain) ->
+verify_proof(Proof, Members, Hash, OldLedger) ->
     %% verify that the list is the proper list
     L = length(Members),
-    HashMembers = blockchain_election:new_group(Chain, Hash, Height, L),
+    HashMembers = blockchain_election:new_group(OldLedger, Hash, L),
     Artifact = term_to_binary(Members),
     case HashMembers of
         Members ->

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -48,8 +48,7 @@ init_chain(Balance, {PrivKey, PubKey}) ->
                           poc_witnesses_percent => 0.02 + 0.03,
                           consensus_percent => 0.10,
                           election_selection_pct => 60,
-                          election_replacement_factor => 4,
-                          election_restart_interval => 5
+                          election_replacement_factor => 4
                          }),
 
     InitialVars = [ VTxn ],
@@ -118,14 +117,14 @@ create_block(ConsensusMembers, Txs) ->
     Height = blockchain_block:height(HeadBlock) + 1,
     Time = blockchain_block:time(HeadBlock) + 1,
     Block0 = blockchain_block_v1:new(#{prev_hash => PrevHash,
-                                       height => Height,
-                                       transactions => Txs,
-                                       signatures => [],
-                                       time => Time,
-                                       hbbft_round => 0,
-                                       election_epoch => 1,
-                                       epoch_start => 0
-                                      }),
+                                     height => Height,
+                                     transactions => Txs,
+                                     signatures => [],
+                                     time => Time,
+                                     hbbft_round => 0,
+                                     election_epoch => 1,
+                                     epoch_start => 0
+                                     }),
     BinBlock = blockchain_block:serialize(Block0),
     Signatures = signatures(ConsensusMembers, BinBlock),
     Block1 = blockchain_block:set_signatures(Block0, Signatures),


### PR DESCRIPTION
Reverts helium/blockchain-core#145

This needs to happen because the metric that we're using isn't deterministic, leading to dkgs that will never complete.