### PR TITLE
Repair CLI interface

### DIFF
--- a/scripts/extensions/repair
+++ b/scripts/extensions/repair
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ -t 0 ] ; then
+    export CLIQUE_COLUMNS=`stty size 2>/dev/null | cut -d ' ' -f 2`
+fi
+relx_nodetool rpc blockchain_console command repair $@
+exit $?

--- a/src/cli/blockchain_cli_registry.erl
+++ b/src/cli/blockchain_cli_registry.erl
@@ -3,6 +3,7 @@
 -define(CLI_MODULES, [
                       blockchain_cli_peer,
                       blockchain_cli_ledger,
+                      blockchain_cli_repair,
                       blockchain_cli_trace,
                       blockchain_cli_txn
                      ]).

--- a/src/cli/blockchain_cli_repair.erl
+++ b/src/cli/blockchain_cli_repair.erl
@@ -1,0 +1,217 @@
+%%%-------------------------------------------------------------------
+%% @doc
+%% == Blockchain CLI Repair ==
+%% @end
+%%%-------------------------------------------------------------------
+-module(blockchain_cli_repair).
+
+-behavior(clique_handler).
+
+-export([register_cli/0]).
+
+-include("blockchain.hrl").
+
+register_cli() ->
+    register_all_usage(), register_all_cmds().
+
+register_all_usage() ->
+    lists:foreach(fun(Args) ->
+                          apply(clique, register_usage, Args)
+                  end,
+                  [
+                   repair_sync_pause_usage(),
+                   repair_sync_cancel_usage(),
+                   repair_sync_resume_usage(),
+                   repair_sync_state_usage(),
+                   repair_analyze_usage(),
+                   repair_repair_usage(),
+                   repair_usage()
+                  ]).
+
+register_all_cmds() ->
+    lists:foreach(fun(Cmds) ->
+                          [apply(clique, register_command, Cmd) || Cmd <- Cmds]
+                  end,
+                  [
+                   repair_sync_pause_cmd(),
+                   repair_sync_cancel_cmd(),
+                   repair_sync_resume_cmd(),
+                   repair_sync_state_cmd(),
+                   repair_analyze_cmd(),
+                   repair_repair_cmd(),
+                   repair_cmd()
+                  ]).
+
+%%--------------------------------------------------------------------
+%% repair
+%%--------------------------------------------------------------------
+repair_usage() ->
+    [["repair"],
+     ["blockchain repair commands\n\n",
+      "  repair sync_pause     - Temporarily pause transaction sync\n",
+      "  repair sync_cancel    - Cancel any in-progress transaction sync.\n",
+      "  repair sync_resume    - Resume any paused transaction sync.\n",
+      "  repair sync_state     - Show current sync state.\n",
+      "  repair analyze        - Display errors in the current blockchain state.\n",
+      "  repair repair         - Attempt to repair errors in blockchain state.\n"
+     ]
+    ].
+
+repair_cmd() ->
+    [
+     [["repair"], [], [], fun(_, _, _) -> usage end]
+    ].
+
+%%--------------------------------------------------------------------
+%% repair sync_pause
+%%--------------------------------------------------------------------
+repair_sync_pause_cmd() ->
+    [
+     [["repair", "sync_pause"], [], [], fun repair_sync_pause/3]
+    ].
+
+repair_sync_pause_usage() ->
+    [["repair", "sync_pause"],
+     ["repair sync_pause\n\n",
+      "  Temporarily suspend sync.\n"
+     ]
+    ].
+
+repair_sync_pause(["repair", "sync_pause"], [], []) ->
+    case blockchain_worker:pause_sync() of
+        ok ->
+            [clique_status:text("ok")];
+        _Other ->
+            [clique_status:text("error")]
+    end;
+repair_sync_pause([], [], []) ->
+    usage.
+
+%%--------------------------------------------------------------------
+%% repair sync_cancel
+%%--------------------------------------------------------------------
+repair_sync_cancel_cmd() ->
+    [
+     [["repair", "sync_cancel"], [], [], fun repair_sync_cancel/3]
+    ].
+
+repair_sync_cancel_usage() ->
+    [["repair", "sync_cancel"],
+     ["repair sync_cancel\n\n",
+      "  Cancel current sync.\n"
+     ]
+    ].
+
+repair_sync_cancel(["repair", "sync_cancel"], [], []) ->
+    case blockchain_worker:cancel_sync() of
+        ok ->
+            [clique_status:text("ok")];
+        _Other ->
+            [clique_status:text("error")]
+    end;
+repair_sync_cancel([], [], []) ->
+    usage.
+
+%%--------------------------------------------------------------------
+%% repair sync_resume
+%%--------------------------------------------------------------------
+repair_sync_resume_cmd() ->
+    [
+     [["repair", "sync_resume"], [], [], fun repair_sync_resume/3]
+    ].
+
+repair_sync_resume_usage() ->
+    [["repair", "sync_resume"],
+     ["repair sync_resume\n\n",
+      "  Resume sync.\n"
+     ]
+    ].
+
+repair_sync_resume(["repair", "sync_resume"], [], []) ->
+    case blockchain_worker:sync() of
+        ok ->
+            [clique_status:text("ok")];
+        _Other ->
+            [clique_error:text("error")]
+    end;
+repair_sync_resume([], [], []) ->
+    usage.
+
+%%--------------------------------------------------------------------
+%% repair sync_state
+%%--------------------------------------------------------------------
+repair_sync_state_cmd() ->
+    [
+     [["repair", "sync_state"], [], [], fun repair_sync_state/3]
+    ].
+
+repair_sync_state_usage() ->
+    [["repair", "sync_state"],
+     ["repair sync_state\n\n",
+      "  Display current sync state (paused or active).\n"
+     ]
+    ].
+
+repair_sync_state(["repair", "sync_state"], [], []) ->
+    case blockchain_worker:sync_paused() of
+        true ->
+            [clique_status:text("sync paused")];
+        false ->
+            [clique_status:text("sync active")]
+    end;
+repair_sync_state([], [], []) ->
+    usage.
+
+%%--------------------------------------------------------------------
+%% repair analyze
+%%--------------------------------------------------------------------
+repair_analyze_cmd() ->
+    [
+     [["repair", "analyze"], [], [], fun repair_analyze/3]
+    ].
+
+repair_analyze_usage() ->
+    [["repair", "analyze"],
+     ["repair analyze\n\n",
+      "  Display inconsistencies between current and lagging ledger states.\n"
+     ]
+    ].
+
+repair_analyze(["repair", "analyze"], [], []) ->
+    BlkChain = blockchain_worker:blockchain(),
+    case blockchain:analyze(BlkChain) of
+        ok ->
+            [clique_status:text("no errors detected")];
+        {error, Error} ->
+            Fmt = io_lib:format("error: ~p~n", [Error]),
+            [clique_error:status(Fmt)]
+    end;
+repair_analyze([], [], []) ->
+    usage.
+
+%%--------------------------------------------------------------------
+%% repair repair
+%%--------------------------------------------------------------------
+repair_repair_cmd() ->
+    [
+     [["repair", "repair"], [], [], fun repair_repair/3]
+    ].
+
+repair_repair_usage() ->
+    [["repair", "repair"],
+     ["repair repair\n\n",
+      "  Attempt a repair of an inconsistency between current and lagging ledger states.\n"
+     ]
+    ].
+
+repair_repair(["repair", "repair"], [], []) ->
+    BlkChain = blockchain_worker:blockchain(),
+    case blockchain:repair(BlkChain) of
+        ok ->
+            [clique_status:text("ok")];
+        Other ->
+            Fmt = io_lib:format("error: ~p~n", [Other]),
+            [clique_error:status(Fmt)]
+    end;
+repair_repair([], [], []) ->
+    usage.

