### PR TITLE
add direct context cache test, fix cache deletes

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -63,6 +63,7 @@
 %% not run their code later.
 -define(upgrades,
         [{<<"gateway_v2">>, fun upgrade_gateways_v2/1}]).
+%% NB: we need to keep this in sync with the filter in the fingerprints
 
 
 -type blocks() :: #{blockchain_block:hash() => blockchain_block:block()}.

--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -409,7 +409,8 @@ get_lower_and_upper_bounds(Secret, OnionKeyHash, Challenger, Ledger, Chain) ->
                                     lager:error("poc_receipts error get_block, last_challenge: ~p, reason: ~p", [LastChallenge, Reason]),
                                     Error3;
                                 {ok, Block1} ->
-                                    case blockchain:head_block(Chain) of
+                                    {ok, HH} = blockchain_ledger_v1:current_height(Ledger),
+                                    case blockchain:get_block(HH, Chain) of
                                         {error, _}=Error4 ->
                                             Error4;
                                         {ok, B} ->


### PR DESCRIPTION
this test should take care of most issues with lagging ledger determinism, but requires a lot of testing; we need to make sure whether or not the insert-witness change means we need to reset all the ledgers, and if so, if there's a way around it.