### PR TITLE
Switch witness garbage collection to on read rather than on assert

### DIFF
--- a/src/ledger/v1/blockchain_ledger_gateway_v2.erl
+++ b/src/ledger/v1/blockchain_ledger_gateway_v2.erl
@@ -27,7 +27,8 @@
     clear_witnesses/1,
     remove_witness/2,
     witnesses/1,
-    witness_hist/1, witness_recent_time/1, witness_first_time/1
+    witnesses/2,
+    witness_hist/1, witness_recent_time/1, witness_first_time/1, witness_nonce/1
 ]).
 
 -import(blockchain_utils, [normalize_float/1]).
@@ -396,9 +397,13 @@ remove_witness(Gateway, WitnessAddr) ->
 has_witness(#gateway_v2{witnesses=Witnesses}, WitnessAddr) ->
     maps:is_key(WitnessAddr, Witnesses).
 
--spec witnesses(gateway()) -> #{libp2p_crypto:pubkey_bin() => gateway_witness()}.
+-spec witnesses(gateway()) -> witnesses().
 witnesses(Gateway) ->
     Gateway#gateway_v2.witnesses.
+
+-spec witnesses(gateway(), witnesses()) -> gateway().
+witnesses(Gateway, NewWitnesses) ->
+    Gateway#gateway_v2{witnesses=NewWitnesses}.
 
 -spec witness_hist(gateway_witness()) -> erlang:error(no_histogram) | #{integer() => integer()}.
 witness_hist(Witness) ->
@@ -412,6 +417,9 @@ witness_recent_time(Witness) ->
 witness_first_time(Witness) ->
     Witness#witness.first_time.
 
+-spec witness_nonce(gateway_witness()) -> pos_integer().
+witness_nonce(Witness) ->
+    Witness#witness.nonce.
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -981,16 +981,22 @@ add_gateway_location(GatewayAddress, Location, Nonce, Ledger) ->
             Bin = blockchain_ledger_gateway_v2:serialize(blockchain_ledger_gateway_v2:clear_witnesses(NewGw)),
             AGwsCF = active_gateways_cf(Ledger),
             cache_put(Ledger, AGwsCF, GatewayAddress, Bin),
-            %% we need to also remove any old witness links for this device's previous location on other gateways
-            lists:foreach(fun({Addr, GW}) ->
-                                  case blockchain_ledger_gateway_v2:has_witness(GW, GatewayAddress) of
-                                      true ->
-                                          GW1 = blockchain_ledger_gateway_v2:remove_witness(GW, GatewayAddress),
-                                          cache_put(Ledger, AGwsCF, Addr, blockchain_ledger_gateway_v2:serialize(GW1));
-                                      false ->
-                                          ok
-                                  end
-                          end, maps:to_list(active_gateways(Ledger)))
+            %% this is only needed if the gateway previously had a location
+            case Nonce > 1 of
+                true ->
+                    %% we need to also remove any old witness links for this device's previous location on other gateways
+                    lists:foreach(fun({Addr, GW}) ->
+                                          case blockchain_ledger_gateway_v2:has_witness(GW, GatewayAddress) of
+                                              true ->
+                                                  GW1 = blockchain_ledger_gateway_v2:remove_witness(GW, GatewayAddress),
+                                                  cache_put(Ledger, AGwsCF, Addr, blockchain_ledger_gateway_v2:serialize(GW1));
+                                              false ->
+                                                  ok
+                                          end
+                                  end, maps:to_list(active_gateways(Ledger)));
+                false ->
+                    ok
+            end
     end.
 
 gateway_versions(Ledger) ->


### PR DESCRIPTION
Prior to this change, gateway witnesses were garbage collected when
their nonce changed as part of a location assertion. This involved a
full scan of all the ledger gateways, which is at least O(N).

This change attempts to drastically reduce the scope by checking the
nonces of witnesses against the actual gateway record's nonce when the
gateway record is loaded from rocksdb. Since gateways have a much
smaller witness list than the total number of gateways this bounds the
compute complexity much lower.

note that this is potentially consensus affecting if the results of the garbage collection are different than the original code. Additionally this PR is based on top of #339 which is much more conservative and likely much safer as an emergency fix.