### PR TITLE
Support for separate absorbed predicate function

### DIFF
--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -22,7 +22,7 @@
     spend/3, spend/4,
     payment_txn/5, payment_txn/6,
     submit_txn/1, submit_txn/2,
-    create_htlc_txn/6,
+    create_htlc_txn/7,
     redeem_htlc_txn/3,
     peer_height/3,
     notify/1,
@@ -163,9 +163,9 @@ payment_txn(SigFun, PubkeyBin, Recipient, Amount, Fee, Nonce) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec create_htlc_txn(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), binary(), non_neg_integer(), non_neg_integer(), non_neg_integer()) -> ok.
-create_htlc_txn(Payee, PubkeyBin, Hashlock, Timelock, Amount, Fee) ->
-    gen_server:cast(?SERVER, {create_htlc_txn, Payee, PubkeyBin, Hashlock, Timelock, Amount, Fee}).
+-spec create_htlc_txn(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), binary(), non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()) -> ok.
+create_htlc_txn(Payee, PubkeyBin, Hashlock, Timelock, Amount, Fee, Nonce) ->
+    gen_server:cast(?SERVER, {create_htlc_txn, Payee, PubkeyBin, Hashlock, Timelock, Amount, Fee, Nonce}).
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -430,9 +430,9 @@ handle_cast({payment_txn, SigFun, PubkeyBin, Recipient, Amount, Fee, Nonce}, #st
             ok = send_txn(SignedPaymentTxn)
     end,
     {noreply, State};
-handle_cast({create_htlc_txn, Payee, PubkeyBin, Hashlock, Timelock, Amount, Fee}, #state{swarm=Swarm}=State) ->
+handle_cast({create_htlc_txn, Payee, PubkeyBin, Hashlock, Timelock, Amount, Fee, Nonce}, #state{swarm=Swarm}=State) ->
     Payer = libp2p_swarm:pubkey_bin(Swarm),
-    CreateTxn = blockchain_txn_create_htlc_v1:new(Payer, Payee, PubkeyBin, Hashlock, Timelock, Amount, Fee),
+    CreateTxn = blockchain_txn_create_htlc_v1:new(Payer, Payee, PubkeyBin, Hashlock, Timelock, Amount, Fee, Nonce),
     {ok, _PubKey, SigFun, _ECDHFun} = libp2p_swarm:keys(Swarm),
     SignedCreateHTLCTxn = blockchain_txn_create_htlc_v1:sign(CreateTxn, SigFun),
     ok = send_txn(SignedCreateHTLCTxn),

--- a/src/cli/blockchain_cli_ledger.erl
+++ b/src/cli/blockchain_cli_ledger.erl
@@ -153,7 +153,8 @@ ledger_create_htlc_helper(Flags, Address) ->
     Hashlock = blockchain_utils:hex_to_bin(list_to_binary(clean(proplists:get_value(hashlock, Flags)))),
     Timelock = list_to_integer(clean(proplists:get_value(timelock, Flags))),
     Fee = list_to_integer(clean(proplists:get_value(fee, Flags))),
-    blockchain_worker:create_htlc_txn(Payee, Address, Hashlock, Timelock, Amount, Fee).
+    Nonce = list_to_integer(clean(proplists:get_value(nonce, Flags))),
+    blockchain_worker:create_htlc_txn(Payee, Address, Hashlock, Timelock, Amount, Fee, Nonce).
 
 %%--------------------------------------------------------------------
 %% ledger redeem

--- a/src/ledger/v1/blockchain_ledger_htlc_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_htlc_v1.erl
@@ -6,7 +6,7 @@
 -module(blockchain_ledger_htlc_v1).
 
 -export([
-    new/0, new/5,
+    new/0, new/6,
     nonce/1, nonce/2,
     payer/1, payer/2,
     payee/1, payee/2,
@@ -42,12 +42,13 @@ new() ->
     #htlc_v1{}.
 
 -spec new(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), non_neg_integer(),
-          binary(), non_neg_integer()) -> htlc().
-new(Payer, Payee, Balance, Hashlock, Timelock) when Balance /= undefined ->
+          non_neg_integer(),binary(), non_neg_integer()) -> htlc().
+new(Payer, Payee, Balance, Nonce, Hashlock, Timelock) when Balance /= undefined ->
     #htlc_v1{
         payer=Payer,
         payee=Payee,
         balance=Balance,
+        nonce=Nonce,
         hashlock=Hashlock,
         timelock=Timelock
     }.
@@ -194,7 +195,7 @@ new_test() ->
         hashlock= <<"hashlock">>,
         timelock=13
     },
-    ?assertEqual(HTLC1, new(<<"payer">>, <<"payee">>, 12, <<"hashlock">>, 13)).
+    ?assertEqual(HTLC1, new(<<"payer">>, <<"payee">>, 12, 0, <<"hashlock">>, 13)).
 
 nonce_test() ->
     HTLC = new(),

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -439,8 +439,8 @@ absorbed(Txn, Chain) ->
     case erlang:function_exported(Type, absorbed, 2) of
         true ->
             try Type:absorbed(Txn, Chain) of
-                true -> true;
-                false -> false
+                Res ->
+                    Res
             catch
                 _What:Why:Stack ->
                     lager:warning("crash during absorbed: ~p ~p", [Why, Stack]),

--- a/src/transactions/v1/blockchain_txn_coinbase_v1.erl
+++ b/src/transactions/v1/blockchain_txn_coinbase_v1.erl
@@ -19,8 +19,7 @@
     is_valid/2,
     absorb/2,
     sign/2,
-    print/1,
-    absorbed/2
+    print/1
 ]).
 
 -ifdef(TEST).
@@ -121,17 +120,6 @@ print(undefined) ->
 print(#blockchain_txn_coinbase_v1_pb{payee=Payee, amount=Amount}) ->
     io_lib:format("txn_coinbase: payee: ~p, amount: ~p",
                   [?TO_B58(Payee), Amount]).
-
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
--spec absorbed(txn_coinbase(), blockchain:blockchain()) -> true | false.
-absorbed(_Txn, _Chain) ->
-    %% impossible to determine whether this type of transaction has already been absorbed
-    %% so we return false in all cases
-    %% have to rely upon is_valid/2
-    false.
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_coinbase_v1.erl
+++ b/src/transactions/v1/blockchain_txn_coinbase_v1.erl
@@ -19,7 +19,8 @@
     is_valid/2,
     absorb/2,
     sign/2,
-    print/1
+    print/1,
+    absorbed/2
 ]).
 
 -ifdef(TEST).
@@ -120,6 +121,17 @@ print(undefined) ->
 print(#blockchain_txn_coinbase_v1_pb{payee=Payee, amount=Amount}) ->
     io_lib:format("txn_coinbase: payee: ~p, amount: ~p",
                   [?TO_B58(Payee), Amount]).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec absorbed(txn_coinbase(), blockchain:blockchain()) -> true | false.
+absorbed(_Txn, _Chain) ->
+    %% impossible to determine whether this type of transaction has already been absorbed
+    %% so we return false in all cases
+    %% have to rely upon is_valid/2
+    false.
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_consensus_group_v1.erl
+++ b/src/transactions/v1/blockchain_txn_consensus_group_v1.erl
@@ -20,6 +20,7 @@
     fee/1,
     is_valid/2,
     absorb/2,
+    absorbed/2,
     print/1
 ]).
 
@@ -204,6 +205,7 @@ absorb(Txn, Chain) ->
             Err
     end.
 
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -219,6 +221,21 @@ print(#blockchain_txn_consensus_group_v1_pb{height = Height,
                    Delay,
                    lists:map(fun blockchain_utils:addr2name/1, Members),
                    erlang:phash2(Proof)]).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec absorbed(txn_consensus_group(), blockchain:blockchain()) -> true | false.
+absorbed(Txn, Chain) ->
+    Ledger = blockchain:ledger(Chain),
+    TxnHeight = ?MODULE:height(Txn),
+    TxnMembers = ?MODULE:members(Txn),
+    {ok, CurLedgerMembers} = blockchain_ledger_v1:consensus_members(Ledger),
+    {ok, CurHeight} = blockchain_ledger_v1:current_height(Ledger),
+    {ok, ElectionHeight} = blockchain_ledger_v1:election_height(Ledger),
+    (CurHeight > 0 andalso ElectionHeight > TxnHeight) orelse
+        lists:sort(CurLedgerMembers) =:= lists:sort(TxnMembers).
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions

