### PR TITLE
fix pmap to not perturb the order of the list

### DIFF
--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -121,7 +121,7 @@ pmap(F, L, Width) ->
     lists:flatten(L3).
 
 partition_list([], [], Acc) ->
-    Acc;
+    lists:reverse(Acc);
 partition_list(L, [0 | T], Acc) ->
     partition_list(L, T, Acc);
 partition_list(L, [H | T], Acc) ->

--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -204,6 +204,6 @@ pmap_test() ->
                 end, #{}, Pids),
     ?assertEqual(6, maps:size(Map)),
     ?assertEqual([3, 3, 3, 4, 4, 4], lists:sort(maps:values(Map))),
-    ?assertEqual(Input, lists:sort(Results)).
+    ?assertEqual(Input, Results).
 
 -endif.


### PR DESCRIPTION
the old pmap didn't change the ordering of the list, so we need to make sure that we maintain that ordering. 