### PR TITLE
Don't allow overlapping assume-valid chains to occur

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -952,30 +952,36 @@ save_block(Block, Batch, #blockchain{default=DefaultCF, blocks=BlocksCF, heights
     %% lexiographic ordering works better with big endian
     ok = rocksdb:batch_put(Batch, HeightsCF, <<Height:64/integer-unsigned-big>>, Hash).
 
-save_temp_block(Block, #blockchain{db=DB, temp_blocks=TempBlocks, default=DefaultCF}) ->
+save_temp_block(Block, #blockchain{db=DB, temp_blocks=TempBlocks, default=DefaultCF}=Chain) ->
     Hash = blockchain_block:hash_block(Block),
     case rocksdb:get(DB, TempBlocks, Hash, []) of
         {ok, _} ->
             %% already got it, thanks
             ok;
         _ ->
-            {ok, Batch} = rocksdb:batch(),
-            PrevHash = blockchain_block:prev_hash(Block),
-            ok = rocksdb:batch_put(Batch, TempBlocks, Hash, blockchain_block:serialize(Block)),
-            %% So, we have to be careful here because we might have multiple seemingly valid chains
-            %% only one of which will lead to the assumed valid block. We need to keep track of all
-            %% the potentials heads and use each of them randomly as our 'sync hash' until we can
-            %% get a valid chain to the 'assumed valid` block. Ugh.
-            TempHeads = case rocksdb:get(DB, DefaultCF, ?TEMP_HEADS, []) of
-                            {ok, BinHeadsList} ->
-                                binary_to_term(BinHeadsList);
-                            _ ->
-                                []
-                        end,
-            Height = blockchain_block:height(Block),
-            lager:info("temp block height is at least ~p", [Height]),
-            ok = rocksdb:batch_put(Batch, DefaultCF, ?TEMP_HEADS, term_to_binary([Hash|TempHeads] -- [PrevHash])),
-            ok = rocksdb:write_batch(DB, Batch, [{sync, true}])
+            case get_block(Hash, Chain) of
+                {ok, _} ->
+                    %% have it on the main chain
+                    ok;
+                _ ->
+                    {ok, Batch} = rocksdb:batch(),
+                    PrevHash = blockchain_block:prev_hash(Block),
+                    ok = rocksdb:batch_put(Batch, TempBlocks, Hash, blockchain_block:serialize(Block)),
+                    %% So, we have to be careful here because we might have multiple seemingly valid chains
+                    %% only one of which will lead to the assumed valid block. We need to keep track of all
+                    %% the potentials heads and use each of them randomly as our 'sync hash' until we can
+                    %% get a valid chain to the 'assumed valid` block. Ugh.
+                    TempHeads = case rocksdb:get(DB, DefaultCF, ?TEMP_HEADS, []) of
+                                    {ok, BinHeadsList} ->
+                                        binary_to_term(BinHeadsList);
+                                    _ ->
+                                        []
+                                end,
+                    Height = blockchain_block:height(Block),
+                    lager:info("temp block height is at least ~p", [Height]),
+                    ok = rocksdb:batch_put(Batch, DefaultCF, ?TEMP_HEADS, term_to_binary([Hash|TempHeads] -- [PrevHash])),
+                    ok = rocksdb:write_batch(DB, Batch, [{sync, true}])
+            end
     end.
 
 get_temp_block(Hash, #blockchain{db=DB, temp_blocks=TempBlocksCF}) ->

--- a/test/assume_valid_SUITE.erl
+++ b/test/assume_valid_SUITE.erl
@@ -14,7 +14,8 @@
     blockchain_restart/1,
     blockchain_almost_synced/1,
     blockchain_crash_while_absorbing/1,
-    blockchain_crash_while_absorbing_and_assume_valid_moves/1
+    blockchain_crash_while_absorbing_and_assume_valid_moves/1,
+    overlapping_streams/1
 ]).
 
 %%--------------------------------------------------------------------
@@ -28,7 +29,7 @@
 %% @end
 %%--------------------------------------------------------------------
 all() ->
-    [basic, blockchain_restart, blockchain_almost_synced, blockchain_crash_while_absorbing, blockchain_crash_while_absorbing_and_assume_valid_moves].
+    [basic, blockchain_restart, blockchain_almost_synced, blockchain_crash_while_absorbing, blockchain_crash_while_absorbing_and_assume_valid_moves, overlapping_streams].
 
 %%--------------------------------------------------------------------
 %% TEST CASES
@@ -275,3 +276,51 @@ blockchain_crash_while_absorbing_and_assume_valid_moves(_Config) ->
     ?assertEqual({ok, 102}, blockchain:sync_height(Chain1)),
     ok.
 
+overlapping_streams(_Config) ->
+    BaseDir = "data/assume_valid_SUITE/overlapping_streams",
+    Balance = 5000,
+    BlocksN = 100,
+    {ok, _Sup, {PrivKey, PubKey}, _Opts} = test_utils:init(BaseDir),
+    {ok, _GenesisMembers, ConsensusMembers, _} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
+    Chain0 = blockchain_worker:blockchain(),
+    {ok, Genesis} = blockchain:genesis_block(Chain0),
+
+    % Add some blocks
+    Blocks = lists:reverse(lists:foldl(
+        fun(_, Acc) ->
+            Block = test_utils:create_block(ConsensusMembers, []),
+            blockchain:add_block(Block, Chain0),
+            [Block|Acc]
+        end,
+        [],
+        lists:seq(1, BlocksN)
+    )),
+    LastBlock = lists:last(Blocks),
+
+    SimDir = "data/assume_valid_SUITE/overlapping_streams_sim",
+    {ok, Chain1} = blockchain:new(SimDir, Genesis, undefined),%, blockchain_block:hash_block(LastBlock)),
+
+    ok = blockchain:add_blocks(lists:sublist(Blocks, 15), Chain1),
+
+    ?assertEqual({ok, 16}, blockchain:height(Chain1)),
+    blockchain:close(Chain1),
+
+    {ok, Chain} = blockchain:new(SimDir, Genesis, blockchain_block:hash_block(LastBlock)),
+    %% this should fail without all the supporting blocks
+    blockchain:add_block(LastBlock, Chain),
+    ?assertEqual({ok, 16}, blockchain:height(Chain)),
+    ok = blockchain:add_blocks(lists:sublist(Blocks, 16, length(Blocks)) -- [LastBlock], Chain),
+    ?assertEqual({ok, 16}, blockchain:height(Chain)),
+    ?assertEqual({ok, 100}, blockchain:sync_height(Chain)),
+
+
+    %% re-add some old blocks again
+    ok = blockchain:add_blocks(lists:sublist(Blocks, 20), Chain),
+
+    %% assert we only have one sync head
+    ?assertEqual(1, length(lists:usort([ blockchain:sync_hash(Chain) || _ <- lists:seq(1, 100)]))),
+
+    ok = blockchain:add_block(LastBlock, Chain),
+    ?assertEqual({ok, 101}, blockchain:height(Chain)),
+    ?assertEqual({ok, 101}, blockchain:sync_height(Chain)),
+    ok.


### PR DESCRIPTION
Prior to this change it was possible for multiple assume-valid sync
heads to develop from blocks on the same chain. This would cause
needless re-syncing of blocks the node already had. This change ensures
we don't add a sync head for blocks we already have.