### PR TITLE
Keep retrying assert location transactions

### DIFF
--- a/src/transactions/blockchain_txn_mgr.erl
+++ b/src/transactions/blockchain_txn_mgr.erl
@@ -239,7 +239,7 @@ rejected(Txn, Member, State=#state{txn_map=TxnMap, chain=Chain}) ->
             F = (N - 1) div 3,
             case length(lists:usort([Member|Rejections])) > F of
                 true ->
-                    %% Temporary patch to keep retrying assert location
+                    %% TODO XXX Temporary patch to keep retrying assert location
                     %% transactions while we make bundles work solid
                     case blockchain_txn:type(Txn) == blockchain_txn_assert_location_v1 of
                         false ->


### PR DESCRIPTION
Far from ideal, but it would make the on-boarding potentially suck less as we'll keep retrying assert location transactions, even after F+1 members have rejected them. This is temporary while we make txn bundles work solid enough.