### PR TITLE
Add blockchain:analyze/1 and blockchain:repair/1

### DIFF
--- a/scripts/extensions/repair
+++ b/scripts/extensions/repair
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ -t 0 ] ; then
+    export CLIQUE_COLUMNS=`stty size 2>/dev/null | cut -d ' ' -f 2`
+fi
+relx_nodetool rpc blockchain_console command repair $@
+exit $?

--- a/src/cli/blockchain_cli_registry.erl
+++ b/src/cli/blockchain_cli_registry.erl
@@ -3,6 +3,7 @@
 -define(CLI_MODULES, [
                       blockchain_cli_peer,
                       blockchain_cli_ledger,
+                      blockchain_cli_repair,
                       blockchain_cli_trace,
                       blockchain_cli_txn
                      ]).

--- a/src/cli/blockchain_cli_repair.erl
+++ b/src/cli/blockchain_cli_repair.erl
@@ -1,0 +1,227 @@
+%%%-------------------------------------------------------------------
+%% @doc
+%% == Blockchain CLI Repair ==
+%% @end
+%%%-------------------------------------------------------------------
+-module(blockchain_cli_repair).
+
+-behavior(clique_handler).
+
+-export([register_cli/0]).
+
+-include("blockchain.hrl").
+
+register_cli() ->
+    register_all_usage(), register_all_cmds().
+
+register_all_usage() ->
+    lists:foreach(fun(Args) ->
+                          apply(clique, register_usage, Args)
+                  end,
+                  [
+                   repair_sync_pause_usage(),
+                   repair_sync_cancel_usage(),
+                   repair_sync_resume_usage(),
+                   repair_sync_state_usage(),
+                   repair_analyze_usage(),
+                   repair_repair_usage(),
+                   repair_usage()
+                  ]).
+
+register_all_cmds() ->
+    lists:foreach(fun(Cmds) ->
+                          [apply(clique, register_command, Cmd) || Cmd <- Cmds]
+                  end,
+                  [
+                   repair_sync_pause_cmd(),
+                   repair_sync_cancel_cmd(),
+                   repair_sync_resume_cmd(),
+                   repair_sync_state_cmd(),
+                   repair_analyze_cmd(),
+                   repair_repair_cmd(),
+                   repair_cmd()
+                  ]).
+
+%%--------------------------------------------------------------------
+%% repair
+%%--------------------------------------------------------------------
+repair_usage() ->
+    [["repair"],
+     ["blockchain repair commands\n\n",
+      "  repair sync_pause     - Temporarily pause transaction sync\n",
+      "  repair sync_cancel    - Cancel any in-progress transaction sync.\n",
+      "  repair sync_resume    - Resume any paused transaction sync.\n",
+      "  repair sync_state     - Show current sync state.\n",
+      "  repair analyze        - Display errors in the current blockchain state.\n",
+      "  repair repair         - Attempt to repair errors in blockchain state.\n"
+     ]
+    ].
+
+repair_cmd() ->
+    [
+     [["repair"], [], [], fun(_, _, _) -> usage end]
+    ].
+
+%%--------------------------------------------------------------------
+%% repair sync_pause
+%%--------------------------------------------------------------------
+repair_sync_pause_cmd() ->
+    [
+     [["repair", "sync_pause"], [], [], fun repair_sync_pause/3]
+    ].
+
+repair_sync_pause_usage() ->
+    [["repair", "sync_pause"],
+     ["repair sync_pause\n\n",
+      "  Temporarily suspend sync.\n"
+     ]
+    ].
+
+repair_sync_pause(["repair", "sync_pause"], [], []) ->
+    case blockchain_worker:pause_sync() of
+        ok ->
+            [clique_status:text("ok")];
+        _Other ->
+            [clique_status:text("error")]
+    end;
+repair_sync_pause([], [], []) ->
+    usage.
+
+%%--------------------------------------------------------------------
+%% repair sync_cancel
+%%--------------------------------------------------------------------
+repair_sync_cancel_cmd() ->
+    [
+     [["repair", "sync_cancel"], [], [], fun repair_sync_cancel/3]
+    ].
+
+repair_sync_cancel_usage() ->
+    [["repair", "sync_cancel"],
+     ["repair sync_cancel\n\n",
+      "  Cancel current sync.\n"
+     ]
+    ].
+
+repair_sync_cancel(["repair", "sync_cancel"], [], []) ->
+    case blockchain_worker:cancel_sync() of
+        ok ->
+            [clique_status:text("ok")];
+        _Other ->
+            [clique_status:text("error")]
+    end;
+repair_sync_cancel([], [], []) ->
+    usage.
+
+%%--------------------------------------------------------------------
+%% repair sync_resume
+%%--------------------------------------------------------------------
+repair_sync_resume_cmd() ->
+    [
+     [["repair", "sync_resume"], [], [], fun repair_sync_resume/3]
+    ].
+
+repair_sync_resume_usage() ->
+    [["repair", "sync_resume"],
+     ["repair sync_resume\n\n",
+      "  Resume sync.\n"
+     ]
+    ].
+
+repair_sync_resume(["repair", "sync_resume"], [], []) ->
+    case blockchain_worker:sync() of
+        ok ->
+            [clique_status:text("ok")];
+        _Other ->
+            [clique_status:text("error")]
+    end;
+repair_sync_resume([], [], []) ->
+    usage.
+
+%%--------------------------------------------------------------------
+%% repair sync_state
+%%--------------------------------------------------------------------
+repair_sync_state_cmd() ->
+    [
+     [["repair", "sync_state"], [], [], fun repair_sync_state/3]
+    ].
+
+repair_sync_state_usage() ->
+    [["repair", "sync_state"],
+     ["repair sync_state\n\n",
+      "  Display current sync state (paused or active).\n"
+     ]
+    ].
+
+repair_sync_state(["repair", "sync_state"], [], []) ->
+    case blockchain_worker:sync_paused() of
+        true ->
+            [clique_status:text("sync paused")];
+        false ->
+            [clique_status:text("sync active")]
+    end;
+repair_sync_state([], [], []) ->
+    usage.
+
+%%--------------------------------------------------------------------
+%% repair analyze
+%%--------------------------------------------------------------------
+repair_analyze_cmd() ->
+    [
+     [["repair", "analyze"], [], [], fun repair_analyze/3]
+    ].
+
+repair_analyze_usage() ->
+    [["repair", "analyze"],
+     ["repair analyze\n\n",
+      "  Display inconsistencies between current and lagging ledger states.\n"
+     ]
+    ].
+
+repair_analyze(["repair", "analyze"], [], []) ->
+    case blockchain_worker:sync_paused() of
+        true ->
+            BlkChain = blockchain_worker:blockchain(),
+            case blockchain:analyze(BlkChain) of
+                ok ->
+                    [clique_status:text("no errors detected")];
+                {error, Error} ->
+                    Fmt = io_lib:format("error: ~p~n", [Error]),
+                    [clique_status:alert([clique_status:text(Fmt)])]
+            end;
+        false ->
+            [clique_status:alert([clique_status:text("please pause sync first")])]
+    end;
+repair_analyze([], [], []) ->
+    usage.
+
+%%--------------------------------------------------------------------
+%% repair repair
+%%--------------------------------------------------------------------
+repair_repair_cmd() ->
+    [
+     [["repair", "repair"], [], [], fun repair_repair/3]
+    ].
+
+repair_repair_usage() ->
+    [["repair", "repair"],
+     ["repair repair\n\n",
+      "  Attempt a repair of an inconsistency between current and lagging ledger states.\n"
+     ]
+    ].
+
+repair_repair(["repair", "repair"], [], []) ->
+    case blockchain_worker:sync_paused() of
+        true ->
+            BlkChain = blockchain_worker:blockchain(),
+            case blockchain:repair(BlkChain) of
+                ok ->
+                    [clique_status:text("ok")];
+                Other ->
+                    Fmt = io_lib:format("error: ~p~n", [Other]),
+                    [clique_status:alert([clique_status:text(Fmt)])]
+            end;
+        false ->
+            [clique_status:alert([clique_status:text("please pause sync first")])]
+    end;
+repair_repair([], [], []) ->
+    usage.

