### PR TITLE
Add eqc for selecting hexes

### DIFF
--- a/eqc/hex_eqc.erl
+++ b/eqc/hex_eqc.erl
@@ -1,0 +1,130 @@
+-module(hex_eqc).
+
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([prop_hex_check/0]).
+
+prop_hex_check() ->
+    ?FORALL({Iterations, Hash}, {elements([1000, 10000, 100000]), binary(32)},
+            begin
+                Ledger = ledger(),
+                application:set_env(blockchain, disable_score_cache, true),
+                {ok, _Pid} = blockchain_score_cache:start_link(),
+
+                %% Grab the list of parent hexes
+                {ok, Hexes} = blockchain_ledger_v1:get_hexes(Ledger),
+                Population = lists:keysort(1, maps:to_list(Hexes)),
+
+                %% Use entropy to generate randval for running iterations
+                Entropy = blockchain_utils:rand_state(Hash),
+
+                %% Need this to match counters against assumptions
+                CumulativePopulationList = cdf(Population),
+                CumulativePopulationMap = maps:from_list(CumulativePopulationList),
+
+                %% Intiial acc for the counter, each node starts with a 0 count
+                InitAcc = maps:map(fun(_, _) -> 0 end, CumulativePopulationMap),
+
+                %% Track all counts a node gets picked
+                {Counter, _} = lists:foldl(fun(_I, {Acc, AccEntropy}) ->
+                                              {RandVal, NewEntropy} = rand:uniform_s(AccEntropy),
+                                              {ok, Node} = blockchain_utils:icdf_select(Population, RandVal),
+                                              {maps:update_with(Node, fun(X) -> X + 1 end, 1, Acc), NewEntropy}
+                                      end,
+                                      {InitAcc, Entropy},
+                                      lists:seq(1, Iterations)),
+
+                %% Check that it's roughly equal or more appropriately within some threshold (0.1 is good enough, probably).
+                %% Fucking probabilities.
+                CheckCounterLinesUp = lists:all(fun({Node, Count}) ->
+                                                        abs(Count/Iterations - maps:get(Node, CumulativePopulationMap)) < 0.1
+                                                end,
+                                                maps:to_list(Counter)),
+
+                blockchain_ledger_v1:close(Ledger),
+                blockchain_score_cache:stop(),
+
+                ?WHENFAIL(begin
+                              blockchain_ledger_v1:close(Ledger),
+                              io:format("Population: ~p~n", [Population]),
+                              io:format("CDF: ~p~n", [CumulativePopulationList]),
+                              io:format("Counter: ~p~n", [Counter])
+                          end,
+                          noshrink(conjunction(
+                                     [{verify_population_exists, length(Population) > 0},
+                                      {verify_unique_nodes, length(Population) == length(lists:usort(Population))},
+                                      {verify_cdf, lists:sum([W || {_, W} <- CumulativePopulationList]) >= 0.99}, %% it's pretty much 1.0 but damn floats
+                                      {verify_counts_line_up, CheckCounterLinesUp}]
+                                    )
+                                  )
+                         )
+            end).
+
+cdf(PopulationList) ->
+    %% This takes the population and coverts it to a cumulative distribution.
+    Sum = lists:sum([Weight || {_Node, Weight} <- PopulationList]),
+    [{Node, blockchain_utils:normalize_float(Weight/Sum)} || {Node, Weight} <- PopulationList].
+
+ledger() ->
+    %% Ledger at height: 168420
+    %% ActiveGateway Count: 2614
+    {ok, Dir} = file:get_cwd(),
+    %% Ensure priv dir exists
+    PrivDir = filename:join([Dir, "priv"]),
+    ok = filelib:ensure_dir(PrivDir ++ "/"),
+    %% Path to static ledger tar
+    LedgerTar = filename:join([PrivDir, "ledger.tar.gz"]),
+    case filelib:is_file(LedgerTar) of
+        true ->
+            %% if we have already unpacked it, no need to do it again
+            LedgerDB = filename:join([PrivDir, "ledger.db"]),
+            case filelib:is_dir(LedgerDB) of
+                true ->
+                    ok;
+                false ->
+                    %% ledger tar file present, extract
+                    ok = erl_tar:extract(LedgerTar, [compressed, {cwd, PrivDir}])
+            end;
+        false ->
+            %% ledger tar file not found, download & extract
+            ok = ssl:start(),
+            {ok, {{_, 200, "OK"}, _, Body}} = httpc:request("https://blockchain-core.s3-us-west-1.amazonaws.com/ledger.tar.gz"),
+            ok = file:write_file(filename:join([PrivDir, "ledger.tar.gz"]), Body),
+            ok = erl_tar:extract(LedgerTar, [compressed, {cwd, PrivDir}])
+    end,
+    Ledger = blockchain_ledger_v1:new(PrivDir),
+    %% if we haven't upgraded the ledger, upgrade it
+    case blockchain_ledger_v1:get_hexes(Ledger) of
+        {ok, _Hexes} ->
+            Ledger;
+        _ ->
+            Ledger1 = blockchain_ledger_v1:new_context(Ledger),
+            blockchain_ledger_v1:vars(maps:merge(default_vars(), targeting_vars()), [], Ledger1),
+            blockchain:bootstrap_hexes(Ledger1),
+            blockchain_ledger_v1:commit_context(Ledger1),
+            Ledger
+    end.
+
+targeting_vars() ->
+    #{poc_v4_target_prob_score_wt => 0.0,
+      poc_v4_target_prob_edge_wt => 0.0,
+      poc_v5_target_prob_randomness_wt => 1.0,
+      poc_v4_target_challenge_age => 300,
+      poc_v4_target_exclusion_cells => 6000,
+      poc_v4_target_score_curve => 2,
+      poc_target_hex_parent_res => 5
+     }.
+
+default_vars() ->
+    #{poc_v4_exclusion_cells => 10,
+      poc_v4_parent_res => 11,
+      poc_v4_prob_bad_rssi => 0.01,
+      poc_v4_prob_count_wt => 0.3,
+      poc_v4_prob_good_rssi => 1.0,
+      poc_v4_prob_no_rssi => 0.5,
+      poc_v4_prob_rssi_wt => 0.3,
+      poc_v4_prob_time_wt => 0.3,
+      poc_v4_randomness_wt => 0.1,
+      poc_target_hex_parent_res => 5,
+      poc_version => 7}.

