### PR TITLE
add some gossip peers to combat block drift

### DIFF
--- a/src/blockchain_sup.erl
+++ b/src/blockchain_sup.erl
@@ -74,8 +74,10 @@ init(Args) ->
           [
            {stream_client, {?GOSSIP_PROTOCOL, {blockchain_gossip_handler, []}}},
            {seed_nodes, proplists:get_value(seed_nodes, Args, [])},
+           %% in should be ~2/3 out, otherwise nodes with good
+           %% connections will hog all the gossip
            {peerbook_connections, proplists:get_value(outbound_gossip_connections, Args, 10)},
-           {inbound_connections, proplists:get_value(max_inbound_connections, Args, 10)},
+           {inbound_connections, proplists:get_value(max_inbound_connections, Args, 6)},
            {peer_cache_timeout, proplists:get_value(peer_cache_timeout, Args, 10 * 1000)}
           ]}
         ],


### PR DESCRIPTION
we're seeing a lot of block delay, add some peers to so we're more likely to get a better-connected network.