### PR TITLE
don't allow election info return of height 0 at genesis

### DIFF
--- a/src/blockchain_election.erl
+++ b/src/blockchain_election.erl
@@ -232,7 +232,11 @@ election_info(Ledger, Chain) ->
     {ok, Block} = blockchain:get_block(Height, Chain),
 
     %% get the election info
-    {Epoch, StartHeight} = blockchain_block_v1:election_info(Block),
+    {Epoch, StartHeight0} = blockchain_block_v1:election_info(Block),
+
+    %% genesis block thinks that the start height is 0, but it is
+    %% block 1, so force it.
+    StartHeight = max(1, StartHeight0),
 
     %% get the election txn
     {ok, StartBlock} = blockchain:get_block(StartHeight, Chain),


### PR DESCRIPTION
when we load the genesis block, we attempt to restore a consensus group, which leads to a crash because the genesis block erroneously has an election info start height of 0.  This PR forces the height to never go below 1, which will avoid the crash, even if the subsequent restore is nonsensical.

TODO (but maybe not in this PR):
 - fix nonsensical election info height in genesis blocks