### PR TITLE
Make assume-valid absorbtion always occur in a background process

### DIFF
--- a/test/assume_valid_SUITE.erl
+++ b/test/assume_valid_SUITE.erl
@@ -203,7 +203,8 @@ blockchain_crash_while_absorbing(_Config) ->
     %% reopen the blockchain and provide the assume-valid hash
     %% since we already have all the blocks, it should immediately sync
     {ok, Chain2} = blockchain:new(SimDir, Genesis, blockchain_block:hash_block(LastBlock)),
-    ?assertEqual({ok, 101}, blockchain:sync_height(Chain2)),
+    %% the sync is done in a background process, so wait for it to complete
+    ok = blockchain_ct_utils:wait_until(fun() -> {ok, 101} =:= blockchain:sync_height(Chain2) end),
     %% the actual height should be the same
     ?assertEqual({ok, 101}, blockchain:height(Chain2)),
     ?assertEqual(blockchain:sync_hash(Chain2), {ok, blockchain_block:hash_block(LastBlock)}),


### PR DESCRIPTION
Prior to this change, if the blockchain was interrupted mid async-valid
absorb, on startup the main blockchain init would be blocked absorbing
blocks. This is not necessary and it impedes the blockchain doing other
things while assume-valid processes in the background.

This change simply runs the assume-valid absorb in a background process,
much like when it's triggered by a blockchain sync.