### PR TITLE
Add block height to assume-valid block information

### DIFF
--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -264,19 +264,22 @@ init(Args) ->
             end,
     BaseDir = proplists:get_value(base_dir, Args, "data"),
     GenDir = proplists:get_value(update_dir, Args, undefined),
-    AssumedValidBlockHash = case application:get_env(blockchain, assumed_valid_block_hash, undefined) of
-                                undefined ->
+    AssumedValidBlockHashAndHeight = case {application:get_env(blockchain, assumed_valid_block_hash, undefined),
+                                  application:get_env(blockchain, assumed_valid_block_height, undefined)} of
+                                {undefined, _} ->
                                     undefined;
-                                BlockHash ->
+                                {_, undefined} ->
+                                    undefined;
+                                BlockHashAndHeight ->
                                     case application:get_env(blockchain, honor_assumed_valid, false) of
                                         true ->
-                                            BlockHash;
+                                            BlockHashAndHeight;
                                         _ ->
                                             undefined
                                     end
                             end,
     Blockchain =
-        case blockchain:new(BaseDir, GenDir, AssumedValidBlockHash) of
+        case blockchain:new(BaseDir, GenDir, AssumedValidBlockHashAndHeight) of
             {no_genesis, _Chain}=R ->
                 %% mark all upgrades done
                 R;