--- a/eqc/hex_eqc.erl
+++ b/eqc/hex_eqc.erl
@@ -42,6 +42,12 @@ prop_hex_check() ->
                                                 end,
                                                 maps:to_list(Counter)),
 
+                %% Check whether the zone with the maximum number of hexes within has the highest counts
+                {MaxCountedHex, _Counts} = hd(lists:reverse(lists:keysort(2, maps:to_list(Counter)))),
+                {MaxPopHex, _} = hd(lists:reverse(lists:keysort(2, Population))),
+                CheckMaxPopZoneCount = MaxCountedHex == MaxPopHex,
+                io:format("CheckMaxPopZoneCount: ~p~n", [CheckMaxPopZoneCount]),
+
                 blockchain_ledger_v1:close(Ledger),
                 blockchain_score_cache:stop(),
 
@@ -55,7 +61,9 @@ prop_hex_check() ->
                                      [{verify_population_exists, length(Population) > 0},
                                       {verify_unique_nodes, length(Population) == length(lists:usort(Population))},
                                       {verify_cdf, lists:sum([W || {_, W} <- CumulativePopulationList]) >= 0.99}, %% it's pretty much 1.0 but damn floats
-                                      {verify_counts_line_up, CheckCounterLinesUp}]
+                                      {verify_counts_line_up, CheckCounterLinesUp},
+                                      {verify_max_pop_zone_count, CheckMaxPopZoneCount}
+                                     ]
                                     )
                                   )
                          )

--- a/eqc/hex_eqc.erl
+++ b/eqc/hex_eqc.erl
@@ -14,7 +14,9 @@ prop_hex_check() ->
 
                 %% Grab the list of parent hexes
                 {ok, Hexes} = blockchain_ledger_v1:get_hexes(Ledger),
