### PR TITLE
Only fetch and score the gateways once

### DIFF
--- a/eqc/path_v2_eqc.erl
+++ b/eqc/path_v2_eqc.erl
@@ -29,10 +29,10 @@ prop_path_check() ->
                 {ok, TargetPubkeyBin} = blockchain_poc_target_v2:target(Hash, GatewayScores, Vars),
                 {Time, Path} = timer:tc(fun() ->
                                                 blockchain_poc_path_v2:build(TargetPubkeyBin,
-                                                                                ActiveGateways,
-                                                                                block_time(),
-                                                                                Hash,
-                                                                                Vars)
+                                                                             GatewayScores,
+                                                                             block_time(),
+                                                                             Hash,
+                                                                             Vars)
                                         end),
 
                 blockchain_ledger_v1:close(Ledger),
@@ -63,7 +63,7 @@ prop_path_check() ->
                             %% - atleast one element in path
                             %% - target is always in path
                             %% - we never go back to the same h3 index in path
-                            %% - check next hop is an witness of previous gateway
+                            %% - check next hop is a witness of previous gateway
                             conjunction([{verify_path_length, PathLength =< PathLimit andalso PathLength >= 1},
                                         {verify_path_uniqueness, length(Path) == length(lists:usort(Path))},
                                         {verify_target_membership, lists:member(TargetPubkeyBin, Path)},
@@ -78,11 +78,11 @@ gen_hash() ->
     binary(32).
 
 gen_challenger_index() ->
-    ?SUCHTHAT(S, int(), S < 1088 andalso S > 0).
+    ?SUCHTHAT(S, int(), S < 1801 andalso S > 0).
 
 ledger() ->
-    %% Ledger at height: 105719
-    %% ActiveGateway Count: 1087
+    %% Ledger at height: 131551
+    %% ActiveGateway Count: 1800
     {ok, Dir} = file:get_cwd(),
     %% Ensure priv dir exists
     PrivDir = filename:join([Dir, "priv"]),
@@ -103,8 +103,8 @@ ledger() ->
     blockchain_ledger_v1:new(PrivDir).
 
 block_time() ->
-    %% block time at height 105719
-    1573151628 * 1000000000.
+    %% block time at height 131551
+    1576022415 * 1000000000.
 
 default_vars() ->
     #{poc_v4_exclusion_cells => 10,

--- a/eqc/path_v2_target_eqc.erl
+++ b/eqc/path_v2_target_eqc.erl
@@ -61,11 +61,11 @@ gen_hash() ->
     binary(32).
 
 gen_challenger_index() ->
-    ?SUCHTHAT(S, int(), S < 1088 andalso S > 0).
+    ?SUCHTHAT(S, int(), S < 1801 andalso S > 0).
 
 ledger() ->
-    %% Ledger at height: 105719
-    %% ActiveGateway Count: 1087
+    %% Ledger at height: 131551
+    %% ActiveGateway Count: 1800
     {ok, Dir} = file:get_cwd(),
     %% Ensure priv dir exists
     PrivDir = filename:join([Dir, "priv"]),

--- a/src/blockchain_poc_path_v2.erl
+++ b/src/blockchain_poc_path_v2.erl
@@ -53,7 +53,7 @@
 %% It is expected that the "GatewayScoreMap" being passed to build/6 fun
 %% has already been pre-filtered to remove "inactive" gateways.
 -spec build(TargetPubkeyBin :: libp2p_crypto:pubkey_bin(),
-            GatewayScoreMap :: blockchain_poc_target_v2:gateway_score_map(),
+            GatewayScoreMap :: blockchain_utils:gateway_score_map(),
             HeadBlockTime :: pos_integer(),
             Hash :: binary(),
             Vars :: map()) -> path().
@@ -74,7 +74,7 @@ build(TargetPubkeyBin, GatewayScoreMap, HeadBlockTime, Hash, Vars) ->
 %% Helpers
 %%%-------------------------------------------------------------------
 -spec build_(TargetPubkeyBin :: libp2p_crypto:pubkey_bin(),
-             GatewayScoreMap :: blockchain_poc_target_v2:gateway_score_map(),
+             GatewayScoreMap :: blockchain_utils:gateway_score_map(),
              HeadBlockTime :: pos_integer(),
              Vars :: map(),
              RandState :: rand:state(),
@@ -109,7 +109,7 @@ build_(_TargetPubkeyBin, _GatewayScoreMap, _HeadBlockTime, _Vars, _RandState, _I
     lists:reverse(Path).
 
 -spec next_hop(GatewayBin :: blockchain_ledger_gateway_v2:gateway(),
-               GatewayScoreMap :: blockchain_poc_target_v2:gateway_score_map(),
+               GatewayScoreMap :: blockchain_utils:gateway_score_map(),
                HeadBlockTime :: pos_integer(),
                Vars :: map(),
                RandVal :: float(),
@@ -269,7 +269,7 @@ select_witness([{_WitnessPubkeyBin, Prob} | Tail], Rnd, Vars) ->
 -spec filter_witnesses(GatewayLoc :: h3:h3_index(),
                        Indices :: [h3:h3_index()],
                        Witnesses :: blockchain_ledger_gateway_v2:witnesses(),
-                       GatewayScoreMap :: blockchain_poc_target_v2:gateway_score_map(),
+                       GatewayScoreMap :: blockchain_utils:gateway_score_map(),
                        Vars :: map()) -> blockchain_ledger_gateway_v2:witnesses().
 filter_witnesses(GatewayLoc, Indices, Witnesses, GatewayScoreMap, Vars) ->
     ParentRes = parent_res(Vars),
@@ -334,7 +334,7 @@ check_witness_bad_rssi(Witness, Vars) ->
     end.
 
 -spec check_witness_inclusion(WitnessPubkeyBin :: libp2p_crypto:pubkey_bin(),
-                              GatewayScoreMap :: blockchain_poc_target_v2:gateway_score_map(),
+                              GatewayScoreMap :: blockchain_utils:gateway_score_map(),
                               Vars :: map()) -> boolean().
 check_witness_inclusion(WitnessPubkeyBin, GatewayScoreMap, Vars) ->
     case poc_version(Vars) of

--- a/src/blockchain_poc_path_v2.erl
+++ b/src/blockchain_poc_path_v2.erl
@@ -59,7 +59,8 @@
             Vars :: map()) -> path().
 build(TargetPubkeyBin, ActiveGateways, HeadBlockTime, Hash, Vars) ->
     true =  maps:is_key(TargetPubkeyBin, ActiveGateways),
-    TargetGwLoc = blockchain_ledger_gateway_v2:location(maps:get(TargetPubkeyBin, ActiveGateways)),
+    {TargetGw, _} = maps:get(TargetPubkeyBin, ActiveGateways),
+    TargetGwLoc = blockchain_ledger_gateway_v2:location(TargetGw),
     RandState = blockchain_utils:rand_state(Hash),
     build_(TargetPubkeyBin,
            ActiveGateways,
@@ -93,7 +94,7 @@ build_(TargetPubkeyBin,
             lists:reverse(Path);
         {ok, WitnessPubkeyBin} ->
             %% Try the next hop in the new path, continue building forward
-            NextHopGw = maps:get(WitnessPubkeyBin, ActiveGateways),
+            {NextHopGw, _} = maps:get(WitnessPubkeyBin, ActiveGateways),
             Index = blockchain_ledger_gateway_v2:location(NextHopGw),
             NewPath = [WitnessPubkeyBin | Path],
             build_(WitnessPubkeyBin,
@@ -115,7 +116,7 @@ build_(_TargetPubkeyBin, _ActiveGateways, _HeadBlockTime, _Vars, _RandState, _In
                Indices :: [h3:h3_index()]) -> {error, no_witness} | {ok, libp2p_crypto:pubkey_bin()}.
 next_hop(GatewayBin, ActiveGateways, HeadBlockTime, Vars, RandVal, Indices) ->
     %% Get gateway
-    Gateway = maps:get(GatewayBin, ActiveGateways),
+    {Gateway, _} = maps:get(GatewayBin, ActiveGateways),
     case blockchain_ledger_gateway_v2:witnesses(Gateway) of
         W when map_size(W) == 0 ->
             {error, no_witness};
@@ -281,7 +282,7 @@ filter_witnesses(GatewayLoc, Indices, Witnesses, ActiveGateways, Vars) ->
                                 %% Don't include if the witness is not in ActiveGateways
                                 false;
                             true ->
-                                WitnessGw = maps:get(WitnessPubkeyBin, ActiveGateways),
+                                {WitnessGw, _} = maps:get(WitnessPubkeyBin, ActiveGateways),
                                 WitnessLoc = blockchain_ledger_gateway_v2:location(WitnessGw),
                                 WitnessParent = h3:parent(WitnessLoc, ParentRes),
                                 %% Dont include any witnesses in any parent cell we've already visited

--- a/src/blockchain_poc_target_v2.erl
+++ b/src/blockchain_poc_target_v2.erl
@@ -17,16 +17,14 @@
          target/3, filter/5
         ]).
 
--type gateway_score_map() :: #{libp2p_crypto:pubkey_bin() => {blockchain_ledger_gateway_v2:gateway(), float()}}.
 -type prob_map() :: #{libp2p_crypto:pubkey_bin() => float()}.
 
--export_type([gateway_score_map/0]).
 
 %% @doc Finds a potential target to start the path from.
 %% This must always return a target.
 %% Favors high scoring gateways, dependent on score^poc_v4_target_score_curve curve.
 -spec target(Hash :: binary(),
-             GatewayScoreMap :: gateway_score_map(),
+             GatewayScoreMap :: blockchain_utils:gateway_score_map(),
              Vars :: map()) -> {ok, libp2p_crypto:pubkey_bin()} | {error, no_target}.
 target(Hash, GatewayScoreMap, Vars) ->
     ProbScores = score_prob(GatewayScoreMap, Vars),
@@ -42,11 +40,11 @@ target(Hash, GatewayScoreMap, Vars) ->
 %% - Inactive gateways (those which haven't challenged in a long time).
 %% - Dont target the challenger gateway itself.
 %% - Ensure that potential target is far from the challenger to avoid collusion.
--spec filter(GatewayScoreMap :: gateway_score_map(),
+-spec filter(GatewayScoreMap :: blockchain_utils:gateway_score_map(),
              ChallengerAddr :: libp2p_crypto:pubkey_bin(),
              ChallengerLoc :: h3:index(),
              Height :: pos_integer(),
-             Vars :: map()) -> gateway_score_map().
+             Vars :: map()) -> blockchain_utils:gateway_score_map().
 filter(GatewayScoreMap, ChallengerAddr, ChallengerLoc, Height, Vars) ->
     maps:filter(fun(_Addr, {Gateway, _Score}) ->
                         case blockchain_ledger_gateway_v2:last_poc_challenge(Gateway) of
@@ -73,7 +71,7 @@ filter(GatewayScoreMap, ChallengerAddr, ChallengerLoc, Height, Vars) ->
 %%%-------------------------------------------------------------------
 %% Helpers
 %%%-------------------------------------------------------------------
--spec score_prob(GatewayScoreMap :: gateway_score_map(), Vars :: map()) -> prob_map().
+-spec score_prob(GatewayScoreMap :: blockchain_utils:gateway_score_map(), Vars :: map()) -> prob_map().
 score_prob(GatewayScoreMap, Vars) ->
     %% Assign probability to each gateway
     ProbScores = maps:map(fun(_Addr, {_G, Score}) ->
@@ -88,7 +86,7 @@ score_prob(GatewayScoreMap, Vars) ->
              end,
              ProbScores).
 
--spec edge_prob(GatewayScoreMap :: gateway_score_map(), Vars :: map()) -> prob_map().
+-spec edge_prob(GatewayScoreMap :: blockchain_utils:gateway_score_map(), Vars :: map()) -> prob_map().
 edge_prob(GatewayScoreMap, Vars) ->
     %% Get all locations
     case prob_edge_wt(Vars) of
@@ -156,7 +154,7 @@ scaled_prob(PTarget, Vars) ->
                      ?normalize_float((P / SumProbs), Vars)
              end, PTarget).
 
--spec locations(GatewayScoreMap :: gateway_score_map(), Vars :: #{}) -> #{h3:index() => integer()}.
+-spec locations(GatewayScoreMap :: blockchain_utils:gateway_score_map(), Vars :: #{}) -> #{h3:index() => integer()}.
 locations(GatewayScoreMap, Vars) ->
     %% Get all locations from score map
     Res = parent_res(Vars),

--- a/src/blockchain_poc_target_v2.erl
+++ b/src/blockchain_poc_target_v2.erl
@@ -17,8 +17,10 @@
          target/3, filter/5
         ]).
 
--type gateway_score_map() :: #{libp2p_crypto:pubkey_bin() => {float(), blockchain_ledger_gateway_v2:gateway()}}.
+-type gateway_score_map() :: #{libp2p_crypto:pubkey_bin() => {blockchain_ledger_gateway_v2:gateway(), float()}}.
 -type prob_map() :: #{libp2p_crypto:pubkey_bin() => float()}.
+
+-export_type([gateway_score_map/0]).
 
 %% @doc Finds a potential target to start the path from.
 %% This must always return a target.

--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -30,6 +30,9 @@
 -define(TRANSMIT_POWER, 28).
 -define(MAX_ANTENNA_GAIN, 6).
 
+-type gateway_score_map() :: #{libp2p_crypto:pubkey_bin() => {blockchain_ledger_gateway_v2:gateway(), float()}}.
+-export_type([gateway_score_map/0]).
+
 %%--------------------------------------------------------------------
 %% @doc Shuffle a list deterministically using a random binary as the seed.
 %% @end
@@ -166,6 +169,7 @@ hex_adjustment(Loc) ->
     EdgeLength = h3:edge_length_kilometers(Res),
     EdgeLength * (round(math:sqrt(3) * math:pow(10, 3)) / math:pow(10, 3)) / 2.
 
+-spec score_gateways(blockchain_ledger_v1:ledger()) -> gateway_score_map().
 score_gateways(Ledger) ->
     {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
     case blockchain_ledger_v1:mode(Ledger) of
@@ -180,6 +184,8 @@ score_gateways(Ledger) ->
             score_tagged_gateways(Height, Ledger)
     end.
 
+-spec score_tagged_gateways(Height :: pos_integer(),
+                            Ledger :: blockchain_ledger_v1:ledger()) -> gateway_score_map().
 score_tagged_gateways(Height, Ledger) ->
     Gateways = blockchain_ledger_v1:active_gateways(Ledger),
     maps:map(fun(A, G) ->

--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -217,23 +217,22 @@ is_valid(Txn, Chain) ->
                                                                     maybe_log_duration(ledger_at, StartLA),
                                                                     Path = case blockchain:config(?poc_version, OldLedger) of
                                                                                {ok, V} when V > 3 ->
-                                                                                   StartA = erlang:monotonic_time(millisecond),
-                                                                                   ActiveGateways = blockchain_ledger_v1:active_gateways(OldLedger),
-                                                                                   maybe_log_duration(activegw, StartA),
-                                                                                   Time = blockchain_block:time(Block1),
-                                                                                   ChallengerLoc = blockchain_ledger_gateway_v2:location(maps:get(Challenger, ActiveGateways)),
-                                                                                   {ok, OldHeight} = blockchain_ledger_v1:current_height(OldLedger),
                                                                                    StartS = erlang:monotonic_time(millisecond),
                                                                                    GatewayScoreMap = blockchain_utils:score_gateways(OldLedger),
                                                                                    Vars = blockchain_utils:vars_binary_keys_to_atoms(blockchain_ledger_v1:all_vars(OldLedger)),
                                                                                    maybe_log_duration(scored, StartS),
+
+                                                                                   Time = blockchain_block:time(Block1),
+                                                                                   {ChallengerGw, _} = maps:get(Challenger, GatewayScoreMap),
+                                                                                   ChallengerLoc = blockchain_ledger_gateway_v2:location(ChallengerGw),
+                                                                                   {ok, OldHeight} = blockchain_ledger_v1:current_height(OldLedger),
                                                                                    StartFT = erlang:monotonic_time(millisecond),
                                                                                    GatewayScores = blockchain_poc_target_v2:filter(GatewayScoreMap, Challenger, ChallengerLoc, OldHeight, Vars),
                                                                                    %% If we make it to this point, we are bound to have a target.
                                                                                    {ok, Target} = blockchain_poc_target_v2:target(Entropy, GatewayScores, Vars),
                                                                                    maybe_log_duration(filter_target, StartFT),
                                                                                    StartB = erlang:monotonic_time(millisecond),
-                                                                                   RetB = blockchain_poc_path_v2:build(Target, ActiveGateways, Time, Entropy, Vars),
+                                                                                   RetB = blockchain_poc_path_v2:build(Target, GatewayScoreMap, Time, Entropy, Vars),
                                                                                    maybe_log_duration(build, StartB),
                                                                                    RetB;
                                                                                _ ->


### PR DESCRIPTION
currently, due to some code paths that were incompletely renovated during the poc_v4 update, we fetch the active_gateways column off the disk twice.  doing this twice adds roughly 30% to the receipt validation time.  it's fairly easy to make the code that uses the unscored gateways map use the scored version, so we can just skip doing this work.