### PR TITLE
Normalize all floating point values used in score calculation

### DIFF
--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -7,7 +7,8 @@
 
 -export([
     shuffle_from_hash/2,
-    rand_from_hash/1
+    rand_from_hash/1,
+    normalize_float/1
 ]).
 
 -ifdef(TEST).
@@ -32,6 +33,16 @@ shuffle_from_hash(Hash, L) ->
 rand_from_hash(Hash) ->
     <<I1:86/integer, I2:85/integer, I3:85/integer, _/binary>> = Hash,
     rand:seed(exs1024, {I1, I2, I3}).
+
+%%--------------------------------------------------------------------
+%% @doc normalize a float by converting it to fixed point and back
+%% using 16 bits of exponent precision. This should be well above
+%% the floating point error threshold and doing this will prevent
+%% errors from accumulating.
+%% @end
+%%--------------------------------------------------------------------
+normalize_float(Float) ->
+    round(Float * 65536) / 65536.
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions


### PR DESCRIPTION
Make sure all floats used in score calculation are rigoriously
normalized so that floating point errors can't accrue and cause score
calculation to deviate.