### PR TITLE
Update to POC V8

### DIFF
--- a/eqc/hex_eqc.erl
+++ b/eqc/hex_eqc.erl
@@ -34,7 +34,7 @@ prop_hex_check() ->
                 {Counter, _} = lists:foldl(fun(_I, {Acc, AccEntropy}) ->
                                               {RandVal, NewEntropy} = rand:uniform_s(AccEntropy),
                                               {ok, Node} = blockchain_utils:icdf_select(Population, RandVal),
-                                              ok = file:write_file(Fname, io_lib:fwrite("~p\n", [Node]), [append]),
+                                              %% ok = file:write_file(Fname, io_lib:fwrite("~p\n", [Node]), [append]),
                                               {maps:update_with(Node, fun(X) -> X + 1 end, 1, Acc), NewEntropy}
                                       end,
                                       {InitAcc, Entropy},

--- a/eqc/hex_eqc.erl
+++ b/eqc/hex_eqc.erl
@@ -28,7 +28,7 @@ prop_hex_check() ->
                 %% Intiial acc for the counter, each node starts with a 0 count
                 InitAcc = maps:map(fun(_, _) -> 0 end, CumulativePopulationMap),
 
-                Fname = "/tmp/zones_" ++ libp2p_crypto:bin_to_b58(Hash),
+                %% Fname = "/tmp/zones_" ++ libp2p_crypto:bin_to_b58(Hash),
 
                 %% Track all counts a node gets picked
                 {Counter, _} = lists:foldl(fun(_I, {Acc, AccEntropy}) ->

--- a/eqc/path_v4_eqc.erl
+++ b/eqc/path_v4_eqc.erl
@@ -158,8 +158,8 @@ targeting_vars() ->
       poc_version => 8,
 
       %% additional rssi bucket range vars
-      poc_good_bucket_low => -140,
-      poc_good_bucket_high => -90,
+      poc_good_bucket_low => -115,
+      poc_good_bucket_high => -80,
 
       %% overwrite poc next hop weights
       poc_v4_prob_rssi_wt => 0.1,

--- a/eqc/path_v4_eqc.erl
+++ b/eqc/path_v4_eqc.erl
@@ -1,0 +1,184 @@
+-module(path_v4_eqc).
+
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([prop_path_check/0]).
+
+prop_path_check() ->
+    ?FORALL({Hash, PathLimit},
+            {gen_hash(), gen_path_limit()},
+            begin
+                Ledger = ledger(),
+                application:set_env(blockchain, disable_score_cache, true),
+                {ok, _Pid} = blockchain_score_cache:start_link(),
+                ActiveGateways = blockchain_ledger_v1:active_gateways(Ledger),
+                LedgerVars = blockchain_utils:vars_binary_keys_to_atoms(blockchain_ledger_v1:all_vars(Ledger)),
+                %% Overwrite poc_path_limit for checking generated path limits
+                Vars = maps:put(poc_path_limit, PathLimit, LedgerVars),
+
+                Check = case blockchain_poc_target_v2:target_v2(Hash, Ledger, Vars) of
+                            {error, not_found} ->
+                                %% TODO: Investigation pending
+                                true;
+                            {ok, TargetPubkeyBin} ->
+
+                                {Time, Path} = timer:tc(fun() ->
+                                                                blockchain_poc_path_v4:build(TargetPubkeyBin,
+                                                                                             Ledger,
+                                                                                             block_time(),
+                                                                                             Hash,
+                                                                                             Vars)
+                                                        end),
+
+                                PathLength = length(Path),
+
+                                B58Path = #{libp2p_crypto:bin_to_b58(TargetPubkeyBin) => [[libp2p_crypto:bin_to_b58(P) || P <- Path]]},
+                                HumanPath = [name(P) || P <- Path],
+                                io:format("Time: ~p\t Path: ~p~n", [erlang:convert_time_unit(Time, microsecond, millisecond), HumanPath]),
+
+                                case length(Path) > 1 of
+                                    true ->
+                                        ok = file:write_file("/tmp/paths_js", io_lib:fwrite("~p.\n", [B58Path]), [append]),
+                                        ok = file:write_file("/tmp/paths_target", io_lib:fwrite("~p: ~p.\n", [name(TargetPubkeyBin), HumanPath]), [append]);
+                                    false ->
+                                        ok = file:write_file("/tmp/paths_beacon", io_lib:fwrite("~p: ~p.\n", [name(TargetPubkeyBin), HumanPath]), [append])
+                                end,
+
+                                %% Checks:
+                                %% - honor path limit
+                                %% - atleast one element in path
+                                %% - target is always in path
+                                %% - we never go back to the same h3 index in path
+                                %% - check next hop is a witness of previous gateway
+                                C1 = PathLength =< PathLimit andalso PathLength >= 1,
+                                C2 = length(Path) == length(lists:usort(Path)),
+                                C3 = lists:member(TargetPubkeyBin, Path),
+                                C4 = check_path_h3_indices(Path, ActiveGateways),
+                                C5 = check_next_hop(Path, ActiveGateways),
+                                C1 andalso C2 andalso C3 andalso C3 andalso C4 andalso C5
+
+                        end,
+
+                blockchain_ledger_v1:close(Ledger),
+                blockchain_score_cache:stop(),
+
+                ?WHENFAIL(begin
+                              blockchain_ledger_v1:close(Ledger)
+                          end,
+                          %% TODO: split into multiple verifiers instead of a single consolidated one
+                          conjunction([{verify_path_construction, Check}]))
+            end).
+
+gen_path_limit() ->
+    elements([3, 4, 5, 6, 7]).
+
+gen_hash() ->
+    binary(32).
+
+ledger() ->
+    %% Ledger at height: 168420
+    %% ActiveGateway Count: 2614
+    {ok, Dir} = file:get_cwd(),
+    %% Ensure priv dir exists
+    PrivDir = filename:join([Dir, "priv"]),
+    ok = filelib:ensure_dir(PrivDir ++ "/"),
+    %% Path to static ledger tar
+    LedgerTar = filename:join([PrivDir, "ledger.tar.gz"]),
+    case filelib:is_file(LedgerTar) of
+        true ->
+            %% if we have already unpacked it, no need to do it again
+            LedgerDB = filename:join([PrivDir, "ledger.db"]),
+            case filelib:is_dir(LedgerDB) of
+                true ->
+                    ok;
+                false ->
+                    %% ledger tar file present, extract
+                    ok = erl_tar:extract(LedgerTar, [compressed, {cwd, PrivDir}])
+            end;
+        false ->
+            %% ledger tar file not found, download & extract
+            ok = ssl:start(),
+            {ok, {{_, 200, "OK"}, _, Body}} = httpc:request("https://blockchain-core.s3-us-west-1.amazonaws.com/ledger.tar.gz"),
+            ok = file:write_file(filename:join([PrivDir, "ledger.tar.gz"]), Body),
+            ok = erl_tar:extract(LedgerTar, [compressed, {cwd, PrivDir}])
+    end,
+    Ledger = blockchain_ledger_v1:new(PrivDir),
+    %% if we haven't upgraded the ledger, upgrade it
+    case blockchain_ledger_v1:get_hexes(Ledger) of
+        {ok, _Hexes} ->
+            Ledger;
+        _ ->
+            Ledger1 = blockchain_ledger_v1:new_context(Ledger),
+            %% Ensure the ledger has the vars we're testing against
+            blockchain_ledger_v1:vars(maps:merge(default_vars(), targeting_vars()), [], Ledger1),
+            blockchain:bootstrap_hexes(Ledger1),
+            blockchain_ledger_v1:commit_context(Ledger1),
+            Ledger
+    end.
+
+block_time() ->
+    %% block time at height 168420
+    1578703246.
+
+check_path_h3_indices(Path, ActiveGateways) ->
+    %% check every path member has a unique h3 index
+    PathIndices = lists:foldl(fun(PubkeyBin, Acc) ->
+                                      [blockchain_ledger_gateway_v2:location(maps:get(PubkeyBin, ActiveGateways)) | Acc]
+                              end,
+                              [],
+                              Path),
+    length(lists:usort(PathIndices)) == length(PathIndices).
+
+check_next_hop([_H], _ActiveGateways) ->
+    true;
+check_next_hop([H | T], ActiveGateways) ->
+    HGw = maps:get(H, ActiveGateways),
+    case maps:is_key(hd(T), blockchain_ledger_gateway_v2:witnesses(HGw)) of
+        true ->
+            check_next_hop(T, ActiveGateways);
+        false ->
+            false
+    end.
+
+name(PubkeyBin) ->
+    {ok, Name} = erl_angry_purple_tiger:animal_name(libp2p_crypto:bin_to_b58(PubkeyBin)),
+    Name.
+
+targeting_vars() ->
+    #{poc_v4_target_prob_score_wt => 0.0,
+      poc_v4_target_prob_edge_wt => 0.0,
+      poc_v5_target_prob_randomness_wt => 1.0,
+      poc_v4_target_challenge_age => 300,
+      poc_v4_target_exclusion_cells => 6000,
+      poc_v4_target_score_curve => 2,
+      poc_target_hex_parent_res => 5,
+
+      %% overwrite poc version
+      poc_version => 8,
+
+      %% additional rssi bucket range vars
+      poc_good_bucket_low => -140,
+      poc_good_bucket_high => -90,
+
+      %% overwrite poc next hop weights
+      poc_v4_prob_rssi_wt => 0.1,
+      poc_v4_prob_time_wt => 0.1,
+      poc_v4_randomness_wt => 0.2,
+      poc_v4_prob_count_wt => 0.1,
+      poc_centrality_wt => 0.5
+     }.
+
+default_vars() ->
+    #{poc_v4_exclusion_cells => 10,
+      poc_v4_parent_res => 11,
+      poc_v4_prob_bad_rssi => 0.01,
+      poc_v4_prob_count_wt => 0.3,
+      poc_v4_prob_good_rssi => 1.0,
+      poc_v4_prob_no_rssi => 0.5,
+      poc_v4_prob_rssi_wt => 0.3,
+      poc_v4_prob_time_wt => 0.3,
+      poc_v4_randomness_wt => 0.1,
+      poc_target_hex_parent_res => 5,
+      poc_version => 8
+     }.

