### PR TITLE
Improve block signature checking

### DIFF
--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -7,6 +7,7 @@
 
 -export([
     shuffle_from_hash/2,
+    shuffle/1,
     rand_from_hash/1,
     normalize_float/1,
     challenge_interval/1,
@@ -21,13 +22,20 @@
 -define(CHALLENGE_INTERVAL, poc_challenge_interval).
 
 %%--------------------------------------------------------------------
-%% @doc
+%% @doc Shuffle a list deterministically using a random binary as the seed.
 %% @end
 %%--------------------------------------------------------------------
 -spec shuffle_from_hash(binary(), list()) -> list().
 shuffle_from_hash(Hash, L) ->
     ?MODULE:rand_from_hash(Hash),
     [X ||{_, X} <- lists:sort([{rand:uniform(), E} || E <- L])].
+
+%%--------------------------------------------------------------------
+%% @doc Shuffle a list randomly.
+%% @end
+%%--------------------------------------------------------------------
+shuffle(List) ->
+    [X || {_,X} <- lists:sort([{rand:uniform(), N} || N <- List])].
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/test/blockchain_fastforward_SUITE.erl
+++ b/test/blockchain_fastforward_SUITE.erl
@@ -40,7 +40,7 @@ basic(_Config) ->
     Balance = 5000,
     BlocksN = 100,
     {ok, Sup, {PrivKey, PubKey}, _Opts} = test_utils:init(BaseDir),
-    {ok, ConsensusMembers, _} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
+    {ok, _GenesisMembers, ConsensusMembers, _} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
     Chain0 = blockchain_worker:blockchain(),
     {ok, Genesis} = blockchain:genesis_block(Chain0),
 

--- a/test/blockchain_keys_SUITE.erl
+++ b/test/blockchain_keys_SUITE.erl
@@ -52,8 +52,8 @@ keys_test(_Config) ->
     ?assert(erlang:is_pid(blockchain_swarm:swarm())),
 
     % Generate fake blockchains (just the keys)
-    RandomKeys1 = test_utils:generate_keys(5, ecc_compact) ,
-    RandomKeys2 = test_utils:generate_keys(5, ed25519),
+    RandomKeys1 = test_utils:generate_keys(3, ecc_compact) ,
+    RandomKeys2 = test_utils:generate_keys(3, ed25519),
     Address = blockchain_swarm:pubkey_bin(),
     ConsensusMembers = [
         {Address, {PubKey, PrivKey, libp2p_crypto:mk_sig_fun(PrivKey)}}

--- a/test/blockchain_simple_SUITE.erl
+++ b/test/blockchain_simple_SUITE.erl
@@ -72,7 +72,7 @@ init_per_testcase(TestCase, Config) ->
     BaseDir = "data/test_SUITE/" ++ erlang:atom_to_list(TestCase),
     Balance = 5000,
     {ok, Sup, {PrivKey, PubKey}, Opts} = test_utils:init(BaseDir),
-    {ok, ConsensusMembers, Keys} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
+    {ok, GenesisMembers, ConsensusMembers, Keys} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
 
     Chain = blockchain_worker:blockchain(),
     Swarm = blockchain_swarm:swarm(),
@@ -96,6 +96,7 @@ init_per_testcase(TestCase, Config) ->
         {swarm, Swarm},
         {n, N},
         {consensus_members, ConsensusMembers},
+        {genesis_members, GenesisMembers},
         Keys
         | Config
     ].
@@ -618,6 +619,7 @@ bogus_coinbase_with_good_payment_test(Config) ->
 
 export_test(Config) ->
     ConsensusMembers = proplists:get_value(consensus_members, Config),
+    GenesisMembers = proplists:get_value(genesis_members, Config),
     Balance = proplists:get_value(balance, Config),
     [_,
      {Payer1, {PayerPubKey1, PayerPrivKey1, _}},
@@ -741,8 +743,8 @@ export_test(Config) ->
                       (Balance - Amount - Fee) == proplists:get_value(balance, Account)
               end, FilteredExportedAccounts),
 
-    %% check all consensus members are included in the exported securities
-    ?assertEqual(length(Securities), N),
+    %% check all genesis members are included in the exported securities
+    ?assertEqual(length(Securities), length(GenesisMembers)),
 
     %% check security balance for each member
     lists:all(fun(Security) ->

--- a/test/blockchain_sync_SUITE.erl
+++ b/test/blockchain_sync_SUITE.erl
@@ -40,7 +40,7 @@ basic(_Config) ->
     Balance = 5000,
     BlocksN = 100,
     {ok, Sup, {PrivKey, PubKey}, _Opts} = test_utils:init(BaseDir),
-    {ok, ConsensusMembers, _} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
+    {ok, _GenesisMembers, ConsensusMembers, _} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
     Chain0 = blockchain_worker:blockchain(),
     {ok, Genesis} = blockchain:genesis_block(Chain0),
 


### PR DESCRIPTION
Prior to this change, we were tolerating signatures from unknown signers
as well as signatures that were invalid. This change requires all the
attached signatures to be valid, to be from one of the consensus members
and also requires at least 2f+1 valid signatures, and no more than 3f+1
signatures.

This change exposed some issues with the unit tests, so they had to be
corrected to supply only valid block signatures.

This is a rework of #214 without the probabilistic aspect.