### PR TITLE
use snapshots for ledger_at, when available

### DIFF
--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -211,8 +211,6 @@ is_valid(Txn, Chain) ->
                                                                     PoCAbsorbedAtBlockHash  = blockchain_block:hash_block(Block1),
                                                                     Entropy = <<Secret/binary, PoCAbsorbedAtBlockHash/binary, Challenger/binary>>,
                                                                     {ok, OldLedger} = blockchain:ledger_at(blockchain_block:height(Block1), Chain),
-                                                                    lager:error([{poc_id, HexPOCID}], "Ledger ~p fingerprints ~p", [blockchain_ledger_v1:current_height(OldLedger),
-                                                                                                                                    blockchain_ledger_v1:fingerprint(OldLedger, true)]),
                                                                     Path = case blockchain:config(?poc_version, OldLedger) of
                                                                                {ok, V} when V > 3 ->
                                                                                    ActiveGateways = blockchain_ledger_v1:active_gateways(OldLedger),


### PR DESCRIPTION
    Since we already create ledger snapshots on block absorb, cache them in
    an ETS table so that if we need to compute a ledger at that height
    later, we have it cached. Snapshots older than the lagging ledger will
    be deleted from the cache and be garbage collected as normal. This
    provides a very sigificant speed increase when syncing blocks or
    when the consensus group is validating proposed transactions.

    In addition remove a log message from poc receipt validation that was
    accidentally merged.