--- a/src/cli/blockchain_cli_repair.erl
+++ b/src/cli/blockchain_cli_repair.erl
@@ -132,7 +132,7 @@ repair_sync_resume(["repair", "sync_resume"], [], []) ->
         ok ->
             [clique_status:text("ok")];
         _Other ->
-            [clique_error:text("error")]
+            [clique_status:text("error")]
     end;
 repair_sync_resume([], [], []) ->
     usage.
@@ -184,7 +184,7 @@ repair_analyze(["repair", "analyze"], [], []) ->
             [clique_status:text("no errors detected")];
         {error, Error} ->
             Fmt = io_lib:format("error: ~p~n", [Error]),
-            [clique_error:status(Fmt)]
+            [clique_status:alert([clique_status:text(Fmt)])]
     end;
 repair_analyze([], [], []) ->
     usage.
@@ -211,7 +211,7 @@ repair_repair(["repair", "repair"], [], []) ->
             [clique_status:text("ok")];
         Other ->
             Fmt = io_lib:format("error: ~p~n", [Other]),
-            [clique_error:status(Fmt)]
+            [clique_status:alert([clique_status:text(Fmt)])]
     end;
 repair_repair([], [], []) ->
     usage.


### PR DESCRIPTION
Problem to solve: It would be far more convenient (and safer) to expose repair operations to a CLI interface than having to use a remote_console to invoke them.

Solution: Implement a CLI interface for certain repair operations. These are:

* pause_sync
* cancel_sync
* resume_sync
* sync_state
* analyze
* repair