### PR TITLE
immediately apply vars when delay is 0

### DIFF
--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -442,9 +442,6 @@ process_delayed_txns(Block, Ledger, Chain) ->
       PendingTxns),
     ok.
 
-%% avoid the rescheduling machinery if we're immediately applying stuff
-delay_vars(0, Vars, Ledger) ->
-    ok = blockchain_txn_vars_v1:delayed_absorb(Vars, Ledger);
 delay_vars(Effective, Vars, Ledger) ->
     DefaultCF = default_cf(Ledger),
     %% save the vars txn to disk

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -284,6 +284,9 @@ maybe_absorb(Txn, Ledger, Chain) ->
                             {ok, Threshold} = blockchain:config(?predicate_threshold, Ledger),
                             Versions = blockchain_ledger_v1:gateway_versions(Ledger),
                             case sum_higher(V, Versions) of
+                                Pct when Pct >= Threshold andalso Delay =:= 0 ->
+                                    delayed_absorb(Txn, Ledger),
+                                    true;
                                 Pct when Pct >= Threshold ->
                                     ok = blockchain_ledger_v1:delay_vars(Effective, Txn, Ledger),
                                     true;


### PR DESCRIPTION
I'm pretty sure that with the current code, a delay of 0 will permanently lock us out of chain vars.  This forces the immediate application of vars if delay is 0, instead of scheduling them in the past, like the current code does.