### PR TITLE
Improve performance of assert location transactions

### DIFF
--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -981,16 +981,22 @@ add_gateway_location(GatewayAddress, Location, Nonce, Ledger) ->
             Bin = blockchain_ledger_gateway_v2:serialize(blockchain_ledger_gateway_v2:clear_witnesses(NewGw)),
             AGwsCF = active_gateways_cf(Ledger),
             cache_put(Ledger, AGwsCF, GatewayAddress, Bin),
-            %% we need to also remove any old witness links for this device's previous location on other gateways
-            lists:foreach(fun({Addr, GW}) ->
-                                  case blockchain_ledger_gateway_v2:has_witness(GW, GatewayAddress) of
-                                      true ->
-                                          GW1 = blockchain_ledger_gateway_v2:remove_witness(GW, GatewayAddress),
-                                          cache_put(Ledger, AGwsCF, Addr, blockchain_ledger_gateway_v2:serialize(GW1));
-                                      false ->
-                                          ok
-                                  end
-                          end, maps:to_list(active_gateways(Ledger)))
+            %% this is only needed if the gateway previously had a location
+            case Nonce > 1 of
+                true ->
+                    %% we need to also remove any old witness links for this device's previous location on other gateways
+                    lists:foreach(fun({Addr, GW}) ->
+                                          case blockchain_ledger_gateway_v2:has_witness(GW, GatewayAddress) of
+                                              true ->
+                                                  GW1 = blockchain_ledger_gateway_v2:remove_witness(GW, GatewayAddress),
+                                                  cache_put(Ledger, AGwsCF, Addr, blockchain_ledger_gateway_v2:serialize(GW1));
+                                              false ->
+                                                  ok
+                                          end
+                                  end, maps:to_list(active_gateways(Ledger)));
+                false ->
+                    ok
+            end
     end.
 
 gateway_versions(Ledger) ->

--- a/src/transactions/v1/blockchain_txn_assert_location_v1.erl
+++ b/src/transactions/v1/blockchain_txn_assert_location_v1.erl
@@ -363,12 +363,18 @@ absorb(Txn, Chain) ->
             blockchain_ledger_v1:add_gateway_location(Gateway, Location, Nonce, Ledger)
     end,
 
-    Gateways = blockchain_ledger_v1:active_gateways(Ledger),
-    Neighbors = blockchain_poc_path:neighbors(Gateway, Gateways, Ledger),
-    {ok, Gw} = blockchain_ledger_v1:find_gateway_info(Gateway, Ledger),
-    ok = blockchain_ledger_v1:fixup_neighbors(Gateway, Gateways, Neighbors, Ledger),
-    Gw1 = blockchain_ledger_gateway_v2:neighbors(Neighbors, Gw),
-    ok = blockchain_ledger_v1:update_gateway(Gw1, Gateway, Ledger).
+    case blockchain_ledger_v1:config(?poc_version, Ledger) of
+        {ok, V} when V > 3 ->
+            %% don't update neighbours anymore
+            ok;
+        _ ->
+            {ok, Gw} = blockchain_ledger_v1:find_gateway_info(Gateway, Ledger),
+            Gateways = blockchain_ledger_v1:active_gateways(Ledger),
+            Neighbors = blockchain_poc_path:neighbors(Gateway, Gateways, Ledger),
+            ok = blockchain_ledger_v1:fixup_neighbors(Gateway, Gateways, Neighbors, Ledger),
+            NewGw = blockchain_ledger_gateway_v2:neighbors(Neighbors, Gw),
+            ok = blockchain_ledger_v1:update_gateway(NewGw, Gateway, Ledger)
+    end.
 
 %%--------------------------------------------------------------------
 %% @doc


### PR DESCRIPTION
This is a conservative change to make a new gateway location assertion
cheaper in 2 ways:

* If the gateway nonce is 1, there's no need to GC old witness
  relationships because this gateway, by definition, cannot have any.
* Don't update the gateway neighbours if the poc version is greater than
  3 as they're no longer used and updating them is expensive