### PR TITLE
Snapshot the ledger after the block is committed for the add_block event

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -542,16 +542,16 @@ add_block_(Block, Blockchain, Syncing) ->
                                                         lager:info("adding block ~p", [Height]),
                                                         ok = ?save_block(Block, Blockchain)
                                                     end,
-                                                    case blockchain_ledger_v1:new_snapshot(Ledger) of
+                                                    case blockchain_txn:absorb_and_commit(Block, Blockchain, BeforeCommit, Rescue) of
                                                         {error, Reason}=Error ->
-                                                            lager:error("Error creating snapshot, Reason: ~p", [Reason]),
+                                                            lager:error("Error absorbing transaction, Ignoring Hash: ~p, Reason: ~p", [blockchain_block:hash_block(Block), Reason]),
                                                             Error;
-                                                        {ok, NewLedger} ->
-                                                            case blockchain_txn:absorb_and_commit(Block, Blockchain, BeforeCommit, Rescue) of
+                                                        ok ->
+                                                            case blockchain_ledger_v1:new_snapshot(blockchain:ledger(Blockchain)) of
                                                                 {error, Reason}=Error ->
-                                                                    lager:error("Error absorbing transaction, Ignoring Hash: ~p, Reason: ~p", [blockchain_block:hash_block(Block), Reason]),
+                                                                    lager:error("Error creating snapshot, Reason: ~p", [Reason]),
                                                                     Error;
-                                                                ok ->
+                                                                {ok, NewLedger} ->
                                                                     lager:info("Notifying new block ~p", [Height]),
                                                                     ok = blockchain_worker:notify({add_block, Hash, Syncing, NewLedger})
                                                             end
@@ -641,21 +641,20 @@ absorb_temp_blocks([BlockHash|Chain], Blockchain, Syncing) ->
     {ok, Block} = get_temp_block(BlockHash, Blockchain),
     Height = blockchain_block:height(Block),
     Hash = blockchain_block:hash_block(Block),
-    Ledger = blockchain:ledger(Blockchain),
     BeforeCommit = fun() ->
                            lager:info("adding block ~p", [Height]),
                            ok = ?save_block(Block, Blockchain)
                    end,
-    case blockchain_ledger_v1:new_snapshot(Ledger) of
+    case blockchain_txn:unvalidated_absorb_and_commit(Block, Blockchain, BeforeCommit, blockchain_block:is_rescue_block(Block)) of
         {error, Reason}=Error ->
-            lager:error("Error creating snapshot, Reason: ~p", [Reason]),
+            lager:error("Error absorbing transaction, Ignoring Hash: ~p, Reason: ~p", [blockchain_block:hash_block(Block), Reason]),
             Error;
-        {ok, NewLedger} ->
-            case blockchain_txn:unvalidated_absorb_and_commit(Block, Blockchain, BeforeCommit, blockchain_block:is_rescue_block(Block)) of
+        ok ->
+            case blockchain_ledger_v1:new_snapshot(blockchain:ledger(Blockchain)) of
                 {error, Reason}=Error ->
-                    lager:error("Error absorbing transaction, Ignoring Hash: ~p, Reason: ~p", [blockchain_block:hash_block(Block), Reason]),
+                    lager:error("Error creating snapshot, Reason: ~p", [Reason]),
                     Error;
-                ok ->
+                {ok, NewLedger} ->
                     lager:info("Notifying new block ~p", [Height]),
                     ok = blockchain_worker:notify({add_block, Hash, Syncing, NewLedger}),
                     absorb_temp_blocks(Chain, Blockchain, Syncing)


### PR DESCRIPTION
When running the pocv4 test you can occasionally observe the poc receipts failing to validate *on the same node that generated them* when the transaction manager evaluates their validity before sending them. It turns out this seems to be because the wrong ledger was being attached to the add_block event. We were snapshotting the ledger before absorbing the block, not after. This snapshotted ledger is only used in blockchain-core/miner in the poc statem, but the poc_statem assumes that the ledger it's passed is for the block where its challenge is accepted. However, prior to this change the ledger was for the previous block.

If you run the pocv4 dist test on miner without this change, and run the test enough times, a grep like this:

```
grep "is_valid failed" _build/test/logs/**/console.log | grep receipt | grep -v not_found
```
Will occasionally return errors about receipts out of order, invalid paths, etc. This indicates the ledger used to generate the challenge and the one used to validate it are different. This change ensures they are the same and as a consequence these errors seem to disappear.

One remaining question is if the assumptions around which ledger is passed with the add block event exist in any other projects, grafana, API, etc. I know @vihu was having a terrible time using the ledger in the add_block in the API at one point, maybe this bug is the reason why?