### PR TITLE
Add a fallback fun for gateway_versions

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -32,7 +32,7 @@
 
 %% the number of blocks before keep a gateway from affecting the
 %% outcome of threshold var application.
--define(var_gw_inactivity_thresh, var_gw_inactivity_thresh).
+-define(var_gw_inactivity_threshold, var_gw_inactivity_threshold).
 
 %%%
 %%% meta vars

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -731,7 +731,7 @@ add_gateway_location(GatewayAddress, Location, Nonce, Ledger) ->
     end.
 
 gateway_versions(Ledger) ->
-    case config(?var_gw_inactivity_thresh, Ledger) of
+    case config(?var_gw_inactivity_threshold, Ledger) of
         {error, not_found} ->
             gateway_versions_fallback(Ledger);
         {ok, DeathThreshold} ->


### PR DESCRIPTION
This is a temp shitty fix for getting miner to sync.