### PR TITLE
Add blockchain_worker:new_ledger/1 to create the ledger w/ right owner

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -905,7 +905,7 @@ reset_ledger(Height,
 
             %% recreate the ledgers and notify the application of the
             %% new chain
-            Ledger1 = blockchain_ledger_v1:new(Dir),
+            {ok, Ledger1} = blockchain_worker:new_ledger(Dir),
             Chain1 = ledger(Ledger1, Chain),
             blockchain_worker:blockchain(Chain1),
 


### PR DESCRIPTION
Calling blockchain_ledger_v1:new can cause some of the member ETS tables
to be owned by the calling process. If the calling process goes away
those ETS tables die and cause a badarg when looking up snapshots.

To remedy this, add a new function to blockchain_worker to allow a new
ledger to be created under the ownership of the blockchain worker (the
normal owner of the ledger) and correct blockchain:reset_ledger to use
this new function.