--- a/test/assume_valid_SUITE.erl
+++ b/test/assume_valid_SUITE.erl
@@ -244,8 +244,7 @@ blockchain_crash_while_absorbing(_Config) ->
     {ok, Chain2} = blockchain:new(SimDir, Genesis, {blockchain_block:hash_block(LastBlock), blockchain_block:height(LastBlock)}),
     %% the sync is done in a background process, so wait for it to complete
     ok = blockchain_ct_utils:wait_until(fun() -> {ok, 101} =:= blockchain:sync_height(Chain2) end),
-    %% the actual height should be the same
-    ?assertEqual({ok, 101}, blockchain:height(Chain2)),
+    ok = blockchain_ct_utils:wait_until(fun() -> {ok, 101} =:= blockchain:height(Chain2) end),
     ?assertEqual(blockchain:sync_hash(Chain2), {ok, blockchain_block:hash_block(LastBlock)}),
     ?assertEqual(blockchain:head_hash(Chain2), {ok, blockchain_block:hash_block(LastBlock)}),
     ok.


### PR DESCRIPTION
There are many things that go wrong when syncing is interrupted by some
kind of hard power down (OTAs or unplugging). This patch intends to try
to add some repair facilities for the common scenarios observed during
sync corruption.

The common sync failures are:

* Missing blocks
* Ledger inconsistency

To detect these failures several checks have been added:

* Check the delayed ledger is the right number of blocks behind
* Check the blockchain and the ledger agree on the blockchain height
* Check the delayed ledger advanced to the leading ledger fingerprints
  the same as the leading ledger

And several repair tools have been added:

* Advance the lagging ledger
* Re-sync a missing block (only gap one block wide is doable right now)
* Apply all the differences from an advanced lagging ledger to the
  leading ledger

To analyze the problems, use blockchain:analyze. Analyze will report a
single problem at a time.

To repair the current analyzed problem (if it is one we can repair), use
blockchain:repair. It will only repair a single problem at a time. It is
recommended you use analyze after each repair to check if there are more
problems, and to repair them if needed.