### PR TITLE
Add support for txn bundles

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -158,3 +158,10 @@
 -define(poc_witnesses_percent, poc_witnesses_percent).
 -define(poc_challengers_percent, poc_challengers_percent).
 -define(dc_percent, dc_percent).
+
+%%%
+%%% bundle txn vars
+%%%
+
+%% Only allow txns of this bundle length to appear on chain
+-define(max_bundle_size, max_bundle_size). %% default: 5

--- a/src/transactions/blockchain_txn.proto
+++ b/src/transactions/blockchain_txn.proto
@@ -41,5 +41,10 @@ message txn {
         txn_token_burn_v1 token_burn = 17;
         txn_dc_coinbase_v1 dc_coinbase = 18;
         txn_token_burn_exchange_rate_v1 token_burn_exchange_rate = 19;
+        txn_bundle_v1 bundle = 20;
     }
+}
+
+message txn_bundle_v1 {
+  repeated txn transactions = 1;
 }

--- a/src/transactions/v1/blockchain_txn_bundle_v1.erl
+++ b/src/transactions/v1/blockchain_txn_bundle_v1.erl
@@ -1,0 +1,122 @@
+%%%-------------------------------------------------------------------
+%% @doc
+%% == Blockchain Transaction Bundle ==
+%% @end
+%%%-------------------------------------------------------------------
+-module(blockchain_txn_bundle_v1).
+
+-behavior(blockchain_txn).
+
+-include("blockchain_vars.hrl").
+-include("pb/blockchain_txn_pb.hrl").
+
+-define(MAX_BUNDLE_SIZE, 5).
+
+-export([
+    new/1,
+    hash/1,
+    absorb/2,
+    sign/2,
+    fee/1,
+    txns/1,
+    is_valid/2
+]).
+
+-type txn_bundle() :: #blockchain_txn_bundle_v1_pb{}.
+-export_type([txn_bundle/0]).
+
+-spec new(Txns :: blockchain_txn:txns()) -> txn_bundle().
+new(Txns) ->
+    #blockchain_txn_bundle_v1_pb{transactions=Txns}.
+
+-spec hash(txn_bundle()) -> blockchain_txn:hash().
+hash(#blockchain_txn_bundle_v1_pb{transactions=Txns}) ->
+    TxnHashes = [blockchain_txn:hash(T) || T <- Txns],
+    crypto:hash(sha256, TxnHashes).
+
+-spec absorb(txn_bundle(), blockchain:blockchain()) -> ok | {error, any()}.
+absorb(#blockchain_txn_bundle_v1_pb{transactions=Txns}=_Txn, Chain) ->
+    lists:foreach(fun(T) -> blockchain_txn:absorb(T, Chain) end, Txns).
+
+-spec sign(txn_bundle(), libp2p_crypto:sig_fun()) -> txn_bundle().
+sign(TxnBundle, _SigFun) ->
+    %% bundles are not signed
+    TxnBundle.
+
+-spec fee(txn_bundle()) -> 0.
+fee(_TxnBundle) ->
+    0.
+
+-spec txns(txn_bundle()) -> blockchain_txn:txns().
+txns(#blockchain_txn_bundle_v1_pb{transactions=Txns}) ->
+    Txns.
+
+-spec is_valid(txn_bundle(), blockchain:blockchain()) -> ok | {error, any()}.
+is_valid(#blockchain_txn_bundle_v1_pb{transactions=Txns}=Txn, Chain) ->
+    TxnBundleSize = length(Txns),
+    MaxBundleSize = max_bundle_size(Chain),
+
+    %% check that the bundle contains minimum two transactions
+    case TxnBundleSize < 2 of
+        true ->
+            {error, {invalid_min_bundle_size, Txn}};
+        false ->
+            %% check that the bundle size doesn't exceed allowed max_bundle_size var
+            case TxnBundleSize > MaxBundleSize of
+                true ->
+                    {error, {bundle_size_exceeded, TxnBundleSize, MaxBundleSize}};
+                false ->
+                    %% check that there are no bundles in the bundle txn
+                    case lists:any(fun(T) ->
+                                           blockchain_txn:type(T) == blockchain_txn_bundle_v1
+                                   end,
+                                   Txns) of
+                        true ->
+                            {error, {invalid_bundleception, Txn}};
+                        false ->
+                            %% speculative check whether the bundle is valid
+                            case speculative_absorb(Txn, Chain) of
+                                [] ->
+                                    ok;
+                                List ->
+                                    {error, {invalid_bundled_txns, List}}
+                            end
+                    end
+            end
+    end.
+
+
+-spec max_bundle_size(blockchain:blockchain()) -> pos_integer().
+max_bundle_size(Chain) ->
+    Ledger = blockchain:ledger(Chain),
+    case blockchain:config(?max_bundle_size, Ledger) of
+        {error, _} ->
+            %% If max bundle size is not set, default to 5
+            ?MAX_BUNDLE_SIZE;
+        {ok, Size} ->
+            Size
+    end.
+
+-spec speculative_absorb(txn_bundle(), blockchain:blockchain()) -> [blockchain_txn:txns()].
+speculative_absorb(#blockchain_txn_bundle_v1_pb{transactions=Txns}, Chain0) ->
+    InitLedger = blockchain:ledger(Chain0),
+    %% Check that the bundled transactions can be absorbed in order in this ledger context
+    LedgerContext = blockchain_ledger_v1:new_context(InitLedger),
+    Chain = blockchain:ledger(LedgerContext, Chain0),
+    InvalidTxns = lists:foldl(fun(Txn, Acc) ->
+                                      case blockchain_txn:is_valid(Txn, Chain) of
+                                          {error, _} ->
+                                              [Txn | Acc];
+                                          ok ->
+                                              case blockchain_txn:absorb(Txn, Chain) of
+                                                  {error, _} ->
+                                                      [Txn | Acc];
+                                                  ok ->
+                                                      Acc
+                                              end
+                                      end
+                              end,
+                              [],
+                              Txns),
+    blockchain_ledger_v1:delete_context(LedgerContext),
+    InvalidTxns.

--- a/src/transactions/v1/blockchain_txn_rewards_v1.proto
+++ b/src/transactions/v1/blockchain_txn_rewards_v1.proto
@@ -13,11 +13,10 @@ message txn_reward_v1 {
     bytes gateway = 3;
     uint64 amount = 4;
     Type type = 5;
-    
 }
 
 message txn_rewards_v1 {
     uint64 start_epoch = 1;
     uint64 end_epoch = 2;
     repeated txn_reward_v1 rewards = 3;
-}   
+}

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -673,6 +673,10 @@ validate_var(?reward_version, Value) ->
             throw({error, {invalid_reward_version, Value}})
     end;
 
+%% bundle vars
+validate_var(?max_bundle_size, Value) ->
+    validate_int(Value, "max_bundle_size", 5, 100, false);
+
 validate_var(Var, Value) ->
     %% something we don't understand, crash
     invalid_var(Var, Value).


### PR DESCRIPTION
The goal here is to allow bundled txn support.

- The bundled transactions are first speculatively absorbed to check whether they are valid in the order they appear in the bundle.
- Introduce `max_bundle_size` chain var. Default: 5