-                Population = lists:keysort(1, maps:to_list(Hexes)),
+                HexList = maps:to_list(Hexes),
+                %% ok = file:write_file("/tmp/hexes", io_lib:fwrite("~p\n", [HexList])),
+                Population = lists:keysort(1, HexList),
 
                 %% Use entropy to generate randval for running iterations
                 Entropy = blockchain_utils:rand_state(Hash),
@@ -32,7 +34,7 @@ prop_hex_check() ->
                 {Counter, _} = lists:foldl(fun(_I, {Acc, AccEntropy}) ->
                                               {RandVal, NewEntropy} = rand:uniform_s(AccEntropy),
                                               {ok, Node} = blockchain_utils:icdf_select(Population, RandVal),
-                                              ok = file:write_file(Fname, io_lib:fwrite("~p\n", [Node]), [append]),
+                                              %% ok = file:write_file(Fname, io_lib:fwrite("~p\n", [Node]), [append]),
                                               {maps:update_with(Node, fun(X) -> X + 1 end, 1, Acc), NewEntropy}
                                       end,
                                       {InitAcc, Entropy},

--- a/eqc/icdf_eqc.erl
+++ b/eqc/icdf_eqc.erl
@@ -23,19 +23,12 @@
 prop_icdf_check() ->
     ?FORALL({Population, Iterations, Hash}, {gen_population(), gen_iterations(), binary(32)},
             begin
-                %% Switch the position to make it easier to work with the existing function.
-                %% Also Node names are unique cuz map and also each hotspot has a unique addr.
-                PopulationList = [{Weight, Node} || {Node, Weight} <- maps:to_list(Population)],
-
-                %% Convert this to a cumulative probability distribution, the sum of
-                %% probabilities must add to 1 for ICDF to work.
-                %% We already do this for targeting when we assign the probabilities.
-                CumulativePopulationList = blockchain_utils:cdf(maps:to_list(Population)),
-
-                %% Sigh, need it back to find the cumulative probability to verify against
-                CumulativePopulationMap = maps:from_list(CumulativePopulationList),
-
+                %% Use entropy to generate randval for running iterations
                 Entropy = blockchain_utils:rand_state(Hash),
+
+                %% Need this to match counters against assumptions
+                CumulativePopulationList = cdf(Population),
+                CumulativePopulationMap = maps:from_list(CumulativePopulationList),
 
                 %% Intiial acc for the counter, each node starts with a 0 count
                 InitAcc = maps:map(fun(_, _) -> 0 end, CumulativePopulationMap),
@@ -43,11 +36,12 @@ prop_icdf_check() ->
                 %% Track all counts a node gets picked
                 {Counter, _} = lists:foldl(fun(_I, {Acc, AccEntropy}) ->
                                               {RandVal, NewEntropy} = rand:uniform_s(AccEntropy),
-                                              {ok, Node} = blockchain_utils:icdf_select(CumulativePopulationList, RandVal),
+                                              {ok, Node} = blockchain_utils:icdf_select(Population, RandVal),
                                               {maps:update_with(Node, fun(X) -> X + 1 end, 1, Acc), NewEntropy}
                                       end,
                                       {InitAcc, Entropy},
                                       lists:seq(1, Iterations)),
+
 
                 %% Check that it's roughly equal or more appropriately within some threshold (0.1 is good enough, probably).
                 %% Fucking probabilities.
@@ -57,14 +51,14 @@ prop_icdf_check() ->
                                                 maps:to_list(Counter)),
 
                 ?WHENFAIL(begin
-                              io:format("PopulationList: ~p~n", [PopulationList]),
+                              io:format("Population: ~p~n", [Population]),
                               io:format("CDF: ~p~n", [CumulativePopulationList]),
                               io:format("Counter: ~p~n", [Counter])
                           end,
                           noshrink(conjunction(
-                                     [{verify_unique_nodes, length(PopulationList) == length(lists:usort(PopulationList))},
+                                     [{verify_population_exists, length(Population) > 0},
+                                      {verify_unique_nodes, length(Population) == length(lists:usort(Population))},
                                       {verify_cdf, lists:sum([W || {_, W} <- CumulativePopulationList]) >= 0.99}, %% it's pretty much 1.0 but damn floats
-                                      {verify_population_exists, length(PopulationList) > 0},
                                       {verify_counts_line_up, CheckCounterLinesUp}]
                                     )
                                   )
@@ -80,7 +74,7 @@ gen_iterations() ->
 gen_population() ->
     %% We need unique node names to mimic unique hotspot addresses
     %% Also keeps things simple.
-    ?SUCHTHAT(M, map(gen_node(), gen_weight()), map_size(M) >= 3).
+    ?SUCHTHAT(L, list({gen_node(), gen_weight()}), length(L) >= 3).
 
 gen_node() ->
     %% Some random node name.
@@ -93,3 +87,8 @@ gen_weight() ->
 gen_prob() ->
     %% Some probability
     ?SUCHTHAT(W, real(), W > 0 andalso W < 1).
+
+cdf(PopulationList) ->
+    %% This takes the population and coverts it to a cumulative distribution.
+    Sum = lists:sum([Weight || {_Node, Weight} <- PopulationList]),
+    [{Node, blockchain_utils:normalize_float(Weight/Sum)} || {Node, Weight} <- PopulationList].

--- a/eqc/zone_target_eqc.erl
+++ b/eqc/zone_target_eqc.erl
@@ -7,7 +7,7 @@
 
 prop_target_check() ->
     noshrink(
-    ?FORALL({Hash, ChallengerIndex},
+    ?FORALL({_Hash, ChallengerIndex},
             {gen_hash(), gen_challenger_index()},
             begin
                 %% known problematic hash/index pairs
@@ -16,6 +16,7 @@ prop_target_check() ->
                 {ok, _Pid} = blockchain_score_cache:start_link(),
                 ActiveGateways = blockchain_ledger_v1:active_gateways(Ledger),
                 Challenger = lists:nth(ChallengerIndex, maps:keys(ActiveGateways)),
+                Hash = crypto:strong_rand_bytes(32),
                 Vars = maps:merge(default_vars(), targeting_vars()),
                 Check = case blockchain_ledger_gateway_v2:location(maps:get(Challenger, ActiveGateways)) of
                             undefined ->

--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -19,7 +19,6 @@
     score_gateways/1,
     free_space_path_loss/2,
     vars_binary_keys_to_atoms/1,
-    cdf/1,
     icdf_select/2
 ]).
 
@@ -208,26 +207,20 @@ vars_binary_keys_to_atoms(Vars) ->
     %% This makes good men sad
     maps:fold(fun(K, V, Acc) -> maps:put(binary_to_atom(K, utf8), V, Acc)  end, #{}, Vars).
 
--spec cdf(PopulationList :: [{any(), float()}, ...]) -> [{any(), float()}, ...].
-cdf(PopulationList) ->
-    %% This takes the population and coverts it to a cumulative distribution.
-    Sum = lists:sum([Weight || {_Node, Weight} <- PopulationList]),
-    [{Node, normalize_float(Weight/Sum)} || {Node, Weight} <- PopulationList].
-
 -spec icdf_select([{any(), float()}, ...], float()) -> {ok, any()}.
 icdf_select(PopulationList, Rnd) ->
-    icdf_select(PopulationList, Rnd, Rnd).
+    Sum = lists:sum([Weight || {_Node, Weight} <- PopulationList]),
+    icdf_select(PopulationList, normalize_float(Rnd * Sum), normalize_float(Rnd * Sum)).
 
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
 icdf_select([{Node, _Weight}], _Rnd, _OrigRnd) ->
     {ok, Node};
 icdf_select([{Node, Weight} | _], Rnd, _OrigRnd) when Rnd - Weight =< 0 ->
     {ok, Node};
 icdf_select([{_Node, Weight} | Tail], Rnd, OrigRnd) ->
     icdf_select(Tail, normalize_float(Rnd - Weight), OrigRnd).
-
-%% ------------------------------------------------------------------
-%% Internal Function Definitions
-%% ------------------------------------------------------------------
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests


### PR DESCRIPTION
Remove cdf function from utils, instead scale the rnd number using the sum of probs. Presumably this will avoid accumulation of error when `(Rnd-Prob) ~ 0.000001`.

As far as I can tell the `icdf_eqc` and now the `hex_eqc` both still conform.

