### PR TITLE
Optimize poc v4 some more

### DIFF
--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -101,15 +101,10 @@ pmap(F, L) ->
         true ->
             lists:map(F, L);
         false ->
-            %% TODO: incorporate this somehow
-            %% Workers = 8,
-            %% Count = 21,
-            %% Min = floor(Count/Workers),
-            %% Rem = Count rem Workers,
-            %% lists:duplicate(Rem, Min+1)++ lists:duplicate(Workers - Rem, Min).
-            %% [3,3,3,3,3,2,2,2]
-            Ct = ceil(Len/Width),
-            OL = [lists:sublist(L, 1 + Ct * N, Ct) || N <- lists:seq(0, Width - 1)],
+            Min = floor(Len/Width),
+            Rem = Len rem Width,
+            Lengths = lists:duplicate(Rem, Min+1)++ lists:duplicate(Width - Rem, Min),
+            OL = partition_list(L, Lengths, []),
             St = lists:foldl(
                    fun([], N) ->
                            N;
@@ -126,6 +121,12 @@ pmap(F, L) ->
             {_, L3} = lists:unzip(lists:keysort(1, L2)),
             lists:flatten(L3)
     end.
+
+partition_list([], [], Acc) ->
+    Acc;
+partition_list(L, [H | T], Acc) ->
+    {Take, Rest} = lists:split(H, L),
+    partition_list(Rest, T, [Take | Acc]).
 
 addr2name(Addr) ->
     B58Addr = libp2p_crypto:bin_to_b58(Addr),

--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -104,7 +104,9 @@ pmap(F, L) ->
             Ct = ceil(Len/Width),
             OL = [lists:sublist(L, 1 + Ct * N, Ct) || N <- lists:seq(0, Width - 1)],
             lists:foldl(
-              fun(IL, N) ->
+              fun([], N) ->
+                      N;
+                 (IL, N) ->
                       spawn(
                         fun() ->
                                 Parent ! {pmap, N, lists:map(F, IL)}


### PR DESCRIPTION
The edge weighting probability function is causing a lot of slowdown on the chain as its generation, required for receipt validation is extremely expensive.  This optimization shifts the algorithm from `O(n^2)` to `O(n)` and results in a substantial targeting speedup.

Additionally, this cleans up the core for parallelizing receipt validation so that it takes better advantage of cores at lower receipt counts.