--- a/src/transactions/v1/blockchain_txn_create_htlc_v1.erl
+++ b/src/transactions/v1/blockchain_txn_create_htlc_v1.erl
@@ -14,7 +14,7 @@
 -include_lib("helium_proto/include/blockchain_txn_create_htlc_v1_pb.hrl").
 
 -export([
-    new/7,
+    new/8,
     hash/1,
     payer/1,
     payee/1,
@@ -23,11 +23,13 @@
     timelock/1,
     amount/1,
     fee/1,
+    nonce/1,
     signature/1,
     sign/2,
     is_valid/2,
     absorb/2,
-    print/1
+    print/1,
+    absorbed/2
 ]).
 
 -ifdef(TEST).
@@ -42,8 +44,8 @@
 %% @end
 %%--------------------------------------------------------------------
 -spec new(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), binary(),
-          non_neg_integer(), non_neg_integer(), non_neg_integer()) -> txn_create_htlc().
-new(Payer, Payee, Address, Hashlock, Timelock, Amount, Fee) ->
+          non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()) -> txn_create_htlc().
+new(Payer, Payee, Address, Hashlock, Timelock, Amount, Fee, Nonce) ->
     #blockchain_txn_create_htlc_v1_pb{
         payer=Payer,
         payee=Payee,
@@ -52,6 +54,7 @@ new(Payer, Payee, Address, Hashlock, Timelock, Amount, Fee) ->
         timelock=Timelock,
         amount=Amount,
         fee=Fee,
+        nonce=Nonce,
         signature = <<>>
     }.
 
@@ -126,6 +129,13 @@ fee(Txn) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+-spec nonce(txn_create_htlc()) -> non_neg_integer().
+nonce(Txn) ->
+    Txn#blockchain_txn_create_htlc_v1_pb.nonce.
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
 -spec signature(txn_create_htlc()) -> binary().
 signature(Txn) ->
     Txn#blockchain_txn_create_htlc_v1_pb.signature.
@@ -190,11 +200,11 @@ absorb(Txn, Chain) ->
     Fee = ?MODULE:fee(Txn),
     Payer = ?MODULE:payer(Txn),
     Payee = ?MODULE:payee(Txn),
+    Nonce = ?MODULE:nonce(Txn),
     case blockchain_ledger_v1:find_entry(Payer, Ledger) of
         {error, _}=Error ->
             Error;
-        {ok, Entry} ->
-            Nonce = blockchain_ledger_entry_v1:nonce(Entry) + 1,
+        {ok, _Entry} ->
             case blockchain_ledger_v1:debit_fee(Payer, Fee, Ledger) of
                 {error, _Reason}=Error ->
                     Error;
@@ -208,6 +218,7 @@ absorb(Txn, Chain) ->
                                                             Payer,
                                                             Payee,
                                                             Amount,
+                                                            Nonce,
                                                             ?MODULE:hashlock(Txn),
                                                             ?MODULE:timelock(Txn),
                                                             Ledger)
@@ -227,6 +238,24 @@ print(#blockchain_txn_create_htlc_v1_pb{
     io_lib:format("type=create_htlc payer=~p payee=~p, address=~p, hashlock=~p, timelock=~p, amount=~p, fee=~p, signature=~p",
                   [?TO_B58(Payer), ?TO_B58(Payee), Address, Hashlock, Timelock, Amount, Fee, Sig]).
 
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec absorbed(txn_create_htlc(), blockchain:blockchain()) -> true | false.
+absorbed(Txn, Chain)->
+    Ledger = blockchain:ledger(Chain),
+    Address = ?MODULE:address(Txn),
+    case blockchain_ledger_v1:find_htlc(Address, Ledger) of
+        {error, _} ->
+            false;
+        {ok, Entry} ->
+            TxnNonce = ?MODULE:nonce(Txn),
+            %% if the ledger nonce is > than the txn nonce, then assume we have seen this txn before
+            blockchain_ledger_htlc_v1:nonce(Entry) >= TxnNonce
+    end.
+
+
 %% ------------------------------------------------------------------
 %% EUNIT Tests
 %% ------------------------------------------------------------------
@@ -241,45 +270,46 @@ new_test() ->
         timelock=0,
         amount=666,
         fee=1,
-        signature= <<>>
+        signature= <<>>,
+        nonce=1
     },
-    ?assertEqual(Tx, new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1)).
+    ?assertEqual(Tx, new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1, 1)).
 
 payer_test() ->
-    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
+    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1, 1),
     ?assertEqual(<<"payer">>, payer(Tx)).
 
 payee_test() ->
-    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
+    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1, 1),
     ?assertEqual(<<"payee">>, payee(Tx)).
 
 address_test() ->
-    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
+    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1, 1),
     ?assertEqual(<<"address">>, address(Tx)).
 
 amount_test() ->
-    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
+    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1, 1),
     ?assertEqual(666, amount(Tx)).
 
 fee_test() ->
-    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
+    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1, 1),
     ?assertEqual(1, fee(Tx)).
 
 hashlock_test() ->
-    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
+    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1, 1),
     ?assertEqual(<<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, hashlock(Tx)).
 
 timelock_test() ->
-    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
+    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1, 1),
     ?assertEqual(0, timelock(Tx)).
 
 signature_test() ->
-    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
+    Tx = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1, 1),
     ?assertEqual(<<>>, signature(Tx)).
 
 sign_test() ->
     #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    Tx0 = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1),
+    Tx0 = new(<<"payer">>, <<"payee">>, <<"address">>, <<"c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2">>, 0, 666, 1, 1),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     Tx1 = sign(Tx0, SigFun),
     Sig1 = signature(Tx1),

--- a/src/transactions/v1/blockchain_txn_dc_coinbase_v1.erl
+++ b/src/transactions/v1/blockchain_txn_dc_coinbase_v1.erl
@@ -19,8 +19,7 @@
     is_valid/2,
     absorb/2,
     sign/2,
-    print/1,
-    absorbed/2
+    print/1
 ]).
 
 -ifdef(TEST).
@@ -123,17 +122,6 @@ print(#blockchain_txn_dc_coinbase_v1_pb{
          payee=Payee, amount=Amount}) ->
     io_lib:format("type=dc_coinbase payee=~p, amount=~p",
                   [?TO_B58(Payee), Amount]).
-
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
--spec absorbed(txn_dc_coinbase(), blockchain:blockchain()) -> true | false.
-absorbed(_Txn, _Chain) ->
-    %% impossible to determine whether this type of transaction has already been absorbed
-    %% so we return false in all cases
-    %% atm this function is just here to highlight the lack of data to determine absorbed/2
-    false.
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_dc_coinbase_v1.erl
+++ b/src/transactions/v1/blockchain_txn_dc_coinbase_v1.erl
@@ -19,7 +19,8 @@
     is_valid/2,
     absorb/2,
     sign/2,
-    print/1
+    print/1,
+    absorbed/2
 ]).
 
 -ifdef(TEST).
@@ -122,6 +123,17 @@ print(#blockchain_txn_dc_coinbase_v1_pb{
          payee=Payee, amount=Amount}) ->
     io_lib:format("type=dc_coinbase payee=~p, amount=~p",
                   [?TO_B58(Payee), Amount]).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec absorbed(txn_dc_coinbase(), blockchain:blockchain()) -> true | false.
+absorbed(_Txn, _Chain) ->
+    %% impossible to determine whether this type of transaction has already been absorbed
+    %% so we return false in all cases
+    %% atm this function is just here to highlight the lack of data to determine absorbed/2
+    false.
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_gen_gateway_v1.erl
+++ b/src/transactions/v1/blockchain_txn_gen_gateway_v1.erl
@@ -21,7 +21,8 @@
     fee/1,
     is_valid/2,
     absorb/2,
-    print/1
+    print/1,
+    absorbed/2
 ]).
 
 -ifdef(TEST).
@@ -153,6 +154,22 @@ print(#blockchain_txn_gen_gateway_v1_pb{
          location=L, nonce=Nonce}) ->
     io_lib:format("type=genesis_gateway gateway=~p, owner=~p, location=~p, nonce=~p",
                   [?TO_ANIMAL_NAME(Gateway), ?TO_B58(Owner), L, Nonce]).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec absorbed(txn_genesis_gateway(), blockchain:blockchain()) -> true | false.
+absorbed(Txn, Chain)->
+    Ledger = blockchain:ledger(Chain),
+    GatewayAddress = ?MODULE:gateway(Txn),
+    case blockchain_ledger_v1:find_gateway_info(GatewayAddress, Ledger) of
+        {ok, GW} ->
+            TxnNonce = ?MODULE:nonce(Txn),
+            blockchain_ledger_gateway_v2:nonce(GW) >= TxnNonce;
+        _ ->
+            false
+    end.
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_oui_v1.erl
+++ b/src/transactions/v1/blockchain_txn_oui_v1.erl
@@ -28,7 +28,8 @@
     is_valid/2,
     absorb/2,
     calculate_staking_fee/1,
-    print/1
+    print/1,
+    absorbed/2
 ]).
 
 -ifdef(TEST).
