### PR TITLE
Use upstream eqc plugin

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -53,7 +53,7 @@
  [
   rebar3_gpb_plugin,
   covertool,
-  {rebar3_eqc, {git, "https://github.com/Vagabond/rebar3-eqc-plugin", {branch, "master"}}}
+  {rebar3_eqc, "1.3.0"}
  ]}.
 
 {provider_hooks, [


### PR DESCRIPTION
Since we got the cover output changes merged upstream, we should use the upstream plugin.