### PR TITLE
Add sync block events

### DIFF
--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -201,7 +201,7 @@ peer_height(Height, Head, Sender) ->
 %%--------------------------------------------------------------------
 -spec notify(any()) -> ok.
 notify(Msg) ->
-    ok = gen_event:notify(?EVT_MGR, Msg).
+    ok = gen_event:sync_notify(?EVT_MGR, Msg).
 
 %%--------------------------------------------------------------------
 %% @doc


### PR DESCRIPTION
Adds the ability to add_sync_handler which ensures block events are delivered synchronously to registered targets. 