@@ -224,7 +225,7 @@ is_valid(Txn, Chain) ->
                             ExpectedStakingFee = ?MODULE:calculate_staking_fee(Chain),
                             case ExpectedStakingFee == StakingFee of
                                 false ->
-                                    {error, {wrong_stacking_fee, ExpectedStakingFee, StakingFee}}; 
+                                    {error, {wrong_stacking_fee, ExpectedStakingFee, StakingFee}};
                                 true ->
                                     Fee = ?MODULE:fee(Txn),
                                     Owner = ?MODULE:owner(Txn),
@@ -262,6 +263,22 @@ absorb(Txn, Chain) ->
             Addresses = ?MODULE:addresses(Txn),
             OUI = ?MODULE:oui(Txn),
             blockchain_ledger_v1:add_oui(Owner, Addresses, OUI, Ledger)
+    end.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec absorbed(txn_oui(), blockchain:blockchain()) -> true | false.
+absorbed(Txn, Chain) ->
+    Ledger = blockchain:ledger(Chain),
+    OUI = ?MODULE:oui(Txn),
+    Owner = ?MODULE:owner(Txn),
+    case blockchain_ledger_v1:find_ouis(Owner, Ledger) of
+        {ok, OUIs} ->
+            lists:member(OUI, OUIs);
+        _ ->
+            false
     end.
 
 %%--------------------------------------------------------------------

--- a/src/transactions/v1/blockchain_txn_payment_v1.erl
+++ b/src/transactions/v1/blockchain_txn_payment_v1.erl
@@ -22,7 +22,8 @@
     sign/2,
     is_valid/2,
     absorb/2,
-    print/1
+    print/1,
+    absorbed/2
 ]).
 
 -ifdef(TEST).
@@ -193,6 +194,22 @@ print(#blockchain_txn_payment_v1_pb{payer=Payer, payee=Recipient, amount=Amount,
                                     fee=Fee, nonce=Nonce, signature = S }) ->
     io_lib:format("type=payment, payer=~p, payee=~p, amount=~p, fee=~p, nonce=~p, signature=~p",
                   [?TO_B58(Payer), ?TO_B58(Recipient), Amount, Fee, Nonce, S]).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec absorbed(txn_payment(), blockchain:blockchain()) -> true | false.
+absorbed(Txn, Chain)->
+    Ledger = blockchain:ledger(Chain),
+    Payer = ?MODULE:payer(Txn),
+    case blockchain_ledger_v1:find_entry(Payer, Ledger) of
+        {error, _} ->
+            false;
+        {ok, Entry} ->
+            TxnNonce = ?MODULE:nonce(Txn),
+            blockchain_ledger_entry_v1:nonce(Entry) >= TxnNonce
+    end.
 
 
 %% ------------------------------------------------------------------

--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -22,6 +22,7 @@
     sign/2,
     is_valid/2,
     absorb/2,
+    absorbed/2,
     create_secret_hash/2,
     connections/1,
     deltas/1, deltas/2,
@@ -194,6 +195,7 @@ is_valid(Txn, Chain) ->
                                                                         blockchain_txn_poc_request_v1:onion_key_hash(T) == POCOnionKeyHash
                                                                     end
                                                             end,
+                                                            %% get list of txns and see if any meet conditions above
                                                             case lists:any(Condition, blockchain_block:transactions(Block1)) of
                                                                 false ->
                                                                     {error, onion_key_hash_mismatch};
@@ -596,6 +598,24 @@ absorb(Txn, Chain) ->
               lager:error([{poc_id, HexPOCID}], "poc receipt calculation failed: ~p ~p ~p", [What, Why, Stacktrace]),
               {error, state_missing}
     end.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+ -spec absorbed(txn_poc_receipts(), blockchain:blockchain()) -> true | false.
+absorbed(Txn, Chain) ->
+    Ledger = blockchain:ledger(Chain),
+    LastOnionKeyHash = ?MODULE:onion_key_hash(Txn),
+    case blockchain_ledger_v1:find_poc(LastOnionKeyHash, Ledger) of
+        {error, _} -> true;
+        _ -> false
+    end.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
 
 -spec get_lower_and_upper_bounds(Secret :: binary(),
                                  OnionKeyHash :: binary(),

--- a/src/transactions/v1/blockchain_txn_poc_request_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_request_v1.erl
@@ -25,8 +25,7 @@
     sign/2,
     is_valid/2,
     absorb/2,
-    print/1,
-    absorbed/2
+    print/1
 ]).
 
 -ifdef(TEST).
@@ -143,30 +142,38 @@ is_valid(Txn, Chain) ->
     PubKey = libp2p_crypto:bin_to_pubkey(Challenger),
     BaseTxn = Txn#blockchain_txn_poc_request_v1_pb{signature = <<>>},
     EncodedTxn = blockchain_txn_poc_request_v1_pb:encode_msg(BaseTxn),
-    case blockchain_ledger_v1:find_gateway_info(Challenger, Ledger) of
-        {error, _Reason}=Error ->
-            Error;
-        {ok, Info} ->
-            case blockchain_ledger_gateway_v2:location(Info) of
-                undefined ->
-                    {error, no_gateway_location};
-                _Location ->
-                    BlockHash = ?MODULE:block_hash(Txn),
-                    case blockchain:get_block(BlockHash, Chain) of
-                        {error, _} ->
-                            {error, poc_request_invalid_blockhash};
-                        {ok, _Block} ->
-                            Fee = ?MODULE:fee(Txn),
-                            Owner = blockchain_ledger_gateway_v2:owner_address(Info),
-                            case blockchain_ledger_v1:check_dc_balance(Owner, Fee, Ledger) of
-                                {error, _} = Error ->
-                                    {error, Error};
-                                ok ->
-                                    case libp2p_crypto:verify(EncodedTxn, ChallengerSignature, PubKey) of
-                                        false ->
-                                            {error, bad_signature};
-                                        true ->
-                                            ok
+    case libp2p_crypto:verify(EncodedTxn, ChallengerSignature, PubKey) of
+        false ->
+            {error, bad_signature};
+        true ->
+            case blockchain_ledger_v1:find_gateway_info(Challenger, Ledger) of
+                {error, _Reason}=Error ->
+                    Error;
+                {ok, Info} ->
+                    case blockchain_ledger_gateway_v2:location(Info) of
+                        undefined ->
+                            {error, no_gateway_location};
+                        _Location ->
+                            {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
+                            LastChallenge = blockchain_ledger_gateway_v2:last_poc_challenge(Info),
+                            PoCInterval = blockchain_utils:challenge_interval(Ledger),
+                            case LastChallenge == undefined orelse LastChallenge =< (Height+1  - PoCInterval) of
+                                false ->
+                                    {error, too_many_challenges};
+                                true ->
+                                    BlockHash = ?MODULE:block_hash(Txn),
+                                    case blockchain:get_block(BlockHash, Chain) of
+                                        {error, _}=Error ->
+                                            Error;
+                                        {ok, Block1} ->
+                                            case (blockchain_block:height(Block1) + PoCInterval) > (Height+1) of
+                                                false ->
+                                                    {error, replaying_request};
+                                                true ->
+                                                    Fee = ?MODULE:fee(Txn),
+                                                    Owner = blockchain_ledger_gateway_v2:owner_address(Info),
+                                                    blockchain_ledger_v1:check_dc_balance(Owner, Fee, Ledger)
+                                            end
                                     end
                             end
                     end
@@ -209,43 +216,6 @@ print(#blockchain_txn_poc_request_v1_pb{challenger=Challenger, secret_hash=Secre
     %% XXX: Should we really print the secret hash in a log???
     io_lib:format("type=poc_request challenger=~p, secret_hash=~p, onion_key_hash=~p, block_hash=~p, fee=~p, signature=~p, version=~p",
                   [?TO_ANIMAL_NAME(Challenger), SecretHash, ?TO_B58(OnionKeyHash), BlockHash, Fee, Sig, Version]).
-
-
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
-%% TODO: maybe just having all of this in is_valid be better, save on dup reads from the ledger ?
--spec absorbed(txn_poc_request(), blockchain:blockchain()) -> true | false.
-absorbed(Txn, Chain) ->
-    Ledger = blockchain:ledger(Chain),
-    BlockHash = ?MODULE:block_hash(Txn),
-    Challenger = ?MODULE:challenger(Txn),
-    case blockchain_ledger_v1:find_gateway_info(Challenger, Ledger) of
-        {error, _} ->
-            %% no GW found, so this is a  malformed request
-            %% however malformedness is handled in is_valid, so we ignore at this point
-            false;
-        {ok, Info} ->
-            {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
-            LastChallenge = blockchain_ledger_gateway_v2:last_poc_challenge(Info),
-            PoCInterval = blockchain_utils:challenge_interval(Ledger),
-            case LastChallenge == undefined orelse LastChallenge =< (Height+1  - PoCInterval) of
-                false ->
-                    %% too many challenges
-                    true;
-                true ->
-                    BlockHash = ?MODULE:block_hash(Txn),
-                    case blockchain:get_block(BlockHash, Chain) of
-                        {error, _} ->
-                            %% challenge is pinned to an unknown block so its a malformed request
-                            %% however malformedness is handled in is_valid, so we ignore at this point
-                            false;
-                        {ok, Block} ->
-                            not ((blockchain_block:height(Block) + PoCInterval) > (Height+1))
-                    end
-            end
-    end.
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_security_exchange_v1.erl
+++ b/src/transactions/v1/blockchain_txn_security_exchange_v1.erl
@@ -22,7 +22,8 @@
     sign/2,
     is_valid/2,
     absorb/2,
-    print/1
+    print/1,
+    absorbed/2
 ]).
 
 -ifdef(TEST).
@@ -185,6 +186,21 @@ absorb(Txn, Chain) ->
             FeeError
     end.
 
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec absorbed(txn_security_exchange(), blockchain:blockchain()) -> true | false.
+absorbed(Txn, Chain)->
+    Ledger = blockchain:ledger(Chain),
+    Payer = ?MODULE:payer(Txn),
+    case blockchain_ledger_v1:find_security_entry(Payer, Ledger) of
+        {error, _}=Error ->
+            Error;
+        {ok, Entry} ->
+            TxnNonce = ?MODULE:nonce(Txn),
+            blockchain_ledger_security_entry_v1:nonce(Entry) >= TxnNonce
+    end.
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_token_burn_v1.erl
+++ b/src/transactions/v1/blockchain_txn_token_burn_v1.erl
@@ -24,7 +24,8 @@
     sign/2,
     is_valid/2,
     absorb/2,
-    print/1
+    print/1,
+    absorbed/2
 ]).
 
 -ifdef(TEST).