--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -227,6 +227,8 @@
 -define(poc_target_hex_parent_res, poc_target_hex_parent_res).
 
 %% RSSI Bucketing variables
+%% Weight associated with biasing for RSSI centrality measures
+-define(poc_centrality_wt, poc_centrality_wt).
 %% Lower bound for known good rssi bucket
 -define(poc_good_bucket_low, poc_good_bucket_low).
 %% Upper bound for known good rssi bucket

--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -225,4 +225,10 @@
 %% Hierarchical targeting variables
 %% Create hexes at this resolution for all the hotspots on the network.
 -define(poc_target_hex_parent_res, poc_target_hex_parent_res).
+
+%% RSSI Bucketing variables
+%% Lower bound for known good rssi bucket
+-define(poc_good_bucket_low, poc_good_bucket_low).
+%% Upper bound for known good rssi bucket
+-define(poc_good_bucket_high, poc_good_bucket_high).
 %% ------------------------------------------------------------------

--- a/src/blockchain_poc_path_v4.erl
+++ b/src/blockchain_poc_path_v4.erl
@@ -110,7 +110,10 @@ build_(_TargetPubkeyBin, _Ledger, _HeadBlockTime, _Vars, _RandState, _Indices, P
                HeadBlockTime :: pos_integer(),
                Vars :: map(),
                RandVal :: float(),
-               Indices :: [h3:h3_index()]) -> {error, no_witness} | {error, all_witnesses_too_close} | {ok, libp2p_crypto:pubkey_bin()}.
+               Indices :: [h3:h3_index()]) -> {error, no_witness} |
+                                              {error, all_witnesses_too_close} |
+                                              {error, zero_weight} |
+                                              {ok, libp2p_crypto:pubkey_bin()}.
 next_hop(GatewayBin, Ledger, HeadBlockTime, Vars, RandVal, Indices) ->
     %% Get gateway
     Gateway = find(GatewayBin, Ledger),

