### PR TITLE
rework folds

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -565,7 +565,7 @@ add_assumed_valid_block(AssumedValidHash, Block, Blockchain=#blockchain{db=DB, b
                     %% storage or to the head of the main chain, whichever comes first
                     case blockchain:head_hash(Blockchain) of
                         {ok, MainChainHeadHash} ->
-                            Chain = build_temp(MainChainHeadHash, Block, Blockchain),
+                            Chain = build_hash_chain(MainChainHeadHash, Block, Blockchain, TempBlocksCF),
                             %% note that 'Chain' includes 'Block' here.
                             %%
                             %% check the oldest block in the temporary chain connects with
@@ -725,22 +725,22 @@ build(StartingBlock, Blockchain, N, Acc) ->
     end.
 
 
--spec build_temp(blockchain_block:hash(), blockchain_block:block(), blockchain()) -> [blockchain_block:hash(), ...].
-build_temp(StopHash,StartingBlock, Blockchain) ->
+-spec build_hash_chain(blockchain_block:hash(), blockchain_block:block(), blockchain(), rocksdb:cf_handle()) -> [blockchain_block:hash(), ...].
+build_hash_chain(StopHash,StartingBlock, Blockchain, CF) ->
     BlockHash = blockchain_block:hash_block(StartingBlock),
     ParentHash = blockchain_block:prev_hash(StartingBlock),
-    build_temp_(StopHash, Blockchain, [ParentHash, BlockHash]).
+    build_hash_chain_(StopHash, CF, Blockchain, [ParentHash, BlockHash]).
 
--spec build_temp_(blockchain_block:hash(), blockchain(), [blockchain_block:hash(), ...]) -> [blockchain_block:hash()].
-build_temp_(StopHash, Blockchain = #blockchain{db=DB, temp_blocks=TempBlocksCF}, [ParentHash|Tail]=Acc) ->
+-spec build_hash_chain_(blockchain_block:hash(), rocksdb:cf_handle(), blockchain(), [blockchain_block:hash(), ...]) -> [blockchain_block:hash()].
+build_hash_chain_(StopHash, CF, Blockchain = #blockchain{db=DB}, [ParentHash|Tail]=Acc) ->
     case ParentHash == StopHash of
         true ->
             %% reached the end
             Tail;
         false ->
-            case rocksdb:get(DB, TempBlocksCF, ParentHash, []) of
+            case rocksdb:get(DB, CF, ParentHash, []) of
                 {ok, BinBlock} ->
-                    build_temp_(StopHash, Blockchain, [blockchain_block:prev_hash(blockchain_block:deserialize(BinBlock))|Acc]);
+                    build_hash_chain_(StopHash, CF, Blockchain, [blockchain_block:prev_hash(blockchain_block:deserialize(BinBlock))|Acc]);
                 _ ->
                     Acc
             end
@@ -761,30 +761,68 @@ reset_ledger(Chain) ->
 
 reset_ledger(Height, #blockchain{db = DB,
                                  dir = Dir,
+                                 default = DefaultCF,
                                  blocks = BlocksCF,
                                  heights = HeightsCF} = Chain) ->
     blockchain_lock:acquire(),
-    %% delete the existing and trailing ledgers
-    ok = blockchain_ledger_v1:clean(ledger(Chain)),
-    %% delete blocks from Height + 1 to the top of the chain
-    {ok, TopHeight} = height(Chain),
-    _ = lists:foreach(
-          fun(H) ->
-                  {ok, B} = get_block(H, Chain),
-                  delete_block(B, Chain)
-          end,
-          %% this will be a noop in the case where Height == TopHeight
-          lists:reverse(lists:seq(Height + 1, TopHeight))),
-    %% recreate the ledgers
-    Ledger1 = blockchain_ledger_v1:new(Dir),
+    %% check this is safe to do
+    {ok, StartBlock} = get_block(Height, Chain),
+    {ok, GenesisHash} = genesis_hash(Chain),
+    %% note that this will not include the genesis block
+    HashChain = build_hash_chain(GenesisHash, StartBlock, Chain, BlocksCF),
+    LastKnownBlock = case get_block(hd(HashChain), Chain) of
+                         {ok, LKB} ->
+                             LKB;
+                         {error, not_found} ->
+                             {ok, LKB} = get_block(hd(tl(HashChain)), Chain),
+                             LKB
+                     end,
+    %% check the height is what we'd expect
+    case length(HashChain) == Height - 1 andalso
+         %% check that the previous block is the genesis block
+         GenesisHash == blockchain_block:prev_hash(LastKnownBlock)  of
+        false ->
+            %% can't do this, we're missing a block somwewhere along the line
+            MissingHash = blockchain_block:prev_hash(LastKnownBlock),
+            MissingHeight = blockchain_block:height(LastKnownBlock) - 1,
+            blockchain_lock:release(),
+            {error, {missing_block, MissingHash, MissingHeight}};
+        true ->
+            %% delete the existing and trailing ledgers
+            ok = blockchain_ledger_v1:clean(ledger(Chain)),
+            %% delete blocks from Height + 1 to the top of the chain
+            {ok, TopHeight} = height(Chain),
+            _ = lists:foreach(
+                  fun(H) ->
+                          case get_block(H, Chain) of
+                              {ok, B} ->
+                                  delete_block(B, Chain);
+                              _ ->
+                                  ok
+                          end
+                  end,
+                  %% this will be a noop in the case where Height == TopHeight
+                  lists:reverse(lists:seq(Height + 1, TopHeight))),
+            {ok, TargetBlock} = get_block(Height, Chain),
+            case head_hash(Chain) ==  {ok, blockchain_block:hash_block(TargetBlock)} of
+                false ->
+                    %% the head hash needs to be corrected (we probably had a hole in the chain)
+                    ok = rocksdb:put(DB, DefaultCF, ?HEAD, blockchain_block:hash_block(TargetBlock), [{sync, true}]);
+                true ->
+                    %% nothing to do
+                    ok
+            end,
 
-    %% reapply the blocks
-    Chain1 =
-        lists:foldl(
-          fun(H, CAcc) ->
-                  case rocksdb:get(DB, HeightsCF, <<H:64/integer-unsigned-big>>, []) of
-                      {ok, Hash0} ->
-                          Hash =
+            %% recreate the ledgers
+            Ledger1 = blockchain_ledger_v1:new(Dir),
+
+            %% reapply the blocks
+            Chain1 =
+            lists:foldl(
+              fun(H, CAcc) ->
+                      case rocksdb:get(DB, HeightsCF, <<H:64/integer-unsigned-big>>, []) of
+                          {ok, Hash0} ->
+                              Hash =
                               case H of
                                   1 ->
                                       {ok, GHash} = genesis_hash(Chain),
@@ -792,24 +830,25 @@ reset_ledger(Height, #blockchain{db = DB,
                                   _ ->
                                       Hash0
                               end,
-                          {ok, BinBlock} = rocksdb:get(DB, BlocksCF, Hash, []),
-                          Block = blockchain_block:deserialize(BinBlock),
-                          lager:info("absorbing block ~p ?= ~p", [H, blockchain_block:height(Block)]),
-                          ok = blockchain_txn:unvalidated_absorb_and_commit(Block, CAcc, fun() -> ok end, blockchain_block:is_rescue_block(Block)),
-                          CAcc;
-                      _ ->
-                          lager:warning("couldn't absorb block at ~p", [H]),
-                          ok
-                  end
-          end,
-          %% this will be a noop in the case where Height == TopHeight
-          ledger(Ledger1, Chain),
-          lists:seq(1, Height)),
+                              {ok, BinBlock} = rocksdb:get(DB, BlocksCF, Hash, []),
+                              Block = blockchain_block:deserialize(BinBlock),
+                              lager:info("absorbing block ~p ?= ~p", [H, blockchain_block:height(Block)]),
+                              ok = blockchain_txn:unvalidated_absorb_and_commit(Block, CAcc, fun() -> ok end, blockchain_block:is_rescue_block(Block)),
+                              CAcc;
+                          _ ->
+                              lager:warning("couldn't absorb block at ~p", [H]),
+                              ok
+                      end
+              end,
+              %% this will be a noop in the case where Height == TopHeight
+              ledger(Ledger1, Chain),
+              lists:seq(1, Height)),
 
-    blockchain_worker:blockchain(Chain1),
+            blockchain_worker:blockchain(Chain1),
 
-    blockchain_lock:release(),
-    ok.
+            blockchain_lock:release(),
+            {ok, Chain1}
+    end.
 
 
 %% ------------------------------------------------------------------

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -1483,7 +1483,8 @@ add_routing(Owner, OUI, Addresses, Nonce, Ledger) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
-clean(#ledger_v1{dir=Dir, db=DB}) ->
+clean(#ledger_v1{dir=Dir, db=DB}=L) ->
+    delete_context(L),
     DBDir = filename:join(Dir, ?DB_FILE),
     ok = rocksdb:close(DB),
     rocksdb:destroy(DBDir, []).

--- a/src/transactions/v1/blockchain_txn_consensus_group_v1.erl
+++ b/src/transactions/v1/blockchain_txn_consensus_group_v1.erl
@@ -120,9 +120,9 @@ is_valid(Txn, Chain) ->
                 ok
         end,
         TxnHeight = ?MODULE:height(Txn),
-        case blockchain:height(Chain) of
+        case blockchain_ledger_v1:current_height(Ledger) of
             %% no chain, genesis block
-            {error, not_found} ->
+            {ok, 0} ->
                 ok;
             {ok, CurrHeight} ->
                 {ok, CurrBlock} = blockchain:get_block(CurrHeight, Chain),

--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -132,7 +132,7 @@ is_valid(Txn, Chain) ->
     PubKey = libp2p_crypto:bin_to_pubkey(Challenger),
     BaseTxn = Txn#blockchain_txn_poc_receipts_v1_pb{signature = <<>>},
     EncodedTxn = blockchain_txn_poc_receipts_v1_pb:encode_msg(BaseTxn),
-    {ok, Height} = blockchain:height(Chain),
+    {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
     POCOnionKeyHash = ?MODULE:onion_key_hash(Txn),
     case libp2p_crypto:verify(EncodedTxn, Signature, PubKey) of
         false ->

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -384,14 +384,14 @@ rescue_absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     delayed_absorb(Txn, Ledger).
 
-maybe_absorb(Txn, Ledger, Chain) ->
+maybe_absorb(Txn, Ledger, _Chain) ->
     case blockchain_ledger_v1:current_height(Ledger) of
         %% genesis block is never delayed
         {ok, 0} ->
             delayed_absorb(Txn, Ledger),
             true;
         _ ->
-            {ok, Height} = blockchain:height(Chain),
+            {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
             {ok, Delay} = blockchain:config(?vars_commit_delay, Ledger),
             Effective = Delay + Height,
             case version_predicate(Txn) of

--- a/test/blockchain_simple_SUITE.erl
+++ b/test/blockchain_simple_SUITE.erl
@@ -63,6 +63,7 @@ all() ->
         election_test,
         chain_vars_test,
         token_burn_test,
+        payer_test,
         poc_sync_interval_test
     ].
 
@@ -1385,13 +1386,13 @@ payer_test(Config) ->
     ?assertEqual({ok, Block2}, blockchain:head_block(Chain)),
     ?assertEqual({ok, 2}, blockchain:height(Chain)),
     ?assertEqual({ok, Block2}, blockchain:get_block(2, Chain)),
-    lists:foreach(
-        fun(_) ->
-                Block = test_utils:create_block(ConsensusMembers, []),
-                _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self())
-        end,
-        lists:seq(1, 20)
-    ),
+    Blocks = lists:map(
+               fun(_) ->
+                       Block = test_utils:create_block(ConsensusMembers, []),
+                       _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+                       Block
+               end,
+               lists:seq(1, 20)),
     ?assertEqual({ok, Rate}, blockchain_ledger_v1:config(?token_burn_exchange_rate, Ledger)),
 
 
@@ -1448,6 +1449,37 @@ payer_test(Config) ->
     {ok, GwInfo} = blockchain_ledger_v1:find_gateway_info(Gateway, blockchain:ledger(Chain)),
     ?assertEqual(Owner, blockchain_ledger_gateway_v2:owner_address(GwInfo)),
     ?assertEqual(?TEST_LOCATION, blockchain_ledger_gateway_v2:location(GwInfo)),
+
+    %% try resyncing the ledger
+    {ok, NewChain} = blockchain:reset_ledger(Chain),
+
+    ?assertEqual({ok, blockchain_block:hash_block(Block24)}, blockchain:head_hash(NewChain)),
+    ?assertEqual({ok, Block24}, blockchain:head_block(NewChain)),
+    ?assertEqual({ok, 24}, blockchain:height(NewChain)),
+    ?assertEqual({ok, Block24}, blockchain:get_block(24, NewChain)),
+    {ok, DCEntry1} = blockchain_ledger_v1:find_dc_entry(Payer, blockchain:ledger(NewChain)),
+    ?assertEqual(10*Rate-11*3, blockchain_ledger_data_credits_entry_v1:balance(DCEntry1)),
+
+    blockchain:delete_block(Block23, NewChain),
+
+    ?assertEqual({error, {missing_block, blockchain_block:hash_block(Block23), blockchain_block:height(Block23)}}, blockchain:reset_ledger(NewChain)),
+
+    {ok, NewerChain} = blockchain:reset_ledger(20, NewChain),
+
+    ?assertEqual(blockchain:head_hash(NewerChain), {ok, blockchain_block:hash_block(lists:nth(18, Blocks))}),
+    ?assertEqual({ok, 20}, blockchain:height(NewerChain)),
+    ?assertEqual({ok, lists:nth(18, Blocks)}, blockchain:head_block(NewerChain)),
+    ?assertEqual({ok, lists:nth(18, Blocks)}, blockchain:get_block(20, NewerChain)),
+
+    blockchain:add_blocks(Blocks ++ [Block23, Block24], NewerChain),
+
+    ?assertEqual({ok, blockchain_block:hash_block(Block24)}, blockchain:head_hash(NewerChain)),
+    ?assertEqual({ok, Block24}, blockchain:head_block(NewerChain)),
+    ?assertEqual({ok, 24}, blockchain:height(NewerChain)),
+    ?assertEqual({ok, Block24}, blockchain:get_block(24, NewerChain)),
+    {ok, DCEntry1} = blockchain_ledger_v1:find_dc_entry(Payer, blockchain:ledger(NewerChain)),
+    ?assertEqual(10*Rate-11*3, blockchain_ledger_data_credits_entry_v1:balance(DCEntry1)),
+
     ok.
 
 poc_sync_interval_test(Config) ->


### PR DESCRIPTION
the fold function has been deprecated, so we use iterators directly now in our code.  also, we change all iteration to go through the reworked fold function, because otherwise that iteration is not cache-aware.