### PR TITLE
cache ledger at contexts where we can't generate a proper snapshot

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -338,7 +338,7 @@ ledger(Ledger, Chain) ->
 -spec ledger_at(pos_integer(), blockchain()) -> {ok, blockchain_ledger_v1:ledger()} | {error, any()}.
 ledger_at(Height, Chain0) ->
     Ledger = ?MODULE:ledger(Chain0),
-      case blockchain_ledger_v1:current_height(Ledger) of
+    case blockchain_ledger_v1:current_height(Ledger) of
         {ok, CurrentHeight} when Height > CurrentHeight->
             {error, invalid_height};
         {ok, Height} ->
@@ -351,20 +351,15 @@ ledger_at(Height, Chain0) ->
                     %% Delayed height is the height we want, just return a new context
                     {ok, blockchain_ledger_v1:new_context(DelayedLedger)};
                 {ok, DelayedHeight} when Height > DelayedHeight andalso Height < CurrentHeight ->
-                    case blockchain_ledger_v1:has_snapshot(Height, Ledger) of
+                    case blockchain_ledger_v1:has_snapshot(Height, DelayedLedger) of
                         {ok, SnapshotLedger} ->
-                            {ok, blockchain_ledger_v1:new_context(SnapshotLedger)};
+                            {ok, SnapshotLedger};
                         _ ->
-                            Chain1 = lists:foldl(
-                                       fun(H, ChainAcc) ->
-                                               {ok, Block} = ?MODULE:get_block(H, Chain0),
-                                               {ok, Chain1} = blockchain_txn:absorb_block(Block, ChainAcc),
-                                               Chain1
-                                       end,
-                                       ?MODULE:ledger(blockchain_ledger_v1:new_context(DelayedLedger), Chain0),
-                                       lists:seq(DelayedHeight+1, Height)
-                                      ),
-                            {ok, ?MODULE:ledger(Chain1)}
+                            Chain1 = fold_chain(Chain0, DelayedHeight, DelayedLedger, Height),
+                            Ledger1 = ?MODULE:ledger(Chain1),
+                            Ctxt = blockchain_ledger_v1:get_context(Ledger1),
+                            blockchain_ledger_v1:context_snapshot(Ctxt, Ledger1),
+                            {ok, Ledger1}
                     end;
                 {ok, DelayedHeight} when Height < DelayedHeight ->
                     {error, height_too_old};
@@ -374,6 +369,17 @@ ledger_at(Height, Chain0) ->
         {error, _}=Error ->
             Error
     end.
+
+fold_chain(Chain0, DelayedHeight, DelayedLedger, Height) ->
+    lists:foldl(
+      fun(H, ChainAcc) ->
+              {ok, Block} = ?MODULE:get_block(H, Chain0),
+              {ok, Chain1} = blockchain_txn:absorb_block(Block, ChainAcc),
+              Chain1
+      end,
+      ?MODULE:ledger(blockchain_ledger_v1:new_context(DelayedLedger), Chain0),
+      lists:seq(DelayedHeight+1, Height)
+     ).
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -12,8 +12,10 @@
 
     check_key/2, mark_key/2,
 
-    new_context/1, delete_context/1, reset_context/1, commit_context/1, context_cache/1,
-    new_snapshot/1, has_snapshot/2, release_snapshot/1, snapshot/1,
+    new_context/1, delete_context/1, reset_context/1, commit_context/1,
+    get_context/1, context_cache/1,
+
+    new_snapshot/1, context_snapshot/2, has_snapshot/2, release_snapshot/1, snapshot/1,
 
     current_height/1, increment_height/2,
     transaction_fee/1, update_transaction_fee/1,
@@ -219,6 +221,22 @@ new_context(Ledger) ->
     Cache = ets:new(txn_cache, [set, protected, {keypos, 1}]),
     context_cache({Context, Cache}, Ledger).
 
+get_context(Ledger) ->
+    case ?MODULE:context_cache(Ledger) of
+        {undefined, undefined} = C ->
+            C;
+        {Context, Cache} ->
+            {Context, flatten_cache(Cache)}
+    end.
+
+flatten_cache(Cache) ->
+    ets:tab2list(Cache).
+
+install_context({Ctxt, FlatCache}, Ledger) ->
+    Cache = ets:new(txn_cache, [set, protected, {keypos, 1}]),
+    ets:insert(Cache, FlatCache),
+    context_cache({Ctxt, Cache}, Ledger).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -294,17 +312,38 @@ new_snapshot(#ledger_v1{db=DB,
             DelayedLedger = blockchain_ledger_v1:mode(delayed, Ledger),
             {ok, DelayedHeight} = current_height(DelayedLedger),
             ets:delete(Cache, DelayedHeight),
-            ets:insert(Cache, {Height, SnapshotHandle}  ),
+            ets:insert(Cache, {Height, {snapshot, SnapshotHandle}}),
             {ok, Ledger#ledger_v1{snapshot=SnapshotHandle}};
         {error, Reason}=Error ->
             lager:error("Error creating new snapshot, reason: ~p", [Reason]),
             Error
     end.
 
+context_snapshot(Context, #ledger_v1{db=DB, snapshots=Cache} = Ledger) ->
+    {ok, Height} = current_height(Ledger),
+    case ets:lookup(Cache, Height) of
+        [{_Height, _Snapshot}] ->
+            ok;
+        _ ->
+            case rocksdb:snapshot(DB) of
+                {ok, SnapshotHandle} ->
+                    ets:insert(Cache, {Height, {context, SnapshotHandle, Context}});
+                {error, Reason} = Error ->
+                    lager:error("Error creating new snapshot, reason: ~p", [Reason]),
+                    Error
+            end
+    end.
+
 has_snapshot(Height, #ledger_v1{snapshots=Cache}=Ledger) ->
     case ets:lookup(Cache, Height) of
-        [{Height, SnapshotHandle}] ->
-            {ok, Ledger#ledger_v1{snapshot=SnapshotHandle}};
+        [{Height, {snapshot, SnapshotHandle}}] ->
+            %% because the snapshot was taken as we ingested a block to the leading ledger we need to query it
+            %% as an active ledger to get the right information at this desired height
+            {ok, blockchain_ledger_v1:new_context(blockchain_ledger_v1:mode(active, Ledger#ledger_v1{snapshot=SnapshotHandle}))};
+        [{Height, {context, SnapshotHandle, Context}}] ->
+            %% context ledgers are always a lagging ledger snapshot with a set of overlay data in an ETS table
+            %% and therefore must be in delayed ledger mode
+            {ok, blockchain_ledger_v1:mode(delayed, install_context(Context, Ledger#ledger_v1{snapshot=SnapshotHandle}))};
         _ ->
             {error, snapshot_not_found}
     end.


### PR DESCRIPTION
since we can't do a snapshot without committing, we do the next best thing and save the context state between ledger_at calls to the same height.  this contains some bad magic, and we really need to figure out why the active ledger needs to be used to for the snapshot branch.