--- a/src/blockchain_poc_path_v4.erl
+++ b/src/blockchain_poc_path_v4.erl
@@ -59,12 +59,16 @@
 build(TargetPubkeyBin, Ledger, HeadBlockTime, Hash, Vars) ->
     TargetGw = find(TargetPubkeyBin, Ledger),
     TargetGwLoc = blockchain_ledger_gateway_v2:location(TargetGw),
+    %% NOTE: Changing the rand_state here allows the _first_ next_hop
+    %% to have a different rand_val compared to the initial target
+    %% selection itself.
     RandState = blockchain_utils:rand_state(Hash),
+    {_RandVal, NewRandState} = rand:uniform_s(RandState),
     build_(TargetPubkeyBin,
            Ledger,
            HeadBlockTime,
            Vars,
-           RandState,
+           NewRandState,
            [TargetGwLoc],
            [TargetPubkeyBin]).
 

--- a/src/blockchain_poc_path_v4.erl
+++ b/src/blockchain_poc_path_v4.erl
@@ -1,0 +1,496 @@
+%%%-----------------------------------------------------------------------------
+%%% @doc blockchain_poc_path_v4 implementation.
+%%%
+%%% The way paths are built depends solely on witnessing data we have accumulated
+%%% in the blockchain ledger.
+%%%
+%%% Consider X having [A, B, C, D] as its geographic neighbors but only
+%%% having [A, C, E] as it's transmission witnesses. It stands to reason
+%%% that we would expect packets from X -> any[A, C, E] to work with relatively
+%%% high confidence compared to its geographic neighbors. RF varies
+%%% heavily depending on surroundings therefore relying only on geographic
+%%% vicinity is not enough to build potentially interesting paths.
+%%%
+%%% In order to build a path, we first find a target gateway using
+%%% blockchain_poc_target_v3:target/3 and build a path outward from it.
+%%%
+%%% Once we have a target we recursively find a potential next hop from the target
+%%% gateway by looking into its witness list.
+%%%
+%%% Before we calculate the probability associated with each witness in witness
+%%% list, we filter out potentially useless paths, depending on the following filters:
+%%% - Next hop witness must not be in the same hex index as the target
+%%% - Every hop in the path must be unique
+%%% - Every hop in the path must have a minimum exclusion distance
+%%%
+%%% The criteria for a potential next hop witness are biased like so:
+%%% - P(WitnessRSSI)  = Probability that the witness has a good (valid) RSSI.
+%%% - P(WitnessTime)  = Probability that the witness timestamp is not stale.
+%%% - P(WitnessCount) = Probability that the witness is infrequent.
+%%%
+%%% The overall probability of picking a next witness is additive depending on
+%%% chain var configurable weights for each one of the calculated probs.
+%%% P(Witness) = RSSIWeight*P(WitnessRSSI) + TimeWeight*P(WitnessTime) + CountWeight*P(WitnessCount)
+%%%
+%%% We scale these probabilities and run an ICDF to select the witness from
+%%% the witness list. Once we have a potential next hop, we simply do the same process
+%%% for the next hop and continue building till the path limit is reached or there
+%%% are no more witnesses to continue with.
+%%%
+%%%-----------------------------------------------------------------------------
+-module(blockchain_poc_path_v4).
+
+-export([
+    build/5
+]).
+
+-include("blockchain_utils.hrl").
+
+-type path() :: [libp2p_crypto:pubkey_bin()].
+-type prob_map() :: #{libp2p_crypto:pubkey_bin() => float()}.
+
+%% @doc Build a path starting at `TargetPubkeyBin`.
+-spec build(TargetPubkeyBin :: libp2p_crypto:pubkey_bin(),
+            Ledger :: blockchain:ledger(),
+            HeadBlockTime :: pos_integer(),
+            Hash :: binary(),
+            Vars :: map()) -> path().
+build(TargetPubkeyBin, Ledger, HeadBlockTime, Hash, Vars) ->
+    TargetGw = find(TargetPubkeyBin, Ledger),
+    TargetGwLoc = blockchain_ledger_gateway_v2:location(TargetGw),
+    RandState = blockchain_utils:rand_state(Hash),
+    build_(TargetPubkeyBin,
+           Ledger,
+           HeadBlockTime,
+           Vars,
+           RandState,
+           [TargetGwLoc],
+           [TargetPubkeyBin]).
+
+%%%-------------------------------------------------------------------
+%% Helpers
+%%%-------------------------------------------------------------------
+-spec build_(TargetPubkeyBin :: libp2p_crypto:pubkey_bin(),
+             Ledger :: blockchain:ledger(),
+             HeadBlockTime :: pos_integer(),
+             Vars :: map(),
+             RandState :: rand:state(),
+             Indices :: [h3:h3_index()],
+             Path :: path()) -> path().
+build_(TargetPubkeyBin,
+       Ledger,
+       HeadBlockTime,
+       #{poc_path_limit := Limit} = Vars,
+       RandState,
+       Indices,
+       Path) when length(Path) < Limit ->
+    %% Try to find a next hop
+    {NewRandVal, NewRandState} = rand:uniform_s(RandState),
+    case next_hop(TargetPubkeyBin, Ledger, HeadBlockTime, Vars, NewRandVal, Indices) of
+        {error, no_witness} ->
+            lists:reverse(Path);
+        {ok, WitnessPubkeyBin} ->
+            %% Try the next hop in the new path, continue building forward
+            NextHopGw = find(WitnessPubkeyBin, Ledger),
+            Index = blockchain_ledger_gateway_v2:location(NextHopGw),
+            NewPath = [WitnessPubkeyBin | Path],
+            build_(WitnessPubkeyBin,
+                   Ledger,
+                   HeadBlockTime,
+                   Vars,
+                   NewRandState,
+                   [Index | Indices],
+                   NewPath)
+    end;
+build_(_TargetPubkeyBin, _Ledger, _HeadBlockTime, _Vars, _RandState, _Indices, Path) ->
+    lists:reverse(Path).
+
+-spec next_hop(GatewayBin :: blockchain_ledger_gateway_v2:gateway(),
+               Ledger :: blockchain:ledger(),
+               HeadBlockTime :: pos_integer(),
+               Vars :: map(),
+               RandVal :: float(),
+               Indices :: [h3:h3_index()]) -> {error, no_witness} | {ok, libp2p_crypto:pubkey_bin()}.
+next_hop(GatewayBin, Ledger, HeadBlockTime, Vars, RandVal, Indices) ->
+    %% Get gateway
+    Gateway = find(GatewayBin, Ledger),
+    case blockchain_ledger_gateway_v2:witnesses(Gateway) of
+        W when map_size(W) == 0 ->
+            {error, no_witness};
+        Witnesses ->
+            %% If this gateway has witnesses, it is implied that it's location cannot be undefined
+            GatewayLoc = blockchain_ledger_gateway_v2:location(Gateway),
+            %% Filter witnesses
+            FilteredWitnesses = filter_witnesses(GatewayLoc, Indices, Witnesses, Ledger, Vars),
+            %% Assign probabilities to filtered witnesses
+            %% P(WitnessRSSI)  = Probability that the witness has a good (valid) RSSI.
+            PWitnessRSSI = rssi_probs(FilteredWitnesses, Vars),
+            %% P(WitnessTime)  = Probability that the witness timestamp is not stale.
+            PWitnessTime = time_probs(HeadBlockTime, FilteredWitnesses, Vars),
+            %% P(WitnessCount) = Probability that the witness is infrequent.
+            PWitnessCount = witness_count_probs(FilteredWitnesses, Vars),
+            %% P(RSSICentrality) = Probability that the witness rssi lies within a good range
+            PWitnessRSSICentrality = witness_rssi_centrality_probs(FilteredWitnesses, Vars),
+            %% P(Witness) = RSSIWeight*P(WitnessRSSI) + TimeWeight*P(WitnessTime) + CountWeight*P(WitnessCount)
+            PWitness = witness_prob(Vars, PWitnessRSSI, PWitnessTime, PWitnessCount, PWitnessRSSICentrality),
+            %% Select witness using icdf
+            blockchain_utils:icdf_select(PWitness, RandVal)
+    end.
+
+-spec witness_prob(Vars :: map(),
+                   PWitnessRSSI :: prob_map(),
+                   PWitnessTime :: prob_map(),
+                   PWitnessCount :: prob_map(),
+                   PWitnessRSSICentrality :: prob_map()) -> prob_map().
+witness_prob(Vars, PWitnessRSSI, PWitnessTime, PWitnessCount, PWitnessRSSICentrality) ->
+    %% P(Witness) = RSSIWeight*P(WitnessRSSI) + TimeWeight*P(WitnessTime) + CountWeight*P(WitnessCount)
+    maps:map(fun(WitnessPubkeyBin, PTime) ->
+                     ?normalize_float((time_weight(Vars) * PTime), Vars) +
+                     ?normalize_float(rssi_weight(Vars) * maps:get(WitnessPubkeyBin, PWitnessRSSI), Vars) +
+                     ?normalize_float(count_weight(Vars) * maps:get(WitnessPubkeyBin, PWitnessCount), Vars) +
+                     %% NOTE: The randomness weight is always multiplied with a probability of 1.0
+                     %% So we can do something like:
+                     %%  - Set all the other weights to 0.0
+                     %%  - Set randomness_wt to 1.0
+                     %% Doing that would basically eliminate the other associated weights and
+                     %% make each witness have equal 1.0 probability of getting picked as next hop
+                     ?normalize_float((randomness_wt(Vars) * 1.0), Vars) +
+                     ?normalize_float((centrality_wt(Vars) * maps:get(WitnessPubkeyBin, PWitnessRSSICentrality)), Vars)
+             end, PWitnessTime).
+
+-spec rssi_probs(Witnesses :: blockchain_ledger_gateway_v2:witnesses(),
+                 Vars :: map()) -> prob_map().
+rssi_probs(Witnesses, _Vars) when map_size(Witnesses) == 1 ->
+    %% There is only a single witness, probabilitiy of picking it is 1
+    maps:map(fun(_, _) -> 1.0 end, Witnesses);
+rssi_probs(Witnesses, Vars) ->
+    WitnessList = maps:to_list(Witnesses),
+    lists:foldl(fun({WitnessPubkeyBin, Witness}, Acc) ->
+                        try
+                            blockchain_ledger_gateway_v2:witness_hist(Witness)
+                        of
+                            RSSIs ->
+                                SumRSSI = lists:sum(maps:values(RSSIs)),
+                                BadRSSI = maps:get(28, RSSIs, 0),
+
+                                case {SumRSSI, BadRSSI} of
+                                    {0, _} ->
+                                        %% No RSSI but we have it in the witness list,
+                                        %% possibly because of next hop poc receipt.
+                                        maps:put(WitnessPubkeyBin, prob_no_rssi(Vars), Acc);
+                                    {_S, 0} ->
+                                        %% No known bad rssi value
+                                        maps:put(WitnessPubkeyBin, prob_good_rssi(Vars), Acc);
+                                    {S, S} ->
+                                        %% All bad RSSI values
+                                        maps:put(WitnessPubkeyBin, prob_bad_rssi(Vars), Acc);
+                                    {S, B} ->
+                                        %% Invert the "bad" probability
+                                        maps:put(WitnessPubkeyBin, ?normalize_float((1 - ?normalize_float(B/S, Vars)), Vars), Acc)
+                                end
+                        catch
+                            error:no_histogram ->
+                                maps:put(WitnessPubkeyBin, prob_no_rssi(Vars), Acc)
+                        end
+                end, #{},
+                WitnessList).
+
+
+-spec time_probs(HeadBlockTime :: pos_integer(),
+                 Witnesses :: blockchain_ledger_gateway_v2:witnesses(),
+                 Vars :: map()) -> prob_map().
+time_probs(_, Witnesses, _Vars) when map_size(Witnesses) == 1 ->
+    %% There is only a single witness, probabilitiy of picking it is 1.0
+    maps:map(fun(_, _) -> 1.0 end, Witnesses);
+time_probs(HeadBlockTime, Witnesses, Vars) ->
+    Deltas = lists:foldl(fun({WitnessPubkeyBin, Witness}, Acc) ->
+                                 case blockchain_ledger_gateway_v2:witness_recent_time(Witness) of
+                                     undefined ->
+                                         maps:put(WitnessPubkeyBin, nanosecond_time(HeadBlockTime), Acc);
+                                     T ->
+                                         maps:put(WitnessPubkeyBin, (nanosecond_time(HeadBlockTime) - T), Acc)
+                                 end
+                         end, #{},
+                         maps:to_list(Witnesses)),
+
+    DeltaSum = lists:sum(maps:values(Deltas)),
+
+    %% NOTE: Use inverse of the probabilities to bias against staler witnesses, hence the one minus
+    maps:map(fun(_WitnessPubkeyBin, Delta) ->
+                     case ?normalize_float((1 - ?normalize_float(Delta/DeltaSum, Vars)), Vars) of
+                         0.0 ->
+                             %% There is only one
+                             1.0;
+                         X ->
+                             X
+                     end
+             end, Deltas).
+
+-spec witness_count_probs(Witnesses :: blockchain_ledger_gateway_v2:witnesses(),
+                          Vars :: map()) -> prob_map().
+witness_count_probs(Witnesses, _Vars) when map_size(Witnesses) == 1 ->
+    %% only a single witness, probability = 1.0
+    maps:map(fun(_, _) -> 1.0 end, Witnesses);
+witness_count_probs(Witnesses, Vars) ->
+    TotalRSSIs = maps:map(fun(_WitnessPubkeyBin, Witness) ->
+                                  RSSIs = blockchain_ledger_gateway_v2:witness_hist(Witness),
+                                  lists:sum(maps:values(RSSIs))
+                          end,
+                          Witnesses),
+
+    maps:map(fun(WitnessPubkeyBin, _Witness) ->
+                     case maps:get(WitnessPubkeyBin, TotalRSSIs) of
+                         0 ->
+                             %% No RSSIs at all, default to 1.0
+                             1.0;
+                         S ->
+                             %% Scale and invert this prob
+                             ?normalize_float((1 - ?normalize_float(S/lists:sum(maps:values(TotalRSSIs)), Vars)), Vars)
+                     end
+             end, Witnesses).
+
+-spec witness_rssi_centrality_probs(Witnesses :: blockchain_ledger_gateway_v2:witnesses(),
+                                    Vars :: map()) -> prob_map().
+witness_rssi_centrality_probs(Witnesses, _Vars) when map_size(Witnesses) == 1 ->
+    maps:map(fun(_, _) -> 1.0 end, Witnesses);
+witness_rssi_centrality_probs(Witnesses, Vars) ->
+    maps:map(fun(_WitnessPubkeyBin, Witness) ->
+                     try
+                         blockchain_ledger_gateway_v2:witness_hist(Witness)
+                     of
+                         Hist ->
+                             {MaxMetric, MeanMetric} = centrality_metrics(Hist, Vars),
+                             blockchain_utils:normalize_float((1 - MaxMetric) * (1 - MeanMetric))
+                     catch
+                         error:no_histogram ->
+                             0.0
+                     end
+             end,
+             Witnesses).
+
+
+-spec filter_witnesses(GatewayLoc :: h3:h3_index(),
+                       Indices :: [h3:h3_index()],
+                       Witnesses :: blockchain_ledger_gateway_v2:witnesses(),
+                       Ledger :: blockchain:ledger(),
+                       Vars :: map()) -> blockchain_ledger_gateway_v2:witnesses().
+filter_witnesses(GatewayLoc, Indices, Witnesses, Ledger, Vars) ->
+    {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
+    ParentRes = parent_res(Vars),
+    ExclusionCells = exclusion_cells(Vars),
+    GatewayParent = h3:parent(GatewayLoc, ParentRes),
+    ParentIndices = [h3:parent(Index, ParentRes) || Index <- Indices],
+    maps:filter(fun(WitnessPubkeyBin, Witness) ->
+                        WitnessGw = find(WitnessPubkeyBin, Ledger),
+                        case is_witness_stale(WitnessGw, Height, Vars) of
+                            true ->
+                                false;
+                            false ->
+                                WitnessLoc = blockchain_ledger_gateway_v2:location(WitnessGw),
+                                WitnessParent = h3:parent(WitnessLoc, ParentRes),
+                                %% Dont include any witnesses in any parent cell we've already visited
+                                not(lists:member(WitnessLoc, Indices)) andalso
+                                %% Don't include any witness whose parent is the same as the gateway we're looking at
+                                (GatewayParent /= WitnessParent) andalso
+                                %% Don't include any witness whose parent is too close to any of the indices we've already seen
+                                check_witness_distance(WitnessParent, ParentIndices, ExclusionCells) andalso
+                                check_witness_bad_rssi(Witness, Vars) andalso
+                                check_witness_bad_rssi_centrality(Witness, Vars)
+                        end
+                end,
+                Witnesses).
+
+-spec check_witness_distance(WitnessParent :: h3:h3_index(),
+                             ParentIndices :: [h3:h3_index()],
+                             ExclusionCells :: pos_integer()) -> boolean().
+check_witness_distance(WitnessParent, ParentIndices, ExclusionCells) ->
+    not(lists:any(fun(ParentIndex) ->
+                          try h3:grid_distance(WitnessParent, ParentIndex) < ExclusionCells of
+                              Res -> Res
+                          catch
+                              %% Grid distance may badarg because of pentagonal distortion or
+                              %% non matching resolutions or just being too far.
+                              %% In either of those cases, we assume that the gateway
+                              %% is potentially legitimate to be a target.
+                              _:_ -> true
+                          end
+                  end, ParentIndices)).
+
+-spec check_witness_bad_rssi(Witness :: blockchain_ledger_gateway_v2:gateway_witness(),
+                             Vars :: map()) -> boolean().
+check_witness_bad_rssi(Witness, Vars) ->
+    case poc_version(Vars) of
+        V when is_integer(V), V > 4 ->
+            try
+                blockchain_ledger_gateway_v2:witness_hist(Witness)
+            of
+                Hist ->
+                    case maps:get(28, Hist, 0) of
+                        0 ->
+                            %% No bad RSSIs found, include
+                            true;
+                        BadCount when is_integer(V), V > 5 ->
+                            %% Activate with PoC v6
+                            %% Check that the bad rssi count is less than
+                            %% the sum of other known good rssi
+                            BadCount < lists:sum(maps:values(maps:without([28], Hist)));
+                        BadCount ->
+                            %% If the bad RSSI count does not dominate
+                            %% the overall RSSIs this witness has, include,
+                            %% otherwise exclude
+                            %% XXX: This is an incorrect check
+                            BadCount < lists:sum(maps:values(Hist))
+                    end
+            catch
+                error:no_histogram ->
+                    %% No histogram found, include
+                    true
+            end;
+        _ ->
+            true
+    end.
+
+-spec check_witness_bad_rssi_centrality(Witness :: blockchain_ledger_gateway_v2:gateway_witness(),
+                                        Vars :: map()) -> boolean().
+check_witness_bad_rssi_centrality(Witness, Vars) ->
+    try
+        blockchain_ledger_gateway_v2:witness_hist(Witness)
+    of
+        Hist ->
+            case centrality_metrics(Hist, Vars) of
+                %% TODO: Check more conditions?
+                %% Check whether the ratio of maxbad/maxgood or meanbad/meangood exceeds 1.0
+                %% If so, we exclude that witness
+                {M1, M2} when M1 >= 1.0 orelse M2 >= 1.0 ->
+                    false;
+                _ ->
+                    true
+            end
+    catch
+        error:no_histogram ->
+            false
+    end.
+
+-spec is_witness_stale(Gateway :: blockchain_ledger_gateway_v2:gateway(),
+                       Height :: pos_integer(),
+                       Vars :: map()) -> boolean().
+is_witness_stale(Gateway, Height, Vars) ->
+    case blockchain_ledger_gateway_v2:last_poc_challenge(Gateway) of
+        undefined ->
+            %% No POC challenge, don't include
+            true;
+        C ->
+            %% Check challenge age is recent depending on the set chain var
+            (Height - C) >= challenge_age(Vars)
+    end.
+
+-spec rssi_weight(Vars :: map()) -> float().
+rssi_weight(Vars) ->
+    maps:get(poc_v4_prob_rssi_wt, Vars).
+
+-spec time_weight(Vars :: map()) -> float().
+time_weight(Vars) ->
+    maps:get(poc_v4_prob_time_wt, Vars).
+
+-spec count_weight(Vars :: map()) -> float().
+count_weight(Vars) ->
+    maps:get(poc_v4_prob_count_wt, Vars).
+
+-spec prob_no_rssi(Vars :: map()) -> float().
+prob_no_rssi(Vars) ->
+    maps:get(poc_v4_prob_no_rssi, Vars).
+
+-spec prob_good_rssi(Vars :: map()) -> float().
+prob_good_rssi(Vars) ->
+    maps:get(poc_v4_prob_good_rssi, Vars).
+
+-spec prob_bad_rssi(Vars :: map()) -> float().
+prob_bad_rssi(Vars) ->
+    maps:get(poc_v4_prob_bad_rssi, Vars).
+
+-spec parent_res(Vars :: map()) -> pos_integer().
+parent_res(Vars) ->
+    maps:get(poc_v4_parent_res, Vars).
+
+-spec exclusion_cells(Vars :: map()) -> pos_integer().
+exclusion_cells(Vars) ->
+    maps:get(poc_v4_exclusion_cells, Vars).
+
+-spec nanosecond_time(Time :: integer()) -> integer().
+nanosecond_time(Time) ->
+    erlang:convert_time_unit(Time, millisecond, nanosecond).
+
+-spec randomness_wt(Vars :: map()) -> float().
+randomness_wt(Vars) ->
+    maps:get(poc_v4_randomness_wt, Vars).
+
+-spec centrality_wt(Vars :: map()) -> float().
+centrality_wt(Vars) ->
+    maps:get(poc_centrality_wt, Vars).
+
+-spec poc_version(Vars :: map()) -> pos_integer().
+poc_version(Vars) ->
+    maps:get(poc_version, Vars).
+
+-spec challenge_age(Vars :: map()) -> pos_integer().
+challenge_age(Vars) ->
+    maps:get(poc_v4_target_challenge_age, Vars).
+
+-spec poc_good_bucket_low(Vars :: map()) -> integer().
+poc_good_bucket_low(Vars) ->
+    maps:get(poc_good_bucket_low, Vars).
+
+-spec poc_good_bucket_high(Vars :: map()) -> integer().
+poc_good_bucket_high(Vars) ->
+    maps:get(poc_good_bucket_high, Vars).
+
+
+%% Helper Functions
+%% ==================================================================
+
+%% we assume that everything that has made it into build has already
+%% been asserted, and thus the lookup will never fail. This function
+%% in no way exists simply because
+%% blockchain_ledger_v1:find_gateway_info is too much to type a bunch
+%% of times.
+find(Addr, Ledger) ->
+    {ok, Gw} = blockchain_ledger_v1:find_gateway_info(Addr, Ledger),
+    Gw.
+
+-spec split_hist(Hist :: blockchain_ledger_gateway_v2:histogram(),
+                 Vars :: map()) -> {blockchain_ledger_gateway_v2:histogram(),
+                                    blockchain_ledger_gateway_v2:histogram()}.
+split_hist(Hist, Vars) ->
+    %% TODO: Maybe these can just be constants instead of vars?
+    GoodBucketLow = poc_good_bucket_low(Vars),
+    GoodBucketHigh = poc_good_bucket_high(Vars),
+
+    %% Split the histogram into two buckets
+    lists:foldl(fun({Bucket, Val}, {GoodAcc, BadAcc}) ->
+                        case lists:member(Bucket, lists:seq(GoodBucketLow, GoodBucketHigh)) of
+                            true ->
+                                maps:put(Bucket, Val, GoodAcc);
+                            false ->
+                                maps:put(Bucket, Val, BadAcc)
+                        end
+                end,
+                {#{}, #{}},
+                maps:to_list(Hist)).
+
+-spec centrality_metrics(Hist :: blockchain_ledger_gateway_v2:histogram(),
+                         Vars :: map()) -> {float(), float()}.
+centrality_metrics(Hist, Vars) ->
+    {GoodBucket, BadBucket} = split_hist(Hist, Vars),
+
+    GoodBucketValues = maps:values(GoodBucket),
+    BadBucketValues = maps:values(BadBucket),
+
+    MaxGood = lists:max(GoodBucketValues),
+    MaxBad = lists:max(BadBucketValues),
+    MeanGood = blockchain_utils:normalize_float(lists:sum(GoodBucketValues) / length(GoodBucketValues)),
+    MeanBad = blockchain_utils:normalize_float(lists:sum(BadBucketValues) / length(BadBucketValues)),
+
+    MaxMetric = blockchain_utils:normalize_float(MaxBad / MaxGood),
+    MeanMetric = blockchain_utils:normalize_float(MeanBad / MeanGood),
+
+    {MaxMetric, MeanMetric}.

--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -216,6 +216,8 @@ icdf_select(PopulationList, Rnd) ->
 %% ------------------------------------------------------------------
 %% Internal Function Definitions
 %% ------------------------------------------------------------------
+icdf_select([{_Node, 0.0}], _Rnd, _OrigRnd) ->
+    {error, zero_weight};
 icdf_select([{Node, _Weight}], _Rnd, _OrigRnd) ->
     {ok, Node};
 icdf_select([{Node, Weight} | _], Rnd, _OrigRnd) when Rnd - Weight =< 0 ->

--- a/src/ledger/v1/blockchain_ledger_gateway_v2.erl
+++ b/src/ledger/v1/blockchain_ledger_gateway_v2.erl
@@ -65,7 +65,8 @@
 -type gateway() :: #gateway_v2{}.
 -type gateway_witness() :: #witness{}.
 -type witnesses() :: #{libp2p_crypto:pubkey_bin() => gateway_witness()}.
--export_type([gateway/0, gateway_witness/0, witnesses/0]).
+-type histogram() :: #{integer() => integer()}.
+-export_type([gateway/0, gateway_witness/0, witnesses/0, histogram/0]).
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -400,7 +401,7 @@ has_witness(#gateway_v2{witnesses=Witnesses}, WitnessAddr) ->
 witnesses(Gateway) ->
     Gateway#gateway_v2.witnesses.
 
--spec witness_hist(gateway_witness()) -> erlang:error(no_histogram) | #{integer() => integer()}.
+-spec witness_hist(gateway_witness()) -> erlang:error(no_histogram) | histogram().
 witness_hist(Witness) ->
     Witness#witness.hist.
 

--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -218,6 +218,18 @@ is_valid(Txn, Chain) ->
                                                                     {ok, OldLedger} = blockchain:ledger_at(blockchain_block:height(Block1), Chain),
                                                                     maybe_log_duration(ledger_at, StartLA),
                                                                     Path = case blockchain:config(?poc_version, OldLedger) of
+                                                                               {ok, V} when V >= 8 ->
+                                                                                   Vars = blockchain_utils:vars_binary_keys_to_atoms(blockchain_ledger_v1:all_vars(OldLedger)),
+                                                                                   StartFT = erlang:monotonic_time(millisecond),
+                                                                                   %% If we make it to this point, we are bound to have a target.
+                                                                                   {ok, Target} = blockchain_poc_target_v2:target_v2(Entropy, OldLedger, Vars),
+                                                                                   maybe_log_duration(target, StartFT),
+                                                                                   StartB = erlang:monotonic_time(millisecond),
+                                                                                   Time = blockchain_block:time(Block1),
+                                                                                   RetB = blockchain_poc_path_v4:build(Target, OldLedger, Time, Entropy, Vars),
+                                                                                   maybe_log_duration(build, StartB),
+                                                                                   RetB;
+
                                                                                {ok, V} when V >= 7 ->
                                                                                    Vars = blockchain_utils:vars_binary_keys_to_atoms(blockchain_ledger_v1:all_vars(OldLedger)),
                                                                                    StartFT = erlang:monotonic_time(millisecond),

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -641,7 +641,7 @@ validate_var(?poc_challenge_interval, Value) ->
     validate_int(Value, "poc_challenge_interval", 10, 1440, false);
 validate_var(?poc_version, Value) ->
     case Value of
-        N when is_integer(N), N >= 1,  N =< 7 ->
+        N when is_integer(N), N >= 1,  N =< 8 ->
             ok;
         _ ->
             throw({error, {invalid_poc_version, Value}})
@@ -690,6 +690,10 @@ validate_var(?poc_typo_fixes, Value) ->
     end;
 validate_var(?poc_target_hex_parent_res, Value) ->
     validate_int(Value, "poc_target_hex_parent_res", 3, 7, false);
+validate_var(?poc_good_bucket_low, Value) ->
+    validate_int(Value, "poc_good_bucket_low", -70, -150, false);
+validate_var(?poc_good_bucket_high, Value) ->
+    validate_int(Value, "poc_good_bucket_high", -70, 29, false);
 
 %% score vars
 validate_var(?alpha_decay, Value) ->

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -691,9 +691,11 @@ validate_var(?poc_typo_fixes, Value) ->
 validate_var(?poc_target_hex_parent_res, Value) ->
     validate_int(Value, "poc_target_hex_parent_res", 3, 7, false);
 validate_var(?poc_good_bucket_low, Value) ->
-    validate_int(Value, "poc_good_bucket_low", -70, -150, false);
+    validate_int(Value, "poc_good_bucket_low", -150, -90, false);
 validate_var(?poc_good_bucket_high, Value) ->
-    validate_int(Value, "poc_good_bucket_high", -70, 29, false);
+    validate_int(Value, "poc_good_bucket_high", -100, -70, false);
+validate_var(?poc_centrality_wt, Value) ->
+    validate_float(Value, "poc_centrality_wt", 0.0, 1.0);
 
 %% score vars
 validate_var(?alpha_decay, Value) ->


### PR DESCRIPTION
This PR adds "centrality" checks for the RSSI histograms we have collected in the ledger.

We split the histogram into two "buckets" and assign probability depending on whether the witnessing appears within an acceptable range which is controlled by introducing three new chain vars:

- `poc_good_bucket_low` -> lower bound for RSSI
- `poc_good_bucket_high` -> upper bound for RSSI
- `poc_centrality_wt` -> weightage given to the centrality probability

I've also added another eqc for the same.