@@ -196,6 +197,22 @@ absorb(Txn, Chain) ->
                     Credits = Amount * Rate,
                     blockchain_ledger_v1:credit_dc(Payer, Credits, Ledger)
             end
+    end.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec absorbed(txn_token_burn(), blockchain:blockchain()) -> true | false.
+absorbed(Txn, Chain)->
+    Ledger = blockchain:ledger(Chain),
+    Payer = ?MODULE:payer(Txn),
+    case blockchain_ledger_v1:find_entry(Payer, Ledger) of
+        {error, _} ->
+            false;
+        {ok, Entry} ->
+            TxnNonce = ?MODULE:nonce(Txn),
+            blockchain_ledger_entry_v1:nonce(Entry) >= TxnNonce
     end.
 
  %% ------------------------------------------------------------------

--- a/test/blockchain_absorbed_SUITE.erl
+++ b/test/blockchain_absorbed_SUITE.erl
@@ -1,0 +1,693 @@
+-module(blockchain_absorbed_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include("blockchain_vars.hrl").
+
+-export([all/0, init_per_testcase/2, end_per_testcase/2]).
+
+-define(TEST_LOCATION, 631210968840687103).
+
+-export([
+    absorbed_txn_add_gateway_and_location_v1_test/1,
+    absorbed_txn_payment_v1_test/1,
+    absorbed_txn_htlc_v1_test/1,
+    absorbed_txn_oui_v1_test/1,
+    absorbed_txn_poc_request_v1/1,
+    absorbed_txn_poc_receipts_v1/1,
+    absorbed_txn_routing_v1_test/1,
+    absorbed_txn_security_exchange_v1_test/1,
+    absorbed_txn_token_burn_v1_test/1,
+    absorbed_txn_vars_v1_test/1
+]).
+
+%%--------------------------------------------------------------------
+%% COMMON TEST CALLBACK FUNCTIONS
+%%--------------------------------------------------------------------
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%%   Running tests for this suite
+%% @end
+%%--------------------------------------------------------------------
+all() ->
+    [
+        absorbed_txn_add_gateway_and_location_v1_test,
+        absorbed_txn_payment_v1_test,
+        absorbed_txn_htlc_v1_test,
+        absorbed_txn_oui_v1_test,
+        absorbed_txn_poc_request_v1,
+        absorbed_txn_poc_receipts_v1,
+        absorbed_txn_routing_v1_test,
+        absorbed_txn_security_exchange_v1_test,
+        absorbed_txn_token_burn_v1_test,
+        absorbed_txn_vars_v1_test
+
+    ].
+
+%%--------------------------------------------------------------------
+%% TEST CASE SETUP
+%%--------------------------------------------------------------------
+
+init_per_testcase(TestCase, Config) ->
+    BaseDir = "data/test_SUITE/" ++ erlang:atom_to_list(TestCase),
+    Balance = 5000,
+    {ok, Sup, {PrivKey, PubKey}, Opts} = test_utils:init(BaseDir),
+    {ok, GenesisMembers, ConsensusMembers, Keys} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
+
+    Chain = blockchain_worker:blockchain(),
+    Swarm = blockchain_swarm:swarm(),
+    N = length(ConsensusMembers),
+
+    % Check ledger to make sure everyone has the right balance
+    Ledger = blockchain:ledger(Chain),
+    Entries = blockchain_ledger_v1:entries(Ledger),
+    _ = lists:foreach(fun(Entry) ->
+        Balance = blockchain_ledger_entry_v1:balance(Entry),
+        0 = blockchain_ledger_entry_v1:nonce(Entry)
+    end, maps:values(Entries)),
+
+    [
+        {basedir, BaseDir},
+        {balance, Balance},
+        {sup, Sup},
+        {pubkey, PubKey},
+        {privkey, PrivKey},
+        {opts, Opts},
+        {chain, Chain},
+        {swarm, Swarm},
+        {n, N},
+        {consensus_members, ConsensusMembers},
+        {genesis_members, GenesisMembers},
+        Keys
+        | Config
+    ].
+
+%%--------------------------------------------------------------------
+%% TEST CASE TEARDOWN
+%%--------------------------------------------------------------------
+end_per_testcase(_, Config) ->
+    Sup = proplists:get_value(sup, Config),
+    % Make sure blockchain saved on file = in memory
+    case erlang:is_process_alive(Sup) of
+        true ->
+            true = erlang:exit(Sup, normal),
+            ok = test_utils:wait_until(fun() -> false =:= erlang:is_process_alive(Sup) end);
+        false ->
+            ok
+    end,
+    ok.
+
+%%--------------------------------------------------------------------
+%% TEST CASES
+%%--------------------------------------------------------------------
+
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+absorbed_txn_add_gateway_and_location_v1_test(Config) ->
+    ConsensusMembers = proplists:get_value(consensus_members, Config),
+    PubKey = proplists:get_value(pubkey, Config),
+    PrivKey = proplists:get_value(privkey, Config),
+    _Owner = libp2p_crypto:pubkey_to_bin(PubKey),
+    Chain = proplists:get_value(chain, Config),
+    Swarm = proplists:get_value(swarm, Config),
+    _Balance = proplists:get_value(balance, Config),
+    OwnerSigFun = libp2p_crypto:mk_sig_fun(PrivKey),
+
+    #{public := GatewayPubKey, secret := GatewayPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
+    Gateway = libp2p_crypto:pubkey_to_bin(GatewayPubKey),
+    GatewaySigFun = libp2p_crypto:mk_sig_fun(GatewayPrivKey),
+    OwnerSigFun = libp2p_crypto:mk_sig_fun(PrivKey),
+
+    Rate = 1000000,
+    {Priv, _} = proplists:get_value(master_key, Config),
+    Vars = #{token_burn_exchange_rate => Rate},
+    VarTxn = blockchain_txn_vars_v1:new(Vars, 3),
+    Proof = blockchain_txn_vars_v1:create_proof(Priv, VarTxn),
+    VarTxn1 = blockchain_txn_vars_v1:proof(VarTxn, Proof),
+    Block1 = test_utils:create_block(ConsensusMembers, [VarTxn1]),
+    _ = blockchain_gossip_handler:add_block(Swarm, Block1, Chain, self()),
+
+    %% We need a gateway added for a couple of tests, so pushed out to a reusable function
+    p_create_and_test_gateway(Config, Gateway, GatewaySigFun, OwnerSigFun, Rate).
+
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+absorbed_txn_htlc_v1_test(Config) ->
+    BaseDir = proplists:get_value(basedir, Config),
+    ConsensusMembers = proplists:get_value(consensus_members, Config),
+    BaseDir = proplists:get_value(basedir, Config),
+    Chain = proplists:get_value(chain, Config),
+    Swarm = proplists:get_value(swarm, Config),
+
+    %% create the htlc txn
+    {Payer, {_, _, PayerSigFun}} = lists:last(ConsensusMembers),
+    % Generate a random address
+    HTLCAddress = crypto:strong_rand_bytes(32),
+    % Create a Hashlock
+    Hashlock = crypto:hash(sha256, <<"sharkfed">>),
+
+    Recipient = blockchain_swarm:pubkey_bin(),
+    Txn1 = blockchain_txn_create_htlc_v1:new(Payer, Recipient, HTLCAddress, Hashlock, 3, 2500, 0, 1),
+    SignedTxn1 = blockchain_txn_create_htlc_v1:sign(Txn1, PayerSigFun),
+
+    %% before we add the block verify it validates
+    ?assertEqual(ok, blockchain_txn_create_htlc_v1:is_valid(SignedTxn1, Chain)),
+
+    %% confirm the txn has not yet been absorbed
+    ?assertEqual(false, blockchain_txn_create_htlc_v1:absorbed(SignedTxn1, Chain)),
+
+    Block1 = test_utils:create_block(ConsensusMembers, [SignedTxn1]),
+    _ = blockchain_gossip_handler:add_block(Swarm, Block1, Chain, self()),
+
+    ok = blockchain_ct_utils:wait_until(fun() -> {ok, 2} =:= blockchain:height(Chain) end),
+
+    %% then check absorbed again on same block, it should return true
+    ?assertEqual(true, blockchain_txn_create_htlc_v1:absorbed(Txn1, Chain)),
+    %% but it should continue to pass validation
+    ?assertEqual(ok, blockchain_txn_create_htlc_v1:is_valid(SignedTxn1, Chain)).
+
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+absorbed_txn_oui_v1_test(Config) ->
+    BaseDir = proplists:get_value(basedir, Config),
+    ConsensusMembers = proplists:get_value(consensus_members, Config),
+    BaseDir = proplists:get_value(basedir, Config),
+    Chain = proplists:get_value(chain, Config),
+    Swarm = proplists:get_value(swarm, Config),
+    _Ledger = blockchain:ledger(Chain),
+
+    %% create the txn
+    [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
+    SigFun = libp2p_crypto:mk_sig_fun(PayerPrivKey),
+
+    meck:new(blockchain_txn_oui_v1, [no_link, passthrough]),
+    meck:expect(blockchain_txn_oui_v1, is_valid, fun(_, _) -> ok end),
+
+    OUI1 = 1,
+    Addresses = [erlang:list_to_binary(libp2p_swarm:p2p_address(Swarm))],
+    Txn1 = blockchain_txn_oui_v1:new(Payer, Addresses, OUI1, 0, 0),
+    SignedTxn1 = blockchain_txn_oui_v1:sign(Txn1, SigFun),
+
+    %% before we add the block verify it validates
+    ?assertEqual(ok, blockchain_txn_oui_v1:is_valid(Txn1, Chain)),
+    %% confirm the txn has not previously been absorbed
+    ?assertEqual(false, blockchain_txn_oui_v1:absorbed(Txn1, Chain)),
+
+    %% create and add the block
+    Block1 = test_utils:create_block(ConsensusMembers, [SignedTxn1]),
+    _ = blockchain_gossip_handler:add_block(Swarm, Block1, Chain, self()),
+
+    ok = blockchain_ct_utils:wait_until(fun() -> {ok, 2} =:= blockchain:height(Chain) end),
+
+    %% then check absorbed again on same block, it should return true
+    ?assertEqual(true, blockchain_txn_oui_v1:absorbed(Txn1, Chain)),
+    %% but it should continue to pass validation
+    ?assertEqual(ok, blockchain_txn_oui_v1:is_valid(Txn1, Chain)),
+
+    meck:unload(blockchain_txn_oui_v1),
+    ok.
+
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+absorbed_txn_payment_v1_test(Config) ->
+    BaseDir = proplists:get_value(basedir, Config),
+    ConsensusMembers = proplists:get_value(consensus_members, Config),
+    BaseDir = proplists:get_value(basedir, Config),
+    Chain = proplists:get_value(chain, Config),
+    Swarm = proplists:get_value(swarm, Config),
+
+    %% create the payment txn
+    {Payer, {_, _, PayerSigFun}} = lists:last(ConsensusMembers),
+    Recipient = blockchain_swarm:pubkey_bin(),
+    Txn1 = blockchain_txn_payment_v1:new(Payer, Recipient, 2500, 0, 1),
+    SignedTxn1 = blockchain_txn_payment_v1:sign(Txn1, PayerSigFun),
+
+    %% before we add the block verify it validates
+    ?assertEqual(ok, blockchain_txn_payment_v1:is_valid(SignedTxn1, Chain)),
+    %% confirm the txn has not yet been absorbed
+    ?assertEqual(false, blockchain_txn_payment_v1:absorbed(Txn1, Chain)),
+
+    Block1 = test_utils:create_block(ConsensusMembers, [SignedTxn1]),
+    _ = blockchain_gossip_handler:add_block(Swarm, Block1, Chain, self()),
+
+    ok = blockchain_ct_utils:wait_until(fun() -> {ok, 2} =:= blockchain:height(Chain) end),
+
+    %% then check absorbed again on same block, it should return true
+    ?assertEqual(true, blockchain_txn_payment_v1:absorbed(Txn1, Chain)),
+    %% but it should continue to pass validation
+    ?assertEqual(ok, blockchain_txn_payment_v1:is_valid(SignedTxn1, Chain)).
+
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+absorbed_txn_poc_request_v1(Config) ->
+    ConsensusMembers = proplists:get_value(consensus_members, Config),
+    PubKey = proplists:get_value(pubkey, Config),
+    PrivKey = proplists:get_value(privkey, Config),
+    _Owner = libp2p_crypto:pubkey_to_bin(PubKey),
+    Chain = proplists:get_value(chain, Config),
+    Swarm = proplists:get_value(swarm, Config),
+    _Balance = proplists:get_value(balance, Config),
+    OwnerSigFun = libp2p_crypto:mk_sig_fun(PrivKey),
+
+    #{public := GatewayPubKey, secret := GatewayPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
+    Gateway = libp2p_crypto:pubkey_to_bin(GatewayPubKey),
+    GatewaySigFun = libp2p_crypto:mk_sig_fun(GatewayPrivKey),
+    OwnerSigFun = libp2p_crypto:mk_sig_fun(PrivKey),
+
+    Rate = 1000000,
+    {Priv, _} = proplists:get_value(master_key, Config),
+    Vars = #{token_burn_exchange_rate => Rate},
+    Txn1 = blockchain_txn_vars_v1:new(Vars, 3),
+    Proof = blockchain_txn_vars_v1:create_proof(Priv, Txn1),
+    Txn2 = blockchain_txn_vars_v1:proof(Txn1, Proof),
+    Block1 = test_utils:create_block(ConsensusMembers, [Txn2]),
+    _ = blockchain_gossip_handler:add_block(Swarm, Block1, Chain, self()),
+
+    %% add the gateway ( NOTE: this will generate 25 blocks )
+    p_create_and_test_gateway(Config, Gateway, GatewaySigFun, OwnerSigFun, Rate),
+
+    % Create the PoC challenge request txn
+    Keys0 = libp2p_crypto:generate_keys(ecc_compact),
+    Secret0 = libp2p_crypto:keys_to_bin(Keys0),
+    #{public := OnionCompactKey0} = Keys0,
+    SecretHash0 = crypto:hash(sha256, Secret0),
+    OnionKeyHash0 = crypto:hash(sha256, libp2p_crypto:pubkey_to_bin(OnionCompactKey0)),
+    Txn3 = blockchain_txn_poc_request_v1:new(Gateway, SecretHash0, OnionKeyHash0, blockchain_block:hash_block(Block1), 1),
+    SignedTxn3 = blockchain_txn_poc_request_v1:sign(Txn3, GatewaySigFun),
+
+
+    %% before we add the block verify it validates
+    ?assertEqual(ok, blockchain_txn_poc_request_v1:is_valid(SignedTxn3, Chain)),
+    %% confirm the txn has not yet been absorbed
+    ?assertEqual(false, blockchain_txn_poc_request_v1:absorbed(Txn3, Chain)),
+
+    Block26 = test_utils:create_block(ConsensusMembers, [SignedTxn3]),
+    _ = blockchain_gossip_handler:add_block(Swarm, Block26, Chain, self()),
+    ok = blockchain_ct_utils:wait_until(fun() -> {ok, 26} =:= blockchain:height(Chain) end),
+
+    %% then check absorbed again on same block, it should return true
+    ?assertEqual(true, blockchain_txn_poc_request_v1:absorbed(Txn3, Chain)),
+    %% but it should continue to pass validation
+    ?assertEqual(ok, blockchain_txn_poc_request_v1:is_valid(SignedTxn3, Chain)).
+
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+absorbed_txn_poc_receipts_v1(Config) ->
+    ConsensusMembers = proplists:get_value(consensus_members, Config),
+    PubKey = proplists:get_value(pubkey, Config),
+    PrivKey = proplists:get_value(privkey, Config),
+    _Owner = libp2p_crypto:pubkey_to_bin(PubKey),
+    Chain = proplists:get_value(chain, Config),
+    Swarm = proplists:get_value(swarm, Config),
+    _Balance = proplists:get_value(balance, Config),
+    OwnerSigFun = libp2p_crypto:mk_sig_fun(PrivKey),
+    Ledger = blockchain:ledger(Chain),
+
+    #{public := GatewayPubKey, secret := GatewayPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
+    Gateway = libp2p_crypto:pubkey_to_bin(GatewayPubKey),
+    GatewaySigFun = libp2p_crypto:mk_sig_fun(GatewayPrivKey),
+    OwnerSigFun = libp2p_crypto:mk_sig_fun(PrivKey),
+
+    Rate = 1000000,
+    {Priv, _} = proplists:get_value(master_key, Config),
+    Vars = #{token_burn_exchange_rate => Rate},
+    Txn1 = blockchain_txn_vars_v1:new(Vars, 3),
+    Proof = blockchain_txn_vars_v1:create_proof(Priv, Txn1),
+    Txn2 = blockchain_txn_vars_v1:proof(Txn1, Proof),
+    Block1 = test_utils:create_block(ConsensusMembers, [Txn2]),
+    _ = blockchain_gossip_handler:add_block(Swarm, Block1, Chain, self()),
+
+    %% add the gateway ( NOTE: this will generate 25 blocks )
+    p_create_and_test_gateway(Config, Gateway, GatewaySigFun, OwnerSigFun, Rate),
+
+    % Create the PoC challenge request txn
+    Keys0 = libp2p_crypto:generate_keys(ecc_compact),
+    Secret0 = libp2p_crypto:keys_to_bin(Keys0),
+    #{public := OnionCompactKey0} = Keys0,
+    SecretHash0 = crypto:hash(sha256, Secret0),
+    OnionKeyHash0 = crypto:hash(sha256, libp2p_crypto:pubkey_to_bin(OnionCompactKey0)),
+    Txn3 = blockchain_txn_poc_request_v1:new(Gateway, SecretHash0, OnionKeyHash0, blockchain_block:hash_block(Block1), 1),
+    SignedTxn3 = blockchain_txn_poc_request_v1:sign(Txn3, GatewaySigFun),
+    Block26 = test_utils:create_block(ConsensusMembers, [SignedTxn3]),
+    _ = blockchain_gossip_handler:add_block(Swarm, Block26, Chain, self()),
+    ok = blockchain_ct_utils:wait_until(fun() -> {ok, 26} =:= blockchain:height(Chain) end),
+
+    Ledger = blockchain:ledger(Chain),
+    {ok, HeadHash3} = blockchain:head_hash(Chain),
+    ?assertEqual(blockchain_block:hash_block(Block26), HeadHash3),
+    ?assertEqual({ok, Block26}, blockchain:get_block(HeadHash3, Chain)),
+    % Check that the last_poc_challenge block height got recorded in GwInfo
+    {ok, GwInfo2} = blockchain_ledger_v1:find_gateway_info(Gateway, Ledger),
+    ?assertEqual(26, blockchain_ledger_gateway_v2:last_poc_challenge(GwInfo2)),
+    ?assertEqual(OnionKeyHash0, blockchain_ledger_gateway_v2:last_poc_onion_key_hash(GwInfo2)),
+
+    % Check that the PoC info
+    {ok, [PoC]} = blockchain_ledger_v1:find_poc(OnionKeyHash0, Ledger),
+    ?assertEqual(SecretHash0, blockchain_ledger_poc_v2:secret_hash(PoC)),
+    ?assertEqual(OnionKeyHash0, blockchain_ledger_poc_v2:onion_key_hash(PoC)),
+    ?assertEqual(Gateway, blockchain_ledger_poc_v2:challenger(PoC)),
+
+    meck:new(blockchain_txn_poc_receipts_v1, [passthrough]),
+    meck:expect(blockchain_txn_poc_receipts_v1, is_valid, fun(_Txn, _Chain) -> ok end),
+
+    Txn4 = blockchain_txn_poc_receipts_v1:new(Gateway, Secret0, OnionKeyHash0, []),
+    SignedTxn4 = blockchain_txn_poc_receipts_v1:sign(Txn4, GatewaySigFun),
+    Block27 = test_utils:create_block(ConsensusMembers, [SignedTxn4]),
+
+    %% before we add the block verify it validates
+    ?assertEqual(ok, blockchain_txn_poc_receipts_v1:is_valid(Txn4, Chain)),
+    %% confirm the txn has not yet been absorbed
+    ?assertEqual(false, blockchain_txn_poc_receipts_v1:absorbed(Txn4, Chain)),
+
+    _ = blockchain_gossip_handler:add_block(Swarm, Block27, Chain, self()),
+    ok = blockchain_ct_utils:wait_until(fun() -> {ok, 27} =:= blockchain:height(Chain) end),
+
+    %% then check absorbed again on same block, it should return true
+    ?assertEqual(true, blockchain_txn_poc_receipts_v1:absorbed(Txn4, Chain)),
+    %% but it should continue to pass validation
+    ?assertEqual(ok, blockchain_txn_poc_receipts_v1:is_valid(Txn4, Chain)),
+
+    meck:unload(blockchain_txn_poc_receipts_v1),
+    ok.
+
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+absorbed_txn_routing_v1_test(Config) ->
+    BaseDir = proplists:get_value(basedir, Config),
+    ConsensusMembers = proplists:get_value(consensus_members, Config),
+    BaseDir = proplists:get_value(basedir, Config),
+    Chain = proplists:get_value(chain, Config),
+    Swarm = proplists:get_value(swarm, Config),
+    Ledger = blockchain:ledger(Chain),
+
+    [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
+    SigFun = libp2p_crypto:mk_sig_fun(PayerPrivKey),
+
+    meck:new(blockchain_txn_oui_v1, [no_link, passthrough]),
+    meck:expect(blockchain_txn_oui_v1, is_valid, fun(_, _) -> ok end),
+
+    OUI1 = 1,
+    Addresses0 = [erlang:list_to_binary(libp2p_swarm:p2p_address(Swarm))],
+    Txn1 = blockchain_txn_oui_v1:new(Payer, Addresses0, OUI1, 0, 0),
+    SignedTxn1 = blockchain_txn_oui_v1:sign(Txn1, SigFun),
+
+    ?assertEqual({error, not_found}, blockchain_ledger_v1:find_routing(OUI1, Ledger)),
+
+    Block0 = test_utils:create_block(ConsensusMembers, [SignedTxn1]),
+    _ = blockchain_gossip_handler:add_block(Swarm, Block0, Chain, self()),
+
+    ok = test_utils:wait_until(fun() -> {ok, 2} == blockchain:height(Chain) end),
+
+    Routing0 = blockchain_ledger_routing_v1:new(OUI1, Payer, Addresses0, 0),
+    ?assertEqual({ok, Routing0}, blockchain_ledger_v1:find_routing(OUI1, Ledger)),
+
+    %% create the routing txn
+    Addresses1 = [<<"/p2p/random">>],
+    Txn2 = blockchain_txn_routing_v1:new(OUI1, Payer, Addresses1, 0, 1),
+    SignedTxn2 = blockchain_txn_routing_v1:sign(Txn2, SigFun),
+
+    %% before we add the block verify it validates
+    ?assertEqual(ok, blockchain_txn_routing_v1:is_valid(SignedTxn2, Chain)),
+    %% confirm the txn has not yet been absorbed
+    ?assertEqual(false, blockchain_txn_routing_v1:absorbed(Txn2, Chain)),
+
+    Block1 = test_utils:create_block(ConsensusMembers, [SignedTxn2]),
+    _ = blockchain_gossip_handler:add_block(Swarm, Block1, Chain, self()),
+
+    ok = test_utils:wait_until(fun() -> {ok, 3} == blockchain:height(Chain) end),
+
+    %% then check absorbed again on same block, it should return true
+    ?assertEqual(true, blockchain_txn_routing_v1:absorbed(Txn2, Chain)),
+    %% but it should continue to pass validation
+    ?assertEqual(ok, blockchain_txn_routing_v1:is_valid(SignedTxn2, Chain)),
+
+    meck:unload(blockchain_txn_oui_v1),
+    ok.
+
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+absorbed_txn_security_exchange_v1_test(Config) ->
+    BaseDir = proplists:get_value(basedir, Config),
+    ConsensusMembers = proplists:get_value(consensus_members, Config),
+    BaseDir = proplists:get_value(basedir, Config),
+    Chain = proplists:get_value(chain, Config),
+    Swarm = proplists:get_value(swarm, Config),
+
+    %% create the security exchange txn
+    [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
+    Recipient = blockchain_swarm:pubkey_bin(),
+    Txn1 = blockchain_txn_security_exchange_v1:new(Payer, Recipient, 2500, 0, 1),
+    SigFun = libp2p_crypto:mk_sig_fun(PayerPrivKey),
+    SignedTxn1 = blockchain_txn_security_exchange_v1:sign(Txn1, SigFun),
+
+    %% before we add the block verify it validates
+    ?assertEqual(ok, blockchain_txn_security_exchange_v1:is_valid(SignedTxn1, Chain)),
+    %% confirm the txn has not yet been absorbed
+    ?assertEqual(false, blockchain_txn_security_exchange_v1:absorbed(Txn1, Chain)),
+
+    Block = test_utils:create_block(ConsensusMembers, [SignedTxn1]),
+    _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+
+    ok = blockchain_ct_utils:wait_until(fun() -> {ok, 2} =:= blockchain:height(Chain) end),
+
+    %% then check absorbed again on same block, it should return true
+    ?assertEqual(true, blockchain_txn_security_exchange_v1:absorbed(Txn1, Chain)),
+    %% but it should continue to pass validation
+    ?assertEqual(ok, blockchain_txn_security_exchange_v1:is_valid(SignedTxn1, Chain)).
+
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+absorbed_txn_token_burn_v1_test(Config) ->
+    BaseDir = proplists:get_value(basedir, Config),
+    ConsensusMembers = proplists:get_value(consensus_members, Config),
+    BaseDir = proplists:get_value(basedir, Config),
+    Chain = proplists:get_value(chain, Config),
+    Swarm = proplists:get_value(swarm, Config),
+
+    [_, {Payer, {_, PayerPrivKey, _}} |_] = ConsensusMembers,
+    PayerSigFun = libp2p_crypto:mk_sig_fun(PayerPrivKey),
+
+    % need to first add exchange rate to ledger
+    Rate = 1000000,
+    {Priv, _} = proplists:get_value(master_key, Config),
+    Vars = #{token_burn_exchange_rate => Rate},
+
+    Txn1 = blockchain_txn_vars_v1:new(Vars, 3),
+    Proof = blockchain_txn_vars_v1:create_proof(Priv, Txn1),
+    ProofedTxn1 = blockchain_txn_vars_v1:proof(Txn1, Proof),
+    Block2 = test_utils:create_block(ConsensusMembers, [ProofedTxn1]),
+    _ = blockchain_gossip_handler:add_block(Swarm, Block2, Chain, self()),
+
+    ok = blockchain_ct_utils:wait_until(fun() -> {ok, 2} =:= blockchain:height(Chain) end),
+
+    _Blocks = lists:map(
+               fun(_) ->
+                       Block = test_utils:create_block(ConsensusMembers, []),
+                       _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+                       Block
+               end,
+               lists:seq(1, 20)),
+
+    ok = blockchain_ct_utils:wait_until(fun() -> {ok, 22} =:= blockchain:height(Chain) end),
+
+    %% create the token burn txn
+    Txn2 = blockchain_txn_token_burn_v1:new(Payer, 10, 1),
+    SignedTxn2 = blockchain_txn_token_burn_v1:sign(Txn2, PayerSigFun),
+
+    %% before we add the block verify it validates
+    ?assertEqual(ok, blockchain_txn_token_burn_v1:is_valid(SignedTxn2, Chain)),
+    %% confirm the txn has not yet been absorbed
+    ?assertEqual(false, blockchain_txn_token_burn_v1:absorbed(Txn2, Chain)),
+
+    Block23 = test_utils:create_block(ConsensusMembers, [SignedTxn2]),
+    _ = blockchain_gossip_handler:add_block(Swarm, Block23, Chain, self()),
+
+    ok = blockchain_ct_utils:wait_until(fun() -> {ok, 23} =:= blockchain:height(Chain) end),
+
+    %% then check absorbed again on same block, it should return true
+    ?assertEqual(true, blockchain_txn_token_burn_v1:absorbed(Txn2, Chain)),
+    %% but it should continue to pass validation
+    ?assertEqual(ok, blockchain_txn_token_burn_v1:is_valid(SignedTxn2, Chain)).
+
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+absorbed_txn_vars_v1_test(Config) ->
+    BaseDir = proplists:get_value(basedir, Config),
+    ConsensusMembers = proplists:get_value(consensus_members, Config),
+    BaseDir = proplists:get_value(basedir, Config),
+    Chain = proplists:get_value(chain, Config),
+    Swarm = proplists:get_value(swarm, Config),
+    {Priv, _} = proplists:get_value(master_key, Config),
+
+    %% create the vars exchange txn
+    Vars = #{poc_version => 2},
+    Txn1 = blockchain_txn_vars_v1:new(Vars, 3),
+    Proof = blockchain_txn_vars_v1:create_proof(Priv, Txn1),
+    ProofedTxn1 = blockchain_txn_vars_v1:proof(Txn1, Proof),
+
+    %% before we add the block verify it validates
+    ?assertEqual(ok, blockchain_txn_vars_v1:is_valid(ProofedTxn1, Chain)),
+    %% confirm the txn has not yet been absorbed
+    ?assertEqual(false, blockchain_txn_vars_v1:absorbed(Txn1, Chain)),
+
+    InitBlock = test_utils:create_block(ConsensusMembers, [ProofedTxn1]),
+    _ = blockchain_gossip_handler:add_block(Swarm, InitBlock, Chain, self()),
+
+    ok = blockchain_ct_utils:wait_until(fun() -> {ok, 2} =:= blockchain:height(Chain) end),
+
+    %% then check absorbed again on same block, it should return true
+    ?assertEqual(true, blockchain_txn_vars_v1:absorbed(Txn1, Chain)),
+    %% but it should continue to pass validation
+    ?assertEqual(ok, blockchain_txn_vars_v1:is_valid(ProofedTxn1, Chain)).
+
+
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+
+p_create_and_test_gateway(Config, Gateway, GatewaySigFun, OwnerSigFun, Rate)->
+    BaseDir = proplists:get_value(basedir, Config),
+    ConsensusMembers = proplists:get_value(consensus_members, Config),
+    GenesisMembers = proplists:get_value(genesis_members, Config),
+    BaseDir = proplists:get_value(basedir, Config),
+    Chain = proplists:get_value(chain, Config),
+    Swarm = proplists:get_value(swarm, Config),
+
+    PubKey = proplists:get_value(pubkey, Config),
+    _PrivKey = proplists:get_value(privkey, Config),
+    Owner = libp2p_crypto:pubkey_to_bin(PubKey),
+    Balance = proplists:get_value(balance, Config),
+
+    Ledger = blockchain:ledger(Chain),
+
+    lists:foreach(
+        fun(_) ->
+                Block = test_utils:create_block(ConsensusMembers, []),
+                _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self())
+        end,
+        lists:seq(1, 20)
+    ),
+    ?assertEqual({ok, Rate}, blockchain_ledger_v1:config(?token_burn_exchange_rate, Ledger)),
+
+
+    BurnTx0 = blockchain_txn_token_burn_v1:new(Owner, 10, 1),
+    SignedBurnTx0 = blockchain_txn_token_burn_v1:sign(BurnTx0, OwnerSigFun),
+
+    %% before we add the block verify it validates
+    ?assertEqual(ok, blockchain_txn_token_burn_v1:is_valid(SignedBurnTx0, Chain)),
+
+    %% confirm the txn has not yet been absorbed
+    ?assertEqual(false, blockchain_txn_token_burn_v1:absorbed(BurnTx0, Chain)),
+
+    Block23 = test_utils:create_block(ConsensusMembers, [SignedBurnTx0]),
+    _ = blockchain_gossip_handler:add_block(Swarm, Block23, Chain, self()),
+
+    ok = blockchain_ct_utils:wait_until(fun() -> {ok, 23} =:= blockchain:height(Chain) end),
+
+    {ok, NewEntry0} = blockchain_ledger_v1:find_entry(Owner, Ledger),
+    ?assertEqual(Balance - 10, blockchain_ledger_entry_v1:balance(NewEntry0)),
+
+    {ok, DCEntry0} = blockchain_ledger_v1:find_dc_entry(Owner, Ledger),
+    ?assertEqual(10*Rate, blockchain_ledger_data_credits_entry_v1:balance(DCEntry0)),
+
+    %% Create the gateway
+
+    %% a GW will have been generated as part of the test init
+    %% so to test absorbed/2 for the gen_gateway txn, we will just create a new txn
+    %% with a used nonce and confirm it returns true to indicate already absorbed
+    {Addr, _} = hd(GenesisMembers),
+    InitialGatewayTxn = blockchain_txn_gen_gateway_v1:new(Addr, Addr, ?TEST_LOCATION, 0),
+    %% confirm the txn HAS been absorbed
+    ?assertEqual(true, blockchain_txn_gen_gateway_v1:absorbed(InitialGatewayTxn, Chain)),
+    %% and as we are not in genesis block validation will fail
+    ?assertEqual({error,not_in_genesis_block}, blockchain_txn_gen_gateway_v1:is_valid(InitialGatewayTxn, Chain)),
+
+
+    Tx24 = blockchain_txn_add_gateway_v1:new(Owner, Gateway, 1, 1),
+    SignedTx24 = blockchain_txn_add_gateway_v1:sign(Tx24, OwnerSigFun),
+    SignedTx24Request = blockchain_txn_add_gateway_v1:sign_request(SignedTx24, GatewaySigFun),
+
+    %% before we add the block verify it validates
+    ?assertEqual(ok, blockchain_txn_add_gateway_v1:is_valid(SignedTx24Request, Chain)),
+    %% confirm the txn has not yet been absorbed
+    ?assertEqual(false, blockchain_txn_add_gateway_v1:absorbed(Tx24, Chain)),
+
+    %% creat the block with the txn
+    Block24 = test_utils:create_block(ConsensusMembers, [SignedTx24Request]),
+    _ = blockchain_gossip_handler:add_block(Swarm, Block24, Chain, self()),
+
+    %% confirm the head block and the heights
+    ok = blockchain_ct_utils:wait_until(fun() -> {ok, 24} =:= blockchain:height(Chain) end),
+
+    %% then check absorbed again on same block, it should return true
+    ?assertEqual(true, blockchain_txn_add_gateway_v1:absorbed(Tx24, Chain)),
+    %% but it should continue to pass validation
+    ?assertEqual(ok, blockchain_txn_add_gateway_v1:is_valid(SignedTx24Request, Chain)),
+
+    % Check that the Gateway is there
+    {ok, GwInfo} = blockchain_ledger_v1:find_gateway_info(Gateway, blockchain:ledger(Chain)),
+    ?assertEqual(Owner, blockchain_ledger_gateway_v2:owner_address(GwInfo)),
+
+    % Assert the Gateways location
+    Tx25 = blockchain_txn_assert_location_v1:new(Gateway, Owner, ?TEST_LOCATION, 1, 1, 1),
+    Tx25SignedRequest = blockchain_txn_assert_location_v1:sign_request(Tx25, GatewaySigFun),
+    Tx25Signed = blockchain_txn_assert_location_v1:sign(Tx25SignedRequest, OwnerSigFun),
+
+    %% before we add the block verify it validates
+    ?assertEqual(ok, blockchain_txn_assert_location_v1:is_valid(Tx25Signed, Chain)),
+    %% confirm the txn has not yet been absorbed
+    ?assertEqual(false, blockchain_txn_assert_location_v1:absorbed(Tx25, Chain)),
+
+    Block25 = test_utils:create_block(ConsensusMembers, [Tx25Signed]),
+    ok = blockchain_gossip_handler:add_block(Swarm, Block25, Chain, self()),
+    timer:sleep(500),
+
+    ok = blockchain_ct_utils:wait_until(fun() -> {ok, 25} =:= blockchain:height(Chain) end),
+
+    %% then check absorbed again on same block, it should return true
+    ?assertEqual(true, blockchain_txn_assert_location_v1:absorbed(Tx25, Chain)),
+    %% but it should continue to pass validation
+    ?assertEqual(ok, blockchain_txn_assert_location_v1:is_valid(Tx25Signed, Chain)).

--- a/test/blockchain_ct_utils.erl
+++ b/test/blockchain_ct_utils.erl
@@ -20,8 +20,26 @@
          end_per_testcase/2,
          create_vars/0, create_vars/1,
          raw_vars/1,
-         init_base_dir_config/3
+         init_base_dir_config/3,
+         generate_keys/1,
+         new_random_key/1
         ]).
+
+generate_keys(N) ->
+    lists:foldl(
+        fun(_, Acc) ->
+            {PrivKey, PubKey} = new_random_key(ecc_compact),
+            SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
+            [{libp2p_crypto:pubkey_to_bin(PubKey), {PubKey, PrivKey, SigFun}}|Acc]
+        end,
+        [],
+        lists:seq(1, N)
+    ).
+
+new_random_key(Curve) ->
+    #{secret := PrivKey, public := PubKey} = libp2p_crypto:generate_keys(Curve),
+    {PrivKey, PubKey}.
+
 
 pmap(F, L) ->
     Parent = self(),

--- a/test/blockchain_simple_SUITE.erl
+++ b/test/blockchain_simple_SUITE.erl
@@ -300,7 +300,7 @@ htlc_payee_redeem_test(Config) ->
     HTLCAddress = crypto:strong_rand_bytes(32),
     % Create a Hashlock
     Hashlock = crypto:hash(sha256, <<"sharkfed">>),
-    CreateTx = blockchain_txn_create_htlc_v1:new(Payer, Payee, HTLCAddress, Hashlock, 3, 2500, 0),
+    CreateTx = blockchain_txn_create_htlc_v1:new(Payer, Payee, HTLCAddress, Hashlock, 3, 2500, 0, 1),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     SignedCreateTx = blockchain_txn_create_htlc_v1:sign(CreateTx, SigFun),
     % send some money to the payee so they have enough to pay the fee for redeeming
@@ -365,7 +365,7 @@ htlc_payer_redeem_test(Config) ->
     HTLCAddress = crypto:strong_rand_bytes(32),
     % Create a Hashlock
     Hashlock = crypto:hash(sha256, <<"sharkfed">>),
-    CreateTx = blockchain_txn_create_htlc_v1:new(Payer, Payer, HTLCAddress, Hashlock, 3, 2500, 0),
+    CreateTx = blockchain_txn_create_htlc_v1:new(Payer, Payer, HTLCAddress, Hashlock, 3, 2500, 0, 1),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     SignedCreateTx = blockchain_txn_create_htlc_v1:sign(CreateTx, SigFun),
     Block = test_utils:create_block(ConsensusMembers, [SignedCreateTx]),


### PR DESCRIPTION
NOTE:  this is dependant upon proto PR: https://github.com/helium/proto/pull/19

Adds support for a new txn specific absorbed/2 function via which we can identify if a txn has already been seen before ( ie a replay ) and preventing a double spend.  It is called as part of and before is_valid and thus if we have seen a txn previously we will avoid having to run the more computationally heavy validations.

absorbed/2 functions have been added to those txns for which I have been able to identify some means to detect potential replays/double spends ( it is included for the heavy POC receipt txns ).

Where a txn specifies a nonce, I have used the approach of checking that.  Where a nonce is not present I have looked at other approaches based on the data available and the actions performed by absorb/2 or is_valid/2.  

If a txn module exports absorbed/2 then it will be called from blockchain_txn:is_valid/2.

Some minor modification have been made to a number of is_valid/2 implementations.  Mostly these are to remove checks/validations which are now in absorbed/2 but more importantly to allow is_valid/2 to be deterministic and to always return the same result for the same txn irrespective of whether the txn has been absorbed or not.  

Further Considerations 
--------------------
This PR is predominantly concerned with being able to determine if a txn is a replay.  It does not attempt to rewrite the is_valid/2 functions.  There is scope for improving the existing is_valid/2 implementations and breaking them out into well-formedness checks and rules based checks ( ie is the member field populated vs is the election too early or too late ).  As this PR has taken so long as it is and touches a fair amount of code and has sufficient value in itself, i think its best to tackle the wider is_valid/2 improvements in a follow up task/PR.  

Txns which have absorbed/2 support
--------------------
- blockchain_txn_add_gateway_v1
- blockchain_txn_assert_location_v1
- blockchain_txn_create_htlc_v1
- blockchain_txn_gen_gateway_v1
- blockchain_txn_oui_v1
- blockchain_txn_payment_v1
- blockchain_txn_poc_receipts_v1
- blockchain_txn_routing_v1
- blockchain_txn_security_exchange_v1
- blockchain_txn_token_burn_v1
- blockchain_txn_vars_v1


txns which do not have absorbed/2 support as no clear means to facilitate 
--------------------
- blockchain_txn_poc_request_v1
- txn_coinbase 
- txn_dc_coinbase ( only passes is_valid/2 if height at genesis block )
- txn_redeem_htlc
- txn_security_coinbase ( only passes is_valid/2 if height at genesis block )
- txn_token_burn_exchange_rate

txns which do not have absorbed/2 support and likely wont ever need it
--------------------
- blockchain_txn_bundle_v1
- blockchain_txn_reward_v1 ( doesnt have an absorb function, why ? )