--- a/test/assume_valid_SUITE.erl
+++ b/test/assume_valid_SUITE.erl
@@ -11,6 +11,7 @@
 
 -export([
     basic/1,
+    wrong_height/1,
     blockchain_restart/1,
     blockchain_almost_synced/1,
     blockchain_crash_while_absorbing/1,
@@ -29,7 +30,7 @@
 %% @end
 %%--------------------------------------------------------------------
 all() ->
-    [basic, blockchain_restart, blockchain_almost_synced, blockchain_crash_while_absorbing, blockchain_crash_while_absorbing_and_assume_valid_moves, overlapping_streams].
+    [basic, wrong_height, blockchain_restart, blockchain_almost_synced, blockchain_crash_while_absorbing, blockchain_crash_while_absorbing_and_assume_valid_moves, overlapping_streams].
 
 %%--------------------------------------------------------------------
 %% TEST CASES
@@ -57,7 +58,7 @@ basic(_Config) ->
     LastBlock = lists:last(Blocks),
 
     SimDir = "data/assume_valid_SUITE/basic_sim",
-    {ok, Chain} = blockchain:new(SimDir, Genesis, blockchain_block:hash_block(LastBlock)),
+    {ok, Chain} = blockchain:new(SimDir, Genesis, {blockchain_block:hash_block(LastBlock), blockchain_block:height(LastBlock)}),
 
     ?assertEqual({ok, 1}, blockchain:height(Chain)),
     %% this should fail without all the supporting blocks
@@ -70,6 +71,43 @@ basic(_Config) ->
     ?assertEqual({ok, 101}, blockchain:height(Chain)),
     ?assertEqual({ok, 101}, blockchain:sync_height(Chain)),
     ok.
+
+wrong_height(_Config) ->
+    BaseDir = "data/assume_valid_SUITE/wrong_height",
+    Balance = 5000,
+    BlocksN = 100,
+    {ok, _Sup, {PrivKey, PubKey}, _Opts} = test_utils:init(BaseDir),
+    {ok, _GenesisMembers, ConsensusMembers, _} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
+    Chain0 = blockchain_worker:blockchain(),
+    {ok, Genesis} = blockchain:genesis_block(Chain0),
+
+    % Add some blocks
+    Blocks = lists:reverse(lists:foldl(
+        fun(_, Acc) ->
+            Block = test_utils:create_block(ConsensusMembers, []),
+            blockchain:add_block(Block, Chain0),
+            [Block|Acc]
+        end,
+        [],
+        lists:seq(1, BlocksN)
+    )),
+    LastBlock = lists:last(Blocks),
+
+    SimDir = "data/assume_valid_SUITE/wrong_height_sim",
+    {ok, Chain} = blockchain:new(SimDir, Genesis, {blockchain_block:hash_block(LastBlock), blockchain_block:height(LastBlock) + 1}),
+
+    ?assertEqual({ok, 1}, blockchain:height(Chain)),
+    %% this should fail without all the supporting blocks
+    blockchain:add_block(LastBlock, Chain),
+    ?assertEqual({ok, 1}, blockchain:height(Chain)),
+    ok = blockchain:add_blocks(Blocks -- [LastBlock], Chain),
+    ?assertEqual({ok, 1}, blockchain:height(Chain)),
+    ?assertEqual({ok, 100}, blockchain:sync_height(Chain)),
+    {error, _} = blockchain:add_block(LastBlock, Chain),
+    ?assertEqual({ok, 1}, blockchain:height(Chain)),
+    ?assertEqual({ok, 100}, blockchain:sync_height(Chain)),
+    ok.
+
 
 blockchain_restart(_Config) ->
     BaseDir = "data/assume_valid_SUITE/blockchain_restart",
@@ -93,7 +131,7 @@ blockchain_restart(_Config) ->
     LastBlock = lists:last(Blocks),
 
     SimDir = "data/assume_valid_SUITE/blockchain_restart_sim",
-    {ok, Chain} = blockchain:new(SimDir, Genesis, blockchain_block:hash_block(LastBlock)),
+    {ok, Chain} = blockchain:new(SimDir, Genesis, {blockchain_block:hash_block(LastBlock), blockchain_block:height(LastBlock)}),
 
     ?assertEqual({ok, 1}, blockchain:height(Chain)),
     ok = blockchain:add_blocks(Blocks -- [LastBlock], Chain),
@@ -101,7 +139,7 @@ blockchain_restart(_Config) ->
     ?assertEqual({ok, 100}, blockchain:sync_height(Chain)),
     %% simulate the node stopping or crashing
     blockchain:close(Chain),
-    {ok, Chain1} = blockchain:new(SimDir, Genesis, blockchain_block:hash_block(LastBlock)),
+    {ok, Chain1} = blockchain:new(SimDir, Genesis, {blockchain_block:hash_block(LastBlock), blockchain_block:height(LastBlock)}),
     ?assertEqual({ok, 1}, blockchain:height(Chain1)),
     ?assertEqual({ok, 100}, blockchain:sync_height(Chain1)),
     ok = blockchain:add_block(LastBlock, Chain1),
@@ -140,7 +178,7 @@ blockchain_almost_synced(_Config) ->
     %% simulate the node stopping or crashing
     blockchain:close(Chain),
     %% re-open with the assumed-valid hash supplied, like if we got an OTA
-    {ok, Chain1} = blockchain:new(SimDir, Genesis, blockchain_block:hash_block(LastBlock)),
+    {ok, Chain1} = blockchain:new(SimDir, Genesis, {blockchain_block:hash_block(LastBlock), blockchain_block:height(LastBlock)}),
     ?assertEqual({ok, 100}, blockchain:height(Chain1)),
     ?assertEqual({ok, 100}, blockchain:sync_height(Chain1)),
     ok = blockchain:add_block(LastBlock, Chain1),
@@ -171,7 +209,7 @@ blockchain_crash_while_absorbing(_Config) ->
     ExplodeBlock = lists:nth(50, Blocks),
 
     SimDir = "data/assume_valid_SUITE/blockchain_crash_while_absorbing_sim",
-    {ok, Chain} = blockchain:new(SimDir, Genesis, blockchain_block:hash_block(LastBlock)),
+    {ok, Chain} = blockchain:new(SimDir, Genesis, {blockchain_block:hash_block(LastBlock), blockchain_block:height(LastBlock)}),
 
     meck:new(blockchain_txn, [passthrough]),
     meck:expect(blockchain_txn, unvalidated_absorb_and_commit,
@@ -203,7 +241,7 @@ blockchain_crash_while_absorbing(_Config) ->
     blockchain:close(Chain1),
     %% reopen the blockchain and provide the assume-valid hash
     %% since we already have all the blocks, it should immediately sync
-    {ok, Chain2} = blockchain:new(SimDir, Genesis, blockchain_block:hash_block(LastBlock)),
+    {ok, Chain2} = blockchain:new(SimDir, Genesis, {blockchain_block:hash_block(LastBlock), blockchain_block:height(LastBlock)}),
     %% the sync is done in a background process, so wait for it to complete
     ok = blockchain_ct_utils:wait_until(fun() -> {ok, 101} =:= blockchain:sync_height(Chain2) end),
     %% the actual height should be the same
@@ -239,7 +277,7 @@ blockchain_crash_while_absorbing_and_assume_valid_moves(_Config) ->
     blockchain:add_block(FinalLastBlock, Chain0),
 
     SimDir = "data/assume_valid_SUITE/blockchain_crash_while_absorbing_and_assume_valid_moves_sim",
-    {ok, Chain} = blockchain:new(SimDir, Genesis, blockchain_block:hash_block(LastBlock)),
+    {ok, Chain} = blockchain:new(SimDir, Genesis, {blockchain_block:hash_block(LastBlock), blockchain_block:height(LastBlock)}),
 
     meck:new(blockchain_txn, [passthrough]),
     meck:expect(blockchain_txn, unvalidated_absorb_and_commit,
@@ -260,7 +298,7 @@ blockchain_crash_while_absorbing_and_assume_valid_moves(_Config) ->
     %% simulate the node stopping or crashing
     blockchain:close(Chain),
     %% re-open with a newer assumed-valid hash supplied, like if we got an OTA
-    {ok, Chain1} = blockchain:new(SimDir, Genesis, blockchain_block:hash_block(FinalLastBlock)),
+    {ok, Chain1} = blockchain:new(SimDir, Genesis, {blockchain_block:hash_block(FinalLastBlock), blockchain_block:height(FinalLastBlock)}),
     %% the sync height should be 101 because we don't have the new assume valid hash
     ?assertEqual({ok, 101}, blockchain:sync_height(Chain1)),
     %% the actual height should be right before the explode block
@@ -305,7 +343,7 @@ overlapping_streams(_Config) ->
     ?assertEqual({ok, 16}, blockchain:height(Chain1)),
     blockchain:close(Chain1),
 
-    {ok, Chain} = blockchain:new(SimDir, Genesis, blockchain_block:hash_block(LastBlock)),
+    {ok, Chain} = blockchain:new(SimDir, Genesis, {blockchain_block:hash_block(LastBlock), blockchain_block:height(LastBlock)}),
     %% this should fail without all the supporting blocks
     blockchain:add_block(LastBlock, Chain),
     ?assertEqual({ok, 16}, blockchain:height(Chain)),


### PR DESCRIPTION
To prevent accidentally syncing past the assume valid block, and to make
it harder to provoke a SHA collision with a bad block, also provide the
height of the assumed valid block and use it for validation.