### PR TITLE
Implement print/1 in all transaction types

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -53,7 +53,7 @@
  [
   rebar3_gpb_plugin,
   covertool,
-  {rebar3_eqc, {git, "https://github.com/Vagabond/rebar3-eqc-plugin", {branch, "master"}}}
+  rebar3_eqc
  ]}.
 
 {provider_hooks, [

--- a/src/blockchain_election.erl
+++ b/src/blockchain_election.erl
@@ -241,7 +241,7 @@ election_info(Ledger, Chain) ->
     %% get the election txn
     {ok, StartBlock} = blockchain:get_block(StartHeight, Chain),
     {ok, Txn} = get_election_txn(StartBlock),
-    lager:debug("txn ~p", [Txn]),
+    lager:debug("txn ~s", [blockchain_txn:print(Txn)]),
     ElectionHeight = blockchain_txn_consensus_group_v1:height(Txn),
     ElectionDelay = blockchain_txn_consensus_group_v1:delay(Txn),
 

--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -646,9 +646,9 @@ send_txn(Txn) ->
                                    (fun(Res) ->
                                             case Res of
                                                 ok ->
-                                                    lager:info("successfully submit txn: ~p", [Txn]);
+                                                    lager:info("successfully submit txn: ~s", [blockchain_txn:print(Txn)]);
                                                 {error, Reason} ->
-                                                    lager:error("failed to submit txn: ~p error: ~p", [Txn, Reason])
+                                                    lager:error("failed to submit txn: ~s error: ~p", [blockchain_txn:print(Txn), Reason])
                                             end
                                     end)).
 

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -44,8 +44,7 @@
 -callback print(txn(), boolean()) -> iodata().
 -callback rescue_absorb(txn(),  blockchain:blockchain()) -> ok | {error, any()}.
 
-%% ideally print/1 would eventually be required
--optional_callbacks([rescue_absorb/2, print/1, print/2]).
+-optional_callbacks([rescue_absorb/2, print/2]).
 
 -export([
     hash/1,

--- a/src/transactions/blockchain_txn_mgr.erl
+++ b/src/transactions/blockchain_txn_mgr.erl
@@ -118,22 +118,22 @@ handle_info(resubmit, State=#state{txn_map=TxnMap, chain=Chain}) ->
 
     {noreply, State#state{txn_map=NewTxnMap}};
 handle_info({accepted, {Dialer, Txn, Member}}, State) ->
-    lager:info("txn: ~p, accepted_by: ~p, Dialer: ~p", [Txn, Member, Dialer]),
+    lager:info("txn: ~s, accepted_by: ~p, Dialer: ~p", [blockchain_txn:print(Txn), Member, Dialer]),
     {noreply, State};
 handle_info({no_group, {Dialer, Txn, Member}}, State) ->
-    lager:info("txn: ~p, no group: ~p, Dialer: ~p", [Txn, Member, Dialer]),
+    lager:info("txn: ~s, no group: ~p, Dialer: ~p", [blockchain_txn:print(Txn), Member, Dialer]),
     NewState = retry(Txn, State),
     {noreply, NewState};
 handle_info({dial_failed, {Dialer, Txn, Member}}, State) ->
-    lager:debug("txn: ~p, dial_failed: ~p, Dialer: ~p", [Txn, Member, Dialer]),
+    lager:debug("txn: ~s, dial_failed: ~p, Dialer: ~p", [blockchain_txn:print(Txn), Member, Dialer]),
     NewState = retry(Txn, State),
     {noreply, NewState};
 handle_info({send_failed, {Dialer, Txn, Member}}, State) ->
-    lager:debug("txn: ~p, send_failed: ~p, Dialer: ~p", [Txn, Member, Dialer]),
+    lager:debug("txn: ~s, send_failed: ~p, Dialer: ~p", [blockchain_txn:print(Txn), Member, Dialer]),
     NewState = retry(Txn, State),
     {noreply, NewState};
 handle_info({rejected, {Dialer, Txn, Member}}, State) ->
-    lager:debug("txn: ~p, rejected_by: ~p, Dialer: ~p", [Txn, Member, Dialer]),
+    lager:debug("txn: ~s, rejected_by: ~p, Dialer: ~p", [blockchain_txn:print(Txn), Member, Dialer]),
     NewState = rejected(Txn, Member, State),
     {noreply, NewState};
 handle_info({blockchain_event, {new_chain, NC}}, State) ->

--- a/src/transactions/v1/blockchain_poc_path_element_v1.erl
+++ b/src/transactions/v1/blockchain_poc_path_element_v1.erl
@@ -61,6 +61,8 @@ receipt(Element) ->
 witnesses(Element) ->
     Element#blockchain_poc_path_element_v1_pb.witnesses.
 
+print(undefined) ->
+    <<"type=element undefined">>;
 print(#blockchain_poc_path_element_v1_pb{
          challengee=Challengee,
          receipt=Receipt,

--- a/src/transactions/v1/blockchain_poc_path_element_v1.erl
+++ b/src/transactions/v1/blockchain_poc_path_element_v1.erl
@@ -22,6 +22,8 @@
 
 -export_type([poc_element/0, poc_path/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -70,7 +72,7 @@ print(#blockchain_poc_path_element_v1_pb{
         }) ->
     io_lib:format("type=element challengee: ~s, receipt: ~s\n\t\twitnesses: ~s",
                   [
-                   element(2, erl_angry_purple_tiger:animal_name(libp2p_crypto:bin_to_b58(Challengee))),
+                   ?TO_ANIMAL_NAME(Challengee),
                    blockchain_poc_receipt_v1:print(Receipt),
                    string:join(lists:map(fun(Witness) ->
                                                  blockchain_poc_witness_v1:print(Witness)

--- a/src/transactions/v1/blockchain_poc_path_element_v1.erl
+++ b/src/transactions/v1/blockchain_poc_path_element_v1.erl
@@ -3,7 +3,7 @@
 %%%-------------------------------------------------------------------
 -module(blockchain_poc_path_element_v1).
 
--include("pb/blockchain_txn_poc_receipts_v1_pb.hrl").
+-include("../../pb/blockchain_txn_poc_receipts_v1_pb.hrl").
 
 -export([
     new/3,

--- a/src/transactions/v1/blockchain_poc_receipt_v1.erl
+++ b/src/transactions/v1/blockchain_poc_receipt_v1.erl
@@ -29,6 +29,9 @@
 
 -export_type([poc_receipt/0, poc_receipts/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -127,7 +130,7 @@ print(#blockchain_poc_receipt_v1_pb{
         }) ->
     io_lib:format("type=receipt gateway: ~s timestamp: ~b signal: ~b origin: ~p",
                   [
-                   element(2, erl_angry_purple_tiger:animal_name(libp2p_crypto:bin_to_b58(Gateway))),
+                   ?TO_ANIMAL_NAME(Gateway),
                    TS,
                    Signal,
                    Origin

--- a/src/transactions/v1/blockchain_poc_receipt_v1.erl
+++ b/src/transactions/v1/blockchain_poc_receipt_v1.erl
@@ -118,7 +118,7 @@ is_valid(Receipt=#blockchain_poc_receipt_v1_pb{gateway=Gateway, signature=Signat
     libp2p_crypto:verify(EncodedReceipt, Signature, PubKey).
 
 print(undefined) ->
-    undefined;
+    <<"type=receipt undefined">>;
 print(#blockchain_poc_receipt_v1_pb{
          gateway=Gateway,
          timestamp=TS,

--- a/src/transactions/v1/blockchain_poc_receipt_v1.erl
+++ b/src/transactions/v1/blockchain_poc_receipt_v1.erl
@@ -4,7 +4,7 @@
 %%%-------------------------------------------------------------------
 -module(blockchain_poc_receipt_v1).
 
--include("pb/blockchain_txn_poc_receipts_v1_pb.hrl").
+-include("../../pb/blockchain_txn_poc_receipts_v1_pb.hrl").
 
 -export([
     new/5,

--- a/src/transactions/v1/blockchain_poc_witness_v1.erl
+++ b/src/transactions/v1/blockchain_poc_witness_v1.erl
@@ -4,7 +4,7 @@
 %%%-------------------------------------------------------------------
 -module(blockchain_poc_witness_v1).
 
--include("pb/blockchain_txn_poc_receipts_v1_pb.hrl").
+-include("../../pb/blockchain_txn_poc_receipts_v1_pb.hrl").
 
 -export([
     new/4,

--- a/src/transactions/v1/blockchain_poc_witness_v1.erl
+++ b/src/transactions/v1/blockchain_poc_witness_v1.erl
@@ -27,6 +27,9 @@
 
 -export_type([poc_witness/0, poc_witnesss/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -105,7 +108,7 @@ is_valid(Receipt=#blockchain_poc_witness_v1_pb{gateway=Gateway, signature=Signat
     libp2p_crypto:verify(EncodedReceipt, Signature, PubKey).
 
 print(undefined) ->
-    undefined;
+    <<"type=witness undefined">>;
 print(#blockchain_poc_witness_v1_pb{
          gateway=Gateway,
          timestamp=TS,
@@ -113,7 +116,7 @@ print(#blockchain_poc_witness_v1_pb{
         }) ->
     io_lib:format("type=witness gateway: ~p timestamp: ~p signal: ~p",
                   [
-                   element(2, erl_angry_purple_tiger:animal_name(libp2p_crypto:bin_to_b58(Gateway))),
+                   ?TO_ANIMAL_NAME(Gateway),
                    TS,
                    Signal
                   ]).

--- a/src/transactions/v1/blockchain_txn_add_gateway_v1.erl
+++ b/src/transactions/v1/blockchain_txn_add_gateway_v1.erl
@@ -7,7 +7,7 @@
 
 -behavior(blockchain_txn).
 
--include("pb/blockchain_txn_add_gateway_v1_pb.hrl").
+-include("../../pb/blockchain_txn_add_gateway_v1_pb.hrl").
 
 -export([
     new/4, new/5,

--- a/src/transactions/v1/blockchain_txn_add_gateway_v1.erl
+++ b/src/transactions/v1/blockchain_txn_add_gateway_v1.erl
@@ -28,7 +28,8 @@
     is_valid_payer/1,
     is_valid/2,
     absorb/2,
-    calculate_staking_fee/1
+    calculate_staking_fee/1,
+    print/1
 ]).
 
 -ifdef(TEST).
@@ -62,6 +63,7 @@ new(OwnerAddress, GatewayAddress, Payer, StakingFee, Fee) ->
         staking_fee=StakingFee,
         fee=Fee
     }.
+
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -297,6 +299,22 @@ absorb(Txn, Chain) ->
 -spec calculate_staking_fee(blockchain:blockchain()) -> non_neg_integer().
 calculate_staking_fee(_Chain) ->
     1.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec print(txn_add_gateway()) -> iodata().
+print(undefined) -> <<"type=add_gateway, undefined">>;
+print(#blockchain_txn_add_gateway_v1_pb{
+         owner = O,
+         gateway = GW,
+         payer = P,
+         staking_fee = SF,
+         fee = F}) ->
+    io_lib:format("type=add_gateway, owner=~p, gateway=~p, payer=~p, staking_fee=~p, fee=~p",
+                  [O, GW, P, SF, F]).
+
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_add_gateway_v1.erl
+++ b/src/transactions/v1/blockchain_txn_add_gateway_v1.erl
@@ -39,6 +39,9 @@
 -type txn_add_gateway() :: #blockchain_txn_add_gateway_v1_pb{}.
 -export_type([txn_add_gateway/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -313,7 +316,7 @@ print(#blockchain_txn_add_gateway_v1_pb{
          staking_fee = SF,
          fee = F}) ->
     io_lib:format("type=add_gateway, owner=~p, gateway=~p, payer=~p, staking_fee=~p, fee=~p",
-                  [O, GW, P, SF, F]).
+                  [?TO_B58(O), ?TO_ANIMAL_NAME(GW), ?TO_B58(P), SF, F]).
 
 
 %% ------------------------------------------------------------------

--- a/src/transactions/v1/blockchain_txn_assert_location_v1.erl
+++ b/src/transactions/v1/blockchain_txn_assert_location_v1.erl
@@ -32,7 +32,8 @@
     is_valid_payer/1,
     is_valid/2,
     absorb/2,
-    calculate_staking_fee/1
+    calculate_staking_fee/1,
+    print/1
 ]).
 
 -ifdef(TEST).
@@ -87,6 +88,8 @@ new(Gateway, Owner, Payer, Location, Nonce, StakingFee, Fee) ->
         staking_fee=StakingFee,
         fee=Fee
     }.
+
+
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -379,6 +382,22 @@ absorb(Txn, Chain) ->
 -spec calculate_staking_fee(blockchain:blockchain()) -> non_neg_integer().
 calculate_staking_fee(_Chain) ->
     1.
+
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec print(txn_assert_location()) -> iodata().
+print(undefined) -> <<"type=assert_location, undefined">>;
+print(#blockchain_txn_assert_location_v1_pb{
+        gateway = Gateway, owner = Owner, payer = Payer,
+        location = Loc, gateway_signature = GS,
+        owner_signature = OS, payer_signature = PS, nonce = Nonce,
+        staking_fee = StakingFee, fee = Fee}) ->
+    io_lib:format("type=assert_location, gateway=~p, owner=~p, payer=~p, location=~p, gateway_signature=~p, owner_signature=~p, payer_signature=~p, nonce=~p, staking_fee=~p, fee=~p",
+                  [Gateway, Owner, Payer, Loc, GS, OS, PS, Nonce,
+                   StakingFee, Fee]).
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions

--- a/src/transactions/v1/blockchain_txn_assert_location_v1.erl
+++ b/src/transactions/v1/blockchain_txn_assert_location_v1.erl
@@ -7,7 +7,7 @@
 
 -behavior(blockchain_txn).
 
--include("pb/blockchain_txn_assert_location_v1_pb.hrl").
+-include("../../pb/blockchain_txn_assert_location_v1_pb.hrl").
 -include("blockchain_vars.hrl").
 
 -export([

--- a/src/transactions/v1/blockchain_txn_assert_location_v1.erl
+++ b/src/transactions/v1/blockchain_txn_assert_location_v1.erl
@@ -44,6 +44,9 @@
 -type txn_assert_location() :: #blockchain_txn_assert_location_v1_pb{}.
 -export_type([txn_assert_location/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -396,8 +399,8 @@ print(#blockchain_txn_assert_location_v1_pb{
         owner_signature = OS, payer_signature = PS, nonce = Nonce,
         staking_fee = StakingFee, fee = Fee}) ->
     io_lib:format("type=assert_location, gateway=~p, owner=~p, payer=~p, location=~p, gateway_signature=~p, owner_signature=~p, payer_signature=~p, nonce=~p, staking_fee=~p, fee=~p",
-                  [Gateway, Owner, Payer, Loc, GS, OS, PS, Nonce,
-                   StakingFee, Fee]).
+                  [?TO_ANIMAL_NAME(Gateway), ?TO_B58(Owner), ?TO_B58(Payer),
+		   Loc, GS, OS, PS, Nonce, StakingFee, Fee]).
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions

--- a/src/transactions/v1/blockchain_txn_bundle_v1.erl
+++ b/src/transactions/v1/blockchain_txn_bundle_v1.erl
@@ -26,6 +26,9 @@
 -type txn_bundle() :: #blockchain_txn_bundle_v1_pb{}.
 -export_type([txn_bundle/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 -spec new(Txns :: blockchain_txn:txns()) -> txn_bundle().
 new(Txns) ->
     #blockchain_txn_bundle_v1_pb{transactions=Txns}.

--- a/src/transactions/v1/blockchain_txn_bundle_v1.erl
+++ b/src/transactions/v1/blockchain_txn_bundle_v1.erl
@@ -8,7 +8,7 @@
 -behavior(blockchain_txn).
 
 -include("blockchain_vars.hrl").
--include("pb/blockchain_txn_pb.hrl").
+-include("../../pb/blockchain_txn_pb.hrl").
 
 -define(MAX_BUNDLE_SIZE, 5).
 

--- a/src/transactions/v1/blockchain_txn_bundle_v1.erl
+++ b/src/transactions/v1/blockchain_txn_bundle_v1.erl
@@ -19,7 +19,8 @@
     sign/2,
     fee/1,
     txns/1,
-    is_valid/2
+    is_valid/2,
+    print/1
 ]).
 
 -type txn_bundle() :: #blockchain_txn_bundle_v1_pb{}.
@@ -84,6 +85,12 @@ is_valid(#blockchain_txn_bundle_v1_pb{transactions=Txns}=Txn, Chain) ->
                     end
             end
     end.
+
+-spec print(txn_bundle()) -> iodata().
+print(#blockchain_txn_bundle_v1_pb{transactions=Txns}) ->
+    io_lib:format("type=bundle, txns=~p", [
+                                           [blockchain_txn:print(T) || T <- Txns]
+                                          ]).
 
 
 -spec max_bundle_size(blockchain:blockchain()) -> pos_integer().

--- a/src/transactions/v1/blockchain_txn_coinbase_v1.erl
+++ b/src/transactions/v1/blockchain_txn_coinbase_v1.erl
@@ -17,7 +17,8 @@
     fee/1,
     is_valid/2,
     absorb/2,
-    sign/2
+    sign/2,
+    print/1
 ]).
 
 -ifdef(TEST).
@@ -107,6 +108,19 @@ absorb(Txn, Chain) ->
     Payee = ?MODULE:payee(Txn),
     Amount = ?MODULE:amount(Txn),
     blockchain_ledger_v1:credit_account(Payee, Amount, Ledger).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec print(undefined|txn_coinbase()) -> [iodata()].
+print(undefined) ->
+    <<"type=coinbase, undefined">>;
+print(#blockchain_txn_coinbase_v1_pb{} = Txn) ->
+    io_lib:format("txn_coinbase: payee: ~p, amount: ~p",
+                  [?MODULE:payee(Txn), ?MODULE:amount(Txn)]);
+print(Other) ->
+    io_lib:format("type=coinbase, unexpected data: ~p", [Other]).
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_coinbase_v1.erl
+++ b/src/transactions/v1/blockchain_txn_coinbase_v1.erl
@@ -7,7 +7,7 @@
 
 -behavior(blockchain_txn).
 
--include("pb/blockchain_txn_coinbase_v1_pb.hrl").
+-include("../../pb/blockchain_txn_coinbase_v1_pb.hrl").
 
 -export([
     new/2,

--- a/src/transactions/v1/blockchain_txn_coinbase_v1.erl
+++ b/src/transactions/v1/blockchain_txn_coinbase_v1.erl
@@ -28,6 +28,9 @@
 -type txn_coinbase() :: #blockchain_txn_coinbase_v1_pb{}.
 -export_type([txn_coinbase/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -118,7 +121,7 @@ print(undefined) ->
     <<"type=coinbase, undefined">>;
 print(#blockchain_txn_coinbase_v1_pb{payee=Payee, amount=Amount}) ->
     io_lib:format("txn_coinbase: payee: ~p, amount: ~p",
-                  [Payee, Amount]).
+                  [?TO_B58(Payee), Amount]).
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_coinbase_v1.erl
+++ b/src/transactions/v1/blockchain_txn_coinbase_v1.erl
@@ -113,14 +113,12 @@ absorb(Txn, Chain) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec print(undefined|txn_coinbase()) -> [iodata()].
+-spec print(txn_coinbase()) -> [iodata()].
 print(undefined) ->
     <<"type=coinbase, undefined">>;
-print(#blockchain_txn_coinbase_v1_pb{} = Txn) ->
+print(#blockchain_txn_coinbase_v1_pb{payee=Payee, amount=Amount}) ->
     io_lib:format("txn_coinbase: payee: ~p, amount: ~p",
-                  [?MODULE:payee(Txn), ?MODULE:amount(Txn)]);
-print(Other) ->
-    io_lib:format("type=coinbase, unexpected data: ~p", [Other]).
+                  [Payee, Amount]).
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_consensus_group_v1.erl
+++ b/src/transactions/v1/blockchain_txn_consensus_group_v1.erl
@@ -7,7 +7,7 @@
 
 -behavior(blockchain_txn).
 
--include("pb/blockchain_txn_consensus_group_v1_pb.hrl").
+-include("../../pb/blockchain_txn_consensus_group_v1_pb.hrl").
 
 -export([
     new/4,

--- a/src/transactions/v1/blockchain_txn_consensus_group_v1.erl
+++ b/src/transactions/v1/blockchain_txn_consensus_group_v1.erl
@@ -32,6 +32,9 @@
 -type txn_consensus_group() :: #blockchain_txn_consensus_group_v1_pb{}.
 -export_type([txn_consensus_group/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end

--- a/src/transactions/v1/blockchain_txn_consensus_group_v1.erl
+++ b/src/transactions/v1/blockchain_txn_consensus_group_v1.erl
@@ -204,6 +204,12 @@ absorb(Txn, Chain) ->
             Err
     end.
 
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec print(txn_consensus_group()) -> iodata().
+print(undefined) -> <<"type=group, undefined">>;
 print(#blockchain_txn_consensus_group_v1_pb{height = Height,
                                             delay = Delay,
                                             members = Members,

--- a/src/transactions/v1/blockchain_txn_create_htlc_v1.erl
+++ b/src/transactions/v1/blockchain_txn_create_htlc_v1.erl
@@ -10,7 +10,7 @@
 
 -behavior(blockchain_txn).
 
--include("pb/blockchain_txn_create_htlc_v1_pb.hrl").
+-include("../../pb/blockchain_txn_create_htlc_v1_pb.hrl").
 
 -export([
     new/7,

--- a/src/transactions/v1/blockchain_txn_create_htlc_v1.erl
+++ b/src/transactions/v1/blockchain_txn_create_htlc_v1.erl
@@ -25,7 +25,8 @@
     signature/1,
     sign/2,
     is_valid/2,
-    absorb/2
+    absorb/2,
+    print/1
 ]).
 
 -ifdef(TEST).
@@ -52,6 +53,7 @@ new(Payer, Payee, Address, Hashlock, Timelock, Amount, Fee) ->
         fee=Fee,
         signature = <<>>
     }.
+
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -211,6 +213,18 @@ absorb(Txn, Chain) ->
                     end
             end
     end.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec print(txn_create_htlc()) -> iodata().
+print(#blockchain_txn_create_htlc_v1_pb{
+        payer=Payer, payee=Payee, address=Address,
+        hashlock=Hashlock, timelock=Timelock, amount=Amount,
+        fee=Fee, signature = Sig}) ->
+    io_lib:format("type=create_htlc payer=~p payee=~p, address=~p, hashlock=~p, timelock=~p, amount=~p, fee=~p, signature=~p",
+                  [Payer, Payee, Address, Hashlock, Timelock, Amount, Fee, Sig]).
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_create_htlc_v1.erl
+++ b/src/transactions/v1/blockchain_txn_create_htlc_v1.erl
@@ -36,6 +36,9 @@
 -type txn_create_htlc() :: #blockchain_txn_create_htlc_v1_pb{}.
 -export_type([txn_create_htlc/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -224,7 +227,7 @@ print(#blockchain_txn_create_htlc_v1_pb{
         hashlock=Hashlock, timelock=Timelock, amount=Amount,
         fee=Fee, signature = Sig}) ->
     io_lib:format("type=create_htlc payer=~p payee=~p, address=~p, hashlock=~p, timelock=~p, amount=~p, fee=~p, signature=~p",
-                  [Payer, Payee, Address, Hashlock, Timelock, Amount, Fee, Sig]).
+                  [?TO_B58(Payer), ?TO_B58(Payee), Address, Hashlock, Timelock, Amount, Fee, Sig]).
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_dc_coinbase_v1.erl
+++ b/src/transactions/v1/blockchain_txn_dc_coinbase_v1.erl
@@ -7,7 +7,7 @@
 
 -behavior(blockchain_txn).
 
--include("pb/blockchain_txn_dc_coinbase_v1_pb.hrl").
+-include("../../pb/blockchain_txn_dc_coinbase_v1_pb.hrl").
 
 -export([
     new/2,

--- a/src/transactions/v1/blockchain_txn_dc_coinbase_v1.erl
+++ b/src/transactions/v1/blockchain_txn_dc_coinbase_v1.erl
@@ -17,7 +17,8 @@
     fee/1,
     is_valid/2,
     absorb/2,
-    sign/2
+    sign/2,
+    print/1
 ]).
 
 -ifdef(TEST).
@@ -34,6 +35,8 @@
 -spec new(libp2p_crypto:pubkey_bin(), non_neg_integer()) -> txn_dc_coinbase().
 new(Payee, Amount) ->
     #blockchain_txn_dc_coinbase_v1_pb{payee=Payee, amount=Amount}.
+
+
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -107,6 +110,17 @@ absorb(Txn, Chain) ->
     Payee = ?MODULE:payee(Txn),
     Amount = ?MODULE:amount(Txn),
     blockchain_ledger_v1:credit_dc(Payee, Amount, Ledger).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec print(txn_dc_coinbase()) -> iodata().
+print(undefined) -> <<"type=dc_coinbase, undefined">>;
+print(#blockchain_txn_dc_coinbase_v1_pb{
+         payee=Payee, amount=Amount}) ->
+    io_lib:format("type=dc_coinbase payee=~p, amount=~p",
+                  [Payee, Amount]).
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_dc_coinbase_v1.erl
+++ b/src/transactions/v1/blockchain_txn_dc_coinbase_v1.erl
@@ -28,6 +28,9 @@
 -type txn_dc_coinbase() :: #blockchain_txn_dc_coinbase_v1_pb{}.
 -export_type([txn_dc_coinbase/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -120,7 +123,7 @@ print(undefined) -> <<"type=dc_coinbase, undefined">>;
 print(#blockchain_txn_dc_coinbase_v1_pb{
          payee=Payee, amount=Amount}) ->
     io_lib:format("type=dc_coinbase payee=~p, amount=~p",
-                  [Payee, Amount]).
+                  [?TO_B58(Payee), Amount]).
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_gen_gateway_v1.erl
+++ b/src/transactions/v1/blockchain_txn_gen_gateway_v1.erl
@@ -19,7 +19,8 @@
     nonce/1,
     fee/1,
     is_valid/2,
-    absorb/2
+    absorb/2,
+    print/1
 ]).
 
 -ifdef(TEST).
@@ -46,6 +47,7 @@ new(Gateway, Owner, Location, Nonce) ->
                                       owner=Owner,
                                       location=L,
                                       nonce=Nonce}.
+
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -138,6 +140,18 @@ absorb(Txn, Chain) ->
                                      Location,
                                      Nonce,
                                      Ledger).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec print(txn_genesis_gateway()) -> iodata().
+print(undefined) -> <<"type=genesis_gateway, undefined">>;
+print(#blockchain_txn_gen_gateway_v1_pb{
+         gateway=Gateway, owner=Owner,
+         location=L, nonce=Nonce}) ->
+    io_lib:format("type=genesis_gateway gateway=~p, owner=~p, location=~p, nonce=~p",
+                  [Gateway, Owner, L, Nonce]).
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_gen_gateway_v1.erl
+++ b/src/transactions/v1/blockchain_txn_gen_gateway_v1.erl
@@ -7,7 +7,7 @@
 
 -behavior(blockchain_txn).
 
--include("pb/blockchain_txn_gen_gateway_v1_pb.hrl").
+-include("../../pb/blockchain_txn_gen_gateway_v1_pb.hrl").
 
 -export([
     new/4,

--- a/src/transactions/v1/blockchain_txn_gen_gateway_v1.erl
+++ b/src/transactions/v1/blockchain_txn_gen_gateway_v1.erl
@@ -30,6 +30,9 @@
 -type txn_genesis_gateway() :: #blockchain_txn_gen_gateway_v1_pb{}.
 -export_type([txn_genesis_gateway/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -151,7 +154,7 @@ print(#blockchain_txn_gen_gateway_v1_pb{
          gateway=Gateway, owner=Owner,
          location=L, nonce=Nonce}) ->
     io_lib:format("type=genesis_gateway gateway=~p, owner=~p, location=~p, nonce=~p",
-                  [Gateway, Owner, L, Nonce]).
+                  [?TO_ANIMAL_NAME(Gateway), ?TO_B58(Owner), L, Nonce]).
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_oui_v1.erl
+++ b/src/transactions/v1/blockchain_txn_oui_v1.erl
@@ -7,7 +7,7 @@
 
 -behavior(blockchain_txn).
 
--include("pb/blockchain_txn_oui_v1_pb.hrl").
+-include("../../pb/blockchain_txn_oui_v1_pb.hrl").
 
 -export([
     new/5, new/6,

--- a/src/transactions/v1/blockchain_txn_oui_v1.erl
+++ b/src/transactions/v1/blockchain_txn_oui_v1.erl
@@ -26,7 +26,8 @@
     is_valid_payer/1,
     is_valid/2,
     absorb/2,
-    calculate_staking_fee/1
+    calculate_staking_fee/1,
+    print/1
 ]).
 
 -ifdef(TEST).
@@ -65,6 +66,8 @@ new(Owner, Addresses, OUI, Payer, StakingFee, Fee) ->
         owner_signature= <<>>,
         payer_signature= <<>>
     }.
+
+
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -269,6 +272,20 @@ absorb(Txn, Chain) ->
 -spec calculate_staking_fee(blockchain:blockchain()) -> non_neg_integer().
 calculate_staking_fee(_Chain) ->
     1.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec print(txn_oui()) -> iodata().
+print(undefined) -> <<"type=oui, undefined">>;
+print(#blockchain_txn_oui_v1_pb{owner=Owner, addresses=Addresses,
+                                oui=OUI, payer=Payer, staking_fee=StakingFee,
+                                fee=Fee, owner_signature= OS,
+                                payer_signature= PS}) ->
+    io_lib:format("type=oui, owner=~p, addresses=~p, oui=~p, payer=~p, staking_fee=~p, fee=~p, owner_signature=~p, payer_signature=~p",
+                  [Owner, Addresses, OUI, Payer, StakingFee, Fee, OS, PS]).
+
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions

--- a/src/transactions/v1/blockchain_txn_oui_v1.erl
+++ b/src/transactions/v1/blockchain_txn_oui_v1.erl
@@ -37,6 +37,9 @@
 -type txn_oui() :: #blockchain_txn_oui_v1_pb{}.
 -export_type([txn_oui/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -284,7 +287,7 @@ print(#blockchain_txn_oui_v1_pb{owner=Owner, addresses=Addresses,
                                 fee=Fee, owner_signature= OS,
                                 payer_signature= PS}) ->
     io_lib:format("type=oui, owner=~p, addresses=~p, oui=~p, payer=~p, staking_fee=~p, fee=~p, owner_signature=~p, payer_signature=~p",
-                  [Owner, Addresses, OUI, Payer, StakingFee, Fee, OS, PS]).
+                  [?TO_B58(Owner), Addresses, OUI, ?TO_B58(Payer), StakingFee, Fee, OS, PS]).
 
 
 %% ------------------------------------------------------------------

--- a/src/transactions/v1/blockchain_txn_payment_v1.erl
+++ b/src/transactions/v1/blockchain_txn_payment_v1.erl
@@ -20,7 +20,8 @@
     signature/1,
     sign/2,
     is_valid/2,
-    absorb/2
+    absorb/2,
+    print/1
 ]).
 
 -ifdef(TEST).
@@ -45,6 +46,7 @@ new(Payer, Recipient, Amount, Fee, Nonce) ->
         nonce=Nonce,
         signature = <<>>
     }.
+
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -179,7 +181,18 @@ absorb(Txn, Chain) ->
                     blockchain_ledger_v1:credit_account(Payee, Amount, Ledger)
             end
     end.
-    
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec print(txn_payment()) -> iodata().
+print(undefined) -> <<"type=payment, undefined">>;
+print(#blockchain_txn_payment_v1_pb{payer=Payer, payee=Recipient, amount=Amount,
+                                    fee=Fee, nonce=Nonce, signature = S }) ->
+    io_lib:format("type=payment, payer=~p, payee=~p, amount=~p, fee=~p, nonce=~p, signature=~p",
+                  [Payer, Recipient, Amount, Fee, Nonce, S]).
+
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_payment_v1.erl
+++ b/src/transactions/v1/blockchain_txn_payment_v1.erl
@@ -31,6 +31,9 @@
 -type txn_payment() :: #blockchain_txn_payment_v1_pb{}.
 -export_type([txn_payment/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -191,7 +194,7 @@ print(undefined) -> <<"type=payment, undefined">>;
 print(#blockchain_txn_payment_v1_pb{payer=Payer, payee=Recipient, amount=Amount,
                                     fee=Fee, nonce=Nonce, signature = S }) ->
     io_lib:format("type=payment, payer=~p, payee=~p, amount=~p, fee=~p, nonce=~p, signature=~p",
-                  [Payer, Recipient, Amount, Fee, Nonce, S]).
+                  [?TO_B58(Payer), ?TO_B58(Recipient), Amount, Fee, Nonce, S]).
 
 
 %% ------------------------------------------------------------------

--- a/src/transactions/v1/blockchain_txn_payment_v1.erl
+++ b/src/transactions/v1/blockchain_txn_payment_v1.erl
@@ -7,7 +7,7 @@
 
 -behavior(blockchain_txn).
 
--include("pb/blockchain_txn_payment_v1_pb.hrl").
+-include("../../pb/blockchain_txn_payment_v1_pb.hrl").
 
 -export([
     new/5,

--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -38,6 +38,9 @@
 
 -export_type([txn_poc_receipts/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -790,9 +793,9 @@ print(#blockchain_txn_poc_receipts_v1_pb{
          path=Path
         }=Txn) ->
     io_lib:format("type=poc_receipts_v1 hash=~p challenger=~p onion=~p path:\n\t~s",
-                  [libp2p_crypto:bin_to_b58(?MODULE:hash(Txn)),
-                   element(2, erl_angry_purple_tiger:animal_name(libp2p_crypto:bin_to_b58(Challenger))),
-                   libp2p_crypto:bin_to_b58(OnionKeyHash),
+                  [?TO_B58(?MODULE:hash(Txn),
+                   ?TO_ANIMAL_NAME(Challenger),
+                   ?TO_B58(OnionKeyHash),
                    print_path(Path)]).
 
 print_path(Path) ->

--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -6,7 +6,7 @@
 
 -behavior(blockchain_txn).
 
--include("pb/blockchain_txn_poc_receipts_v1_pb.hrl").
+-include("../../pb/blockchain_txn_poc_receipts_v1_pb.hrl").
 -include("blockchain_vars.hrl").
 
 -export([
@@ -793,7 +793,7 @@ print(#blockchain_txn_poc_receipts_v1_pb{
          path=Path
         }=Txn) ->
     io_lib:format("type=poc_receipts_v1 hash=~p challenger=~p onion=~p path:\n\t~s",
-                  [?TO_B58(?MODULE:hash(Txn),
+                  [?TO_B58(?MODULE:hash(Txn)),
                    ?TO_ANIMAL_NAME(Challenger),
                    ?TO_B58(OnionKeyHash),
                    print_path(Path)]).

--- a/src/transactions/v1/blockchain_txn_poc_request_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_request_v1.erl
@@ -7,7 +7,7 @@
 
 -behavior(blockchain_txn).
 
--include("pb/blockchain_txn_poc_request_v1_pb.hrl").
+-include("../../pb/blockchain_txn_poc_request_v1_pb.hrl").
 -include("blockchain_vars.hrl").
 
 -export([

--- a/src/transactions/v1/blockchain_txn_poc_request_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_request_v1.erl
@@ -23,7 +23,8 @@
     fee/1,
     sign/2,
     is_valid/2,
-    absorb/2
+    absorb/2,
+    print/1
 ]).
 
 -ifdef(TEST).
@@ -200,6 +201,19 @@ absorb(Txn, Chain) ->
         {error, _Reason}=Error ->
             Error
     end.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec print(txn_poc_request()) -> iodata().
+print(undefined) -> <<"type=poc_request, undefined">>;
+print(#blockchain_txn_poc_request_v1_pb{challenger=Challenger, secret_hash=SecretHash,
+                                        onion_key_hash=OnionKeyHash, block_hash=BlockHash,
+                                        fee=Fee, signature = Sig, version = Version }) ->
+    %% XXX: Should we really print the secret hash in a log???
+    io_lib:format("type=poc_request challenger=~p, secret_hash=~p, onion_key_hash=~p, block_hash=~p, fee=~p, signature=~p, version=~p",
+                  [Challenger, SecretHash, OnionKeyHash, BlockHash, Fee, Sig, Version]).
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_poc_request_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_request_v1.erl
@@ -34,6 +34,9 @@
 -type txn_poc_request() :: #blockchain_txn_poc_request_v1_pb{}.
 -export_type([txn_poc_request/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -213,7 +216,7 @@ print(#blockchain_txn_poc_request_v1_pb{challenger=Challenger, secret_hash=Secre
                                         fee=Fee, signature = Sig, version = Version }) ->
     %% XXX: Should we really print the secret hash in a log???
     io_lib:format("type=poc_request challenger=~p, secret_hash=~p, onion_key_hash=~p, block_hash=~p, fee=~p, signature=~p, version=~p",
-                  [Challenger, SecretHash, OnionKeyHash, BlockHash, Fee, Sig, Version]).
+                  [?TO_ANIMAL_NAME(Challenger), SecretHash, ?TO_B58(OnionKeyHash), BlockHash, Fee, Sig, Version]).
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_redeem_htlc_v1.erl
+++ b/src/transactions/v1/blockchain_txn_redeem_htlc_v1.erl
@@ -30,6 +30,9 @@
 -type txn_redeem_htlc() :: #blockchain_txn_redeem_htlc_v1_pb{}.
 -export_type([txn_redeem_htlc/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -210,7 +213,7 @@ print(#blockchain_txn_redeem_htlc_v1_pb{payee=Payee, address=Address,
                                         preimage=PreImage, fee=Fee,
                                         signature=Sig}) ->
     io_lib:format("type=redeem_htlc payee=~p, address=~p, preimage=~p, fee=~p, signature=~p",
-                  [Payee, Address, PreImage, Fee, Sig]).
+                  [?TO_B58(Payee), Address, PreImage, Fee, Sig]).
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_redeem_htlc_v1.erl
+++ b/src/transactions/v1/blockchain_txn_redeem_htlc_v1.erl
@@ -19,7 +19,8 @@
     signature/1,
     sign/2,
     is_valid/2,
-    absorb/2
+    absorb/2,
+    print/1
 ]).
 
 -ifdef(TEST).
@@ -198,6 +199,18 @@ absorb(Txn, Chain) ->
                     blockchain_ledger_v1:redeem_htlc(Address, Payee, Ledger)
             end
     end.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec print(txn_redeem_htlc()) -> iodata().
+print(undefined) -> <<"type=redeem_htlc, undefined">>;
+print(#blockchain_txn_redeem_htlc_v1_pb{payee=Payee, address=Address,
+                                        preimage=PreImage, fee=Fee,
+                                        signature=Sig}) ->
+    io_lib:format("type=redeem_htlc payee=~p, address=~p, preimage=~p, fee=~p, signature=~p",
+                  [Payee, Address, PreImage, Fee, Sig]).
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_redeem_htlc_v1.erl
+++ b/src/transactions/v1/blockchain_txn_redeem_htlc_v1.erl
@@ -7,7 +7,7 @@
 
 -behavior(blockchain_txn).
 
--include("pb/blockchain_txn_redeem_htlc_v1_pb.hrl").
+-include("../../pb/blockchain_txn_redeem_htlc_v1_pb.hrl").
 
 -export([
     new/4,

--- a/src/transactions/v1/blockchain_txn_reward_v1.erl
+++ b/src/transactions/v1/blockchain_txn_reward_v1.erl
@@ -13,7 +13,8 @@
     gateway/1,
     amount/1,
     type/1,
-    is_valid/1
+    is_valid/1,
+    print/1
 ]).
 
 -ifdef(TEST).
@@ -98,6 +99,17 @@ is_valid(#blockchain_txn_reward_v1_pb{account=Account, gateway=Gateway,
     (erlang:is_binary(Gateway) orelse Gateway == undefined) andalso
     Amount > 0 andalso
     lists:member(Type, ?TYPES).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec print(reward()) -> iodata().
+print(undefined) -> <<"type=reward undefined">>;
+print(#blockchain_txn_reward_v1_pb{account=Account, gateway=Gateway,
+                                   amount=Amount, type=Type}) ->
+    io_lib:format("type=reward account=~p, gateway=~p, amount=~p, type=~p",
+                  [Account, Gateway, Amount, Type]).
 
 
 

--- a/src/transactions/v1/blockchain_txn_reward_v1.erl
+++ b/src/transactions/v1/blockchain_txn_reward_v1.erl
@@ -28,6 +28,8 @@
 -export_type([reward/0, rewards/0, type/0]).
 
 -define(TYPES, [securities, data_credits, poc_challengees, poc_challengers, poc_witnesses, consensus]).
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -109,7 +111,7 @@ print(undefined) -> <<"type=reward undefined">>;
 print(#blockchain_txn_reward_v1_pb{account=Account, gateway=Gateway,
                                    amount=Amount, type=Type}) ->
     io_lib:format("type=reward account=~p, gateway=~p, amount=~p, type=~p",
-                  [Account, Gateway, Amount, Type]).
+                  [?TO_B58(Account), ?TO_ANIMAL_NAME(Gateway), Amount, Type]).
 
 
 

--- a/src/transactions/v1/blockchain_txn_reward_v1.erl
+++ b/src/transactions/v1/blockchain_txn_reward_v1.erl
@@ -4,7 +4,7 @@
 %%%-------------------------------------------------------------------
 -module(blockchain_txn_reward_v1).
 
--include("pb/blockchain_txn_rewards_v1_pb.hrl").
+-include("../../pb/blockchain_txn_rewards_v1_pb.hrl").
 
 -export([
     new/4,

--- a/src/transactions/v1/blockchain_txn_rewards_v1.erl
+++ b/src/transactions/v1/blockchain_txn_rewards_v1.erl
@@ -39,6 +39,9 @@
 -type txn_rewards() :: #blockchain_txn_rewards_v1_pb{}.
 -export_type([txn_rewards/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end

--- a/src/transactions/v1/blockchain_txn_rewards_v1.erl
+++ b/src/transactions/v1/blockchain_txn_rewards_v1.erl
@@ -20,7 +20,8 @@
     fee/1,
     is_valid/2,
     absorb/2,
-    calculate_rewards/3
+    calculate_rewards/3,
+    print/1
 ]).
 
 -ifdef(TEST).
@@ -199,6 +200,17 @@ calculate_rewards(Start, End, Chain) ->
                     {error, already_existing_rewards}
             end
     end.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec print(txn_rewards()) -> iodata().
+print(undefined) -> <<"type=rewards undefined">>;
+print(#blockchain_txn_rewards_v1_pb{start_epoch=Start, end_epoch=End,
+                                    rewards=Rewards}) ->
+    io_lib:format("type=rewards start_epoch=~p end_epoch=~p rewards=~p",
+                  [Start, End, Rewards]).
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions

--- a/src/transactions/v1/blockchain_txn_rewards_v1.erl
+++ b/src/transactions/v1/blockchain_txn_rewards_v1.erl
@@ -8,7 +8,7 @@
 -behavior(blockchain_txn).
 
 -include("blockchain_vars.hrl").
--include("pb/blockchain_txn_rewards_v1_pb.hrl").
+-include("../../pb/blockchain_txn_rewards_v1_pb.hrl").
 
 -export([
     new/3,

--- a/src/transactions/v1/blockchain_txn_routing_v1.erl
+++ b/src/transactions/v1/blockchain_txn_routing_v1.erl
@@ -20,7 +20,8 @@
     signature/1,
     sign/2,
     is_valid/2,
-    absorb/2
+    absorb/2,
+    print/1
 ]).
 
 -ifdef(TEST).
@@ -177,6 +178,18 @@ absorb(Txn, Chain) ->
             Nonce = ?MODULE:nonce(Txn),
             blockchain_ledger_v1:add_routing(Owner, OUI, Addresses, Nonce, Ledger)
     end.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec print(txn_routing()) -> iodata().
+print(undefined) -> <<"type=routing undefined">>;
+print(#blockchain_txn_routing_v1_pb{oui=OUI, owner=Owner,
+                                    addresses=Addresses, fee=Fee,
+                                    nonce=Nonce, signature=Sig}) ->
+    io_lib:format("type=routing oui=~p owner=~p addresses=~p fee=~p nonce=~p signature=~p",
+                  [OUI, Owner, Addresses, Fee, Nonce, Sig]).
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions

--- a/src/transactions/v1/blockchain_txn_routing_v1.erl
+++ b/src/transactions/v1/blockchain_txn_routing_v1.erl
@@ -7,7 +7,7 @@
 
 -behavior(blockchain_txn).
 
--include("pb/blockchain_txn_routing_v1_pb.hrl").
+-include("../../pb/blockchain_txn_routing_v1_pb.hrl").
 
 -export([
     new/5,

--- a/src/transactions/v1/blockchain_txn_routing_v1.erl
+++ b/src/transactions/v1/blockchain_txn_routing_v1.erl
@@ -31,6 +31,9 @@
 -type txn_routing() :: #blockchain_txn_routing_v1_pb{}.
 -export_type([txn_routing/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -189,7 +192,7 @@ print(#blockchain_txn_routing_v1_pb{oui=OUI, owner=Owner,
                                     addresses=Addresses, fee=Fee,
                                     nonce=Nonce, signature=Sig}) ->
     io_lib:format("type=routing oui=~p owner=~p addresses=~p fee=~p nonce=~p signature=~p",
-                  [OUI, Owner, Addresses, Fee, Nonce, Sig]).
+                  [OUI, ?TO_B58(Owner), Addresses, Fee, Nonce, Sig]).
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions

--- a/src/transactions/v1/blockchain_txn_security_coinbase_v1.erl
+++ b/src/transactions/v1/blockchain_txn_security_coinbase_v1.erl
@@ -17,7 +17,8 @@
     fee/1,
     is_valid/2,
     absorb/2,
-    sign/2
+    sign/2,
+    print/1
 ]).
 
 -ifdef(TEST).
@@ -107,6 +108,16 @@ absorb(Txn, Chain) ->
     Payee = ?MODULE:payee(Txn),
     Amount = ?MODULE:amount(Txn),
     blockchain_ledger_v1:credit_security(Payee, Amount, Ledger).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec print(txn_security_coinbase()) -> iodata().
+print(undefined) -> <<"type=security_coinbase undefined">>;
+print(#blockchain_txn_security_coinbase_v1_pb{payee=Payee, amount=Amount}) ->
+    io_lib:format("type=security_coinbase payee=~p amount=~p",
+                  [Payee, Amount]).
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_security_coinbase_v1.erl
+++ b/src/transactions/v1/blockchain_txn_security_coinbase_v1.erl
@@ -28,6 +28,9 @@
 -type txn_security_coinbase() :: #blockchain_txn_security_coinbase_v1_pb{}.
 -export_type([txn_security_coinbase/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -117,7 +120,7 @@ absorb(Txn, Chain) ->
 print(undefined) -> <<"type=security_coinbase undefined">>;
 print(#blockchain_txn_security_coinbase_v1_pb{payee=Payee, amount=Amount}) ->
     io_lib:format("type=security_coinbase payee=~p amount=~p",
-                  [Payee, Amount]).
+                  [?TO_B58(Payee), Amount]).
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_security_coinbase_v1.erl
+++ b/src/transactions/v1/blockchain_txn_security_coinbase_v1.erl
@@ -7,7 +7,7 @@
 
 -behavior(blockchain_txn).
 
--include("pb/blockchain_txn_security_coinbase_v1_pb.hrl").
+-include("../../pb/blockchain_txn_security_coinbase_v1_pb.hrl").
 
 -export([
     new/2,

--- a/src/transactions/v1/blockchain_txn_security_exchange_v1.erl
+++ b/src/transactions/v1/blockchain_txn_security_exchange_v1.erl
@@ -31,6 +31,9 @@
 -type txn_security_exchange() :: #blockchain_txn_security_exchange_v1_pb{}.
 -export_type([txn_security_exchange/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -57,7 +60,7 @@ print(#blockchain_txn_security_exchange_v1_pb{payer=Payer, payee=Recipient,
                                               amount=Amount, fee=Fee,
                                               nonce=Nonce, signature = Sig}) ->
     io_lib:format("type=security_exchange payer=~p payee=~p amount=~p fee=~p nonce=~p signature=~p",
-                  [Payer, Recipient, Amount, Fee, Nonce, Sig]).
+                  [?TO_B58(Payer), ?TO_B58(Recipient), Amount, Fee, Nonce, Sig]).
 
 
 %%--------------------------------------------------------------------

--- a/src/transactions/v1/blockchain_txn_security_exchange_v1.erl
+++ b/src/transactions/v1/blockchain_txn_security_exchange_v1.erl
@@ -7,7 +7,7 @@
 
 -behavior(blockchain_txn).
 
--include("pb/blockchain_txn_security_exchange_v1_pb.hrl").
+-include("../../pb/blockchain_txn_security_exchange_v1_pb.hrl").
 
 -export([
     new/5,

--- a/src/transactions/v1/blockchain_txn_security_exchange_v1.erl
+++ b/src/transactions/v1/blockchain_txn_security_exchange_v1.erl
@@ -20,7 +20,8 @@
     signature/1,
     sign/2,
     is_valid/2,
-    absorb/2
+    absorb/2,
+    print/1
 ]).
 
 -ifdef(TEST).
@@ -45,6 +46,19 @@ new(Payer, Recipient, Amount, Fee, Nonce) ->
         nonce=Nonce,
         signature = <<>>
     }.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec print(txn_security_exchange()) -> iodata().
+print(undefined) -> <<"type=security_exchange undefined">>;
+print(#blockchain_txn_security_exchange_v1_pb{payer=Payer, payee=Recipient,
+                                              amount=Amount, fee=Fee,
+                                              nonce=Nonce, signature = Sig}) ->
+    io_lib:format("type=security_exchange payer=~p payee=~p amount=~p fee=~p nonce=~p signature=~p",
+                  [Payer, Recipient, Amount, Fee, Nonce, Sig]).
+
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/src/transactions/v1/blockchain_txn_token_burn_exchange_rate_v1.erl
+++ b/src/transactions/v1/blockchain_txn_token_burn_exchange_rate_v1.erl
@@ -17,7 +17,8 @@
     fee/1,
     is_valid/2,
     absorb/2,
-    sign/2
+    sign/2,
+    print/1
 ]).
 
 -ifdef(TEST).
@@ -93,6 +94,15 @@ absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Rate = ?MODULE:rate(Txn),
     blockchain_ledger_v1:token_burn_exchange_rate(Rate, Ledger).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec print(txn_token_burn_exchange_rate()) -> iodata().
+print(undefined) -> <<"type=burn_exchange_rate undefined">>;
+print(#blockchain_txn_token_burn_exchange_rate_v1_pb{rate=Amount}) ->
+    io_lib:format("type=burn_exchange_rate rate=~p", [Amount]).
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_token_burn_exchange_rate_v1.erl
+++ b/src/transactions/v1/blockchain_txn_token_burn_exchange_rate_v1.erl
@@ -28,6 +28,9 @@
 -type txn_token_burn_exchange_rate() :: #blockchain_txn_token_burn_exchange_rate_v1_pb{}.
 -export_type([txn_token_burn_exchange_rate/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end

--- a/src/transactions/v1/blockchain_txn_token_burn_exchange_rate_v1.erl
+++ b/src/transactions/v1/blockchain_txn_token_burn_exchange_rate_v1.erl
@@ -8,7 +8,7 @@
 
 -behavior(blockchain_txn).
 
--include("pb/blockchain_txn_token_burn_exchange_rate_v1_pb.hrl").
+-include("../../pb/blockchain_txn_token_burn_exchange_rate_v1_pb.hrl").
 
 -export([
     new/1,

--- a/src/transactions/v1/blockchain_txn_token_burn_v1.erl
+++ b/src/transactions/v1/blockchain_txn_token_burn_v1.erl
@@ -33,6 +33,9 @@
 -type txn_token_burn() :: #blockchain_txn_token_burn_v1_pb{}.
 -export_type([txn_token_burn/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -69,7 +72,7 @@ print(#blockchain_txn_token_burn_v1_pb{type=Type, payer=Payer, key=Key,
                                        amount=Amount, nonce=Nonce,
                                        signature=Sig}) ->
   io_lib:format("type=token_burn type=~p payer=~p key=~p amount=~p nonce=~p signature=~p",
-                [Type, Payer, Key, Amount, Nonce, Sig]).
+                [Type, ?TO_B58(Payer), Key, Amount, Nonce, Sig]).
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/src/transactions/v1/blockchain_txn_token_burn_v1.erl
+++ b/src/transactions/v1/blockchain_txn_token_burn_v1.erl
@@ -7,7 +7,7 @@
 
 -behavior(blockchain_txn).
 
--include("pb/blockchain_txn_token_burn_v1_pb.hrl").
+-include("../../pb/blockchain_txn_token_burn_v1_pb.hrl").
 -include("blockchain_vars.hrl").
 
   -export([

--- a/src/transactions/v1/blockchain_txn_token_burn_v1.erl
+++ b/src/transactions/v1/blockchain_txn_token_burn_v1.erl
@@ -22,7 +22,8 @@
     signature/1,
     sign/2,
     is_valid/2,
-    absorb/2
+    absorb/2,
+    print/1
 ]).
 
 -ifdef(TEST).
@@ -57,6 +58,18 @@ new(Payer, Amount, Nonce, Key) ->
         nonce=Nonce,
         signature = <<>>
     }.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec print(txn_token_burn()) -> iodata().
+print(undefined) -> <<"type=token_burn undefined">>;
+print(#blockchain_txn_token_burn_v1_pb{type=Type, payer=Payer, key=Key,
+                                       amount=Amount, nonce=Nonce,
+                                       signature=Sig}) ->
+  io_lib:format("type=token_burn type=~p payer=~p key=~p amount=~p nonce=~p signature=~p",
+                [Type, Payer, Key, Amount, Nonce, Sig]).
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -7,7 +7,7 @@
 
 -behavior(blockchain_txn).
 
--include("pb/blockchain_txn_vars_v1_pb.hrl").
+-include("../../pb/blockchain_txn_vars_v1_pb.hrl").
 -include("blockchain_vars.hrl").
 
 -export([

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -26,7 +26,8 @@
          nonce/1,
          absorb/2,
          rescue_absorb/2,
-         sign/2
+         sign/2,
+         print/1
         ]).
 
 %% helper API
@@ -92,6 +93,7 @@ new(Vars, Nonce, Optional) ->
                                unsets = encode_unsets(Unsets),
                                cancels = Cancels,
                                nonce = Nonce}.
+
 
 encode_vars(Vars) ->
     V = maps:to_list(Vars),
@@ -467,6 +469,15 @@ sum_higher(Target, [{Vers, Pct}| T], Sum) ->
 
 decode_unsets(Unsets) ->
     lists:map(fun(U) -> binary_to_atom(U, utf8) end, Unsets).
+
+-spec print(txn_vars()) -> iodata().
+print(undefined) -> <<"type=vars undefined">>;
+print(#blockchain_txn_vars_v1_pb{vars = Vars, version_predicate = VersionP,
+                                 master_key = MasterKey, key_proof = KeyProof,
+                                 unsets = Unsets, cancels = Cancels,
+                                 nonce = Nonce}) ->
+    io_lib:format("type=vars vars=~p version_predicate=~p master_key=~p key_proof=~p unsets=~p cancels=~p nonce=~p",
+                  [Vars, VersionP, MasterKey, KeyProof, Unsets, Cancels, Nonce]).
 
 %%%
 %%% Helper API

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -55,6 +55,9 @@
 -type txn_vars() :: #blockchain_txn_vars_v1_pb{}.
 -export_type([txn_vars/0]).
 
+-define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(TO_ANIMAL_NAME(X), element(2, libp2p_crypto:bin_to_b58(erl_angry_purple_tiger:animal_name(X)))).
+
 %% message var_v1 {
 %%     string type = 1;
 %%     bytes value = 2;


### PR DESCRIPTION
Problems to solve:
* The eqc plugin should be deprecated in favor of upstream
* While there are some `print/1` functions in txn types, they are not fully implemented
* Find locations in the code where transactions are logged "naked" convert those calls to use the shiny new `print` function.

Solutions:
* Point eqc plugin to upstream
* Implement `print/1` for the rest of the transaction types.
* Update log directives to call the `print` function.

[story](https://app.clubhouse.io/hlm/story/5576/add-print-callback-to-all-transaction-types)