### PR TITLE
Implement and require validation for all defined chain vars

### DIFF
--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -275,6 +275,7 @@ absorb_and_commit(Block, Chain0, BeforeCommit, Rescue) ->
                     Error
             end;
         {_ValidTxns, InvalidTxns} ->
+            blockchain_ledger_v1:delete_context(Ledger1),
             lager:error("found invalid transactions: ~p", [InvalidTxns]),
             {error, invalid_txns}
     end.
@@ -285,19 +286,29 @@ unvalidated_absorb_and_commit(Block, Chain0, BeforeCommit, Rescue) ->
     Ledger0 = blockchain:ledger(Chain0),
     Ledger1 = blockchain_ledger_v1:new_context(Ledger0),
     Chain1 = blockchain:ledger(Ledger1, Chain0),
-    case ?MODULE:absorb_block(Block, Rescue, Chain1) of
-        {ok, Chain2} ->
-            Ledger2 = blockchain:ledger(Chain2),
-            case BeforeCommit() of
-                ok ->
-                    ok = blockchain_ledger_v1:commit_context(Ledger2),
-                    absorb_delayed(Block, Chain0);
-                Any ->
-                    Any
+    Transactions0 = blockchain_block:transactions(Block),
+    %% chain vars must always be validated so we don't accidentally sync past a change we don't understand
+    Transactions = lists:filter(fun(T) -> ?MODULE:type(T) == blockchain_txn_vars_v1 end, (Transactions0)),
+    case ?MODULE:validate(Transactions, Chain1, Rescue) of
+        {_ValidTxns, []} ->
+            case ?MODULE:absorb_block(Block, Rescue, Chain1) of
+                {ok, Chain2} ->
+                    Ledger2 = blockchain:ledger(Chain2),
+                    case BeforeCommit() of
+                        ok ->
+                            ok = blockchain_ledger_v1:commit_context(Ledger2),
+                            absorb_delayed(Block, Chain0);
+                        Any ->
+                            Any
+                    end;
+                Error ->
+                    blockchain_ledger_v1:delete_context(Ledger1),
+                    Error
             end;
-        Error ->
+        {_ValidTxns, InvalidTxns} ->
             blockchain_ledger_v1:delete_context(Ledger1),
-            Error
+            lager:error("found invalid transactions: ~p", [InvalidTxns]),
+            {error, invalid_txns}
     end.
 
 %%--------------------------------------------------------------------

--- a/test/blockchain_simple_SUITE.erl
+++ b/test/blockchain_simple_SUITE.erl
@@ -1233,7 +1233,7 @@ chain_vars_test(Config) ->
 
     Ledger = blockchain:ledger(Chain),
 
-    Vars = #{chain_var => foo},
+    Vars = #{poc_version => 2},
 
     ct:pal("priv_key ~p", [Priv]),
 
@@ -1252,10 +1252,10 @@ chain_vars_test(Config) ->
                 Block = test_utils:create_block(ConsensusMembers, []),
                 _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
                 {ok, Height} = blockchain:height(Chain),
-                case blockchain:config(chain_var, Ledger) of % ignore "?"
+                case blockchain:config(poc_version, Ledger) of % ignore "?"
                     {error, not_found} when Height < (Delay + 1) ->
                         ok;
-                    {ok, foo} when Height >= (Delay + 1) ->
+                    {ok, 2} when Height >= (Delay + 1) ->
                         ok;
                     Res ->
                         throw({error, {chain_var_wrong_height, Res, Height}})
@@ -1274,7 +1274,7 @@ chain_vars_set_unset_test(Config) ->
 
     Ledger = blockchain:ledger(Chain),
 
-    Vars = #{chain_var => foo},
+    Vars = #{poc_version => 2},
 
     ct:pal("priv_key ~p", [Priv]),
 
@@ -1293,10 +1293,10 @@ chain_vars_set_unset_test(Config) ->
                 Block = test_utils:create_block(ConsensusMembers, []),
                 _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
                 {ok, Height} = blockchain:height(Chain),
-                case blockchain:config(chain_var, Ledger) of % ignore "?"
+                case blockchain:config(poc_version, Ledger) of % ignore "?"
                     {error, not_found} when Height < (Delay + 1) ->
                         ok;
-                    {ok, foo} when Height >= (Delay + 1) ->
+                    {ok, 2} when Height >= (Delay + 1) ->
                         ok;
                     Res ->
                         throw({error, {chain_var_wrong_height, Res, Height}})
@@ -1308,7 +1308,7 @@ chain_vars_set_unset_test(Config) ->
     {ok, Height} = blockchain:height(Chain),
     ct:pal("Height ~p", [Height]),
 
-    UnsetVarTxn = blockchain_txn_vars_v1:new(#{}, 4, #{unsets => [chain_var]}),
+    UnsetVarTxn = blockchain_txn_vars_v1:new(#{}, 4, #{unsets => [poc_version]}),
     UnsetProof = blockchain_txn_vars_v1:create_proof(Priv, UnsetVarTxn),
     UnsetVarTxn1 = blockchain_txn_vars_v1:proof(UnsetVarTxn, UnsetProof),
 
@@ -1321,8 +1321,8 @@ chain_vars_set_unset_test(Config) ->
                 _ = blockchain_gossip_handler:add_block(Swarm, Block1, Chain, self()),
                 {ok, Height1} = blockchain:height(Chain),
                 ct:pal("Height1 ~p", [Height1]),
-                case blockchain:config(chain_var, Ledger) of % ignore "?"
-                    {ok, foo} when Height1 < (Height + Delay + 1) ->
+                case blockchain:config(poc_version, Ledger) of % ignore "?"
+                    {ok, 2} when Height1 < (Height + Delay + 1) ->
                         ok;
                     {error, not_found} when Height1 >= (Height + Delay) ->
                         ok;


### PR DESCRIPTION
Instead of only validating selected chain vars, implement validation for
all known chain vars. Unknown chain vars or chain var values out of
range will cause blocks to fail to validate.

Additionally, when doing unvalidated absorb of blocks, validate the
chain vars anyway.

The rationale for all these changes is to prevent syncing past a block
that contains chain var changes we don't understand and corrupting our
ledger, preventing a sync after an OTA to add support for that new chain
var or value from proceeding.