### PR TITLE
Rework block sync protocol and make it intentionally incompatible

### DIFF
--- a/include/blockchain.hrl
+++ b/include/blockchain.hrl
@@ -1,6 +1,6 @@
 % Protocols
 -define(GOSSIP_PROTOCOL, "blockchain_gossip/1.0.0").
--define(SYNC_PROTOCOL, "blockchain_sync/1.0.0").
+-define(SYNC_PROTOCOL, "blockchain_sync/1.1.0").
 -define(FASTFORWARD_PROTOCOL, "blockchain_fastforward/1.0.0").
 -define(TX_PROTOCOL, "blockchain_txn/1.0.0").
 -define(LOC_ASSERTION_PROTOCOL, "loc_assertion/1.0.0").

--- a/src/handlers/blockchain_sync_handler.erl
+++ b/src/handlers/blockchain_sync_handler.erl
@@ -29,7 +29,11 @@
 ]).
 
 -record(state, {
-    blockchain :: blockchain:blochain()
+    blockchain :: blockchain:blochain(),
+    block :: undefined | blockchain_block:block(),
+    batch_size :: pos_integer(),
+    batch_limit :: pos_integer(),
+    batches_sent = 0 :: non_neg_integer()
 }).
 
 %% ------------------------------------------------------------------
@@ -49,47 +53,57 @@ init(client, _Conn, [Blockchain]) ->
         true ->
             {stop, sync_paused};
         false ->
-            lager:debug("started sync_handler client"),
-            {ok, #state{blockchain=Blockchain}}
+            BatchSize = application:get_env(blockchain, block_sync_batch_size, 5),
+            BatchLimit = application:get_env(blockchain, block_sync_batch_limit, 40),
+            {ok, #state{blockchain=Blockchain, batch_size=BatchSize, batch_limit=BatchLimit}}
     end;
 init(server, _Conn, [_Path, _, Blockchain]) ->
-    lager:debug("started sync_handler server"),
-    {ok, #state{blockchain=Blockchain}}.
+    BatchSize = application:get_env(blockchain, block_sync_batch_size, 5),
+    BatchLimit = application:get_env(blockchain, block_sync_batch_limit, 40),
+    {ok, #state{blockchain=Blockchain, batch_size=BatchSize, batch_limit=BatchLimit}}.
 
 handle_data(client, Data, #state{blockchain=Chain}=State) ->
-    lager:debug("client got data: ~p", [Data]),
     #blockchain_sync_blocks_pb{blocks=BinBlocks} =
         blockchain_sync_handler_pb:decode_msg(Data, blockchain_sync_blocks_pb),
     Blocks = [blockchain_block:deserialize(B) || B <- BinBlocks],
     case blockchain:add_blocks(Blocks, Chain) of
         ok ->
-            ok;
-        Error ->
+            {noreply, State, blockchain_sync_handler_pb:encode_msg(#blockchain_sync_req_pb{msg={response, true}})};
+        _Error ->
             %% TODO: maybe dial for sync again?
-            lager:error("Couldn't sync blocks, error: ~p", [Error])
-    end,
-    {stop, normal, State};
-handle_data(server, Data, #state{blockchain=Blockchain}=State) ->
-    lager:debug("server got data: ~p", [Data]),
-    #blockchain_sync_hash_pb{hash=Hash} =
-        blockchain_sync_handler_pb:decode_msg(Data, blockchain_sync_hash_pb),
-    lager:debug("syncing blocks with peer hash ~p", [Hash]),
-    StartingBlock =
-        case blockchain:get_block(Hash, Blockchain) of
-            {ok, Block} ->
-                Block;
-            {error, _Reason} ->
-                {ok, B} = blockchain:genesis_block(Blockchain),
-                B
-        end,
-    Blocks = blockchain:build(StartingBlock, Blockchain, 200),
-    Msg = #blockchain_sync_blocks_pb{blocks=[blockchain_block:serialize(B) || B <- Blocks]},
-    {stop, normal, State, blockchain_sync_handler_pb:encode_msg(Msg)
-}.
+            {stop, normal, State, blockchain_sync_handler_pb:encode_msg(#blockchain_sync_req_pb{msg={response, false}})}
+    end;
+handle_data(server, Data, #state{blockchain=Blockchain, batch_size=BatchSize, batches_sent=Sent, batch_limit=Limit}=State) ->
+    case blockchain_sync_handler_pb:decode_msg(Data, blockchain_sync_req_pb) of
+        #blockchain_sync_req_pb{msg={hash, #blockchain_sync_hash_pb{hash=Hash}}} ->
+            case blockchain:get_block(Hash, Blockchain) of
+                {ok, StartingBlock} ->
+                    case blockchain:build(StartingBlock, Blockchain, BatchSize) of
+                        [] ->
+                            {stop, normal, State};
+                        Blocks ->
+                            Msg = #blockchain_sync_blocks_pb{blocks=[blockchain_block:serialize(B) || B <- Blocks]},
+                            {noreply, State#state{batches_sent=Sent+1, block=lists:last(Blocks)}, blockchain_sync_handler_pb:encode_msg(Msg)}
+                    end;
+                {error, _Reason} ->
+                    {stop, normal, State}
+            end;
+        #blockchain_sync_req_pb{msg={response, true}} when Sent < Limit, State#state.block /= undefined ->
+            StartingBlock = State#state.block,
+            case blockchain:build(StartingBlock, Blockchain, BatchSize) of
+                [] ->
+                    {stop, normal, State};
+                Blocks ->
+                    Msg = #blockchain_sync_blocks_pb{blocks=[blockchain_block:serialize(B) || B <- Blocks]},
+                    {noreply, State#state{batches_sent=Sent+1, block=lists:last(Blocks)}, blockchain_sync_handler_pb:encode_msg(Msg)}
+            end;
+        _ ->
+            %% ack was false, block was undefined, limit was hit or the message was not understood
+            {stop, normal, State}
+    end.
 
 handle_info(client, {hash, Hash}, State) ->
-    Msg = #blockchain_sync_hash_pb{hash=Hash},
+    Msg = #blockchain_sync_req_pb{msg={hash, #blockchain_sync_hash_pb{hash=Hash}}},
     {noreply, State, blockchain_sync_handler_pb:encode_msg(Msg)};
 handle_info(_Type, _Msg, State) ->
-    lager:debug("rcvd unknown type: ~p unknown msg: ~p", [_Type, _Msg]),
     {noreply, State}.

--- a/src/handlers/blockchain_sync_handler.proto
+++ b/src/handlers/blockchain_sync_handler.proto
@@ -7,3 +7,10 @@ message sync_hash {
 message sync_blocks {
     repeated bytes blocks= 1;
 }
+
+message sync_req {
+  oneof msg {
+    sync_hash hash = 1;
+    bool response = 2;
+  }
+}


### PR DESCRIPTION
To prevent old firmwares syncing too far on the chain that they encounter ledger corrupting bugs, increment the block sync protcol so older firmware cannot dial newer nodes.

In addition, rework how blocks are delivered to allow for more incremental updates which may play better with traffic shaping and other network issues.