### PR TITLE
Maybe start new sync handler client if hit disjoint_chain error when adding block

### DIFF
--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -31,6 +31,7 @@
 
     new_ledger/1,
 
+    maybe_sync/0,
     sync/0,
     cancel_sync/0,
     pause_sync/0,
@@ -106,6 +107,9 @@ cancel_sync() ->
 
 pause_sync() ->
     gen_server:call(?SERVER, pause_sync, infinity).
+
+maybe_sync() ->
+    gen_server:call(?SERVER, maybe_sync, infinity).
 
 sync_paused() ->
     try
@@ -344,6 +348,9 @@ handle_call({new_ledger, Dir}, _From, State) ->
     %% snapshot cache ETS table can be owned by an ephemeral process.
     Ledger1 = blockchain_ledger_v1:new(Dir),
     {reply, {ok, Ledger1}, State};
+
+handle_call(maybe_sync, _From, State) ->
+    {reply, ok, maybe_sync(State)};
 handle_call(sync, _From, State) ->
     %% if sync is paused, unpause it
     {reply, ok, maybe_sync(State#state{sync_paused = false})};

--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -109,7 +109,7 @@ pause_sync() ->
     gen_server:call(?SERVER, pause_sync, infinity).
 
 maybe_sync() ->
-    gen_server:call(?SERVER, maybe_sync, infinity).
+    gen_server:cast(?SERVER, maybe_sync).
 
 sync_paused() ->
     try
@@ -349,8 +349,6 @@ handle_call({new_ledger, Dir}, _From, State) ->
     Ledger1 = blockchain_ledger_v1:new(Dir),
     {reply, {ok, Ledger1}, State};
 
-handle_call(maybe_sync, _From, State) ->
-    {reply, ok, maybe_sync(State)};
 handle_call(sync, _From, State) ->
     %% if sync is paused, unpause it
     {reply, ok, maybe_sync(State#state{sync_paused = false})};
@@ -364,6 +362,8 @@ handle_call(_Msg, _From, State) ->
     lager:warning("rcvd unknown call msg: ~p from: ~p", [_Msg, _From]),
     {reply, ok, State}.
 
+handle_cast(maybe_sync, State) ->
+    {noreply, maybe_sync(State)};
 handle_cast({integrate_genesis_block, GenesisBlock}, #state{blockchain={no_genesis, Blockchain}
                                                             ,swarm=Swarm}=State) ->
     case blockchain_block:is_genesis(GenesisBlock) of

--- a/src/handlers/blockchain_gossip_handler.erl
+++ b/src/handlers/blockchain_gossip_handler.erl
@@ -48,28 +48,14 @@ handle_gossip_data(_StreamPid, Data, [Swarm, Blockchain]) ->
     end,
     noreply.
 
-add_block(Swarm, Block, Chain, Sender) ->
+add_block(_Swarm, Block, Chain, Sender) ->
     lager:debug("Sender: ~p, MyAddress: ~p", [Sender, blockchain_swarm:pubkey_bin()]),
     case blockchain:add_block(Block, Chain) of
         ok ->
             ok;
         {error, disjoint_chain} ->
-            lager:warning("gossipped block doesn't fit with our chain"),
-            P2PPubkeyBin = libp2p_crypto:pubkey_bin_to_p2p(Sender),
-            lager:info("syncing with the sender ~p", [P2PPubkeyBin]),
-            case libp2p_swarm:dial_framed_stream(Swarm,
-                                                 P2PPubkeyBin,
-                                                 ?SYNC_PROTOCOL,
-                                                 blockchain_sync_handler,
-                                                 [Chain])
-            of
-                {ok, Stream} ->
-                    erlang:unlink(Stream),
-                    {ok, HeadHash} = blockchain:head_hash(Chain),
-                    Stream ! {hash, HeadHash};
-                _Error ->
-                    lager:warning("Failed to dial sync service on: ~p ~p", [P2PPubkeyBin, _Error])
-            end;
+            lager:warning("gossipped block doesn't fit with our chain, do nothing"),
+            ok;
         Error ->
             %% Uhm what is this?
             lager:error("Something bad happened: ~p", [Error])

--- a/src/handlers/blockchain_gossip_handler.erl
+++ b/src/handlers/blockchain_gossip_handler.erl
@@ -54,7 +54,7 @@ add_block(_Swarm, Block, Chain, Sender) ->
         ok ->
             ok;
         {error, disjoint_chain} ->
-            lager:warning("gossipped block doesn't fit with our chain, will start sync if not already actve"),
+            lager:warning("gossipped block doesn't fit with our chain, will start sync if not already active"),
             blockchain_worker:maybe_sync(),
             ok;
         Error ->

--- a/src/handlers/blockchain_gossip_handler.erl
+++ b/src/handlers/blockchain_gossip_handler.erl
@@ -54,7 +54,8 @@ add_block(_Swarm, Block, Chain, Sender) ->
         ok ->
             ok;
         {error, disjoint_chain} ->
-            lager:warning("gossipped block doesn't fit with our chain, do nothing"),
+            lager:warning("gossipped block doesn't fit with our chain, will start sync if not already actve"),
+            blockchain_worker:maybe_sync(),
             ok;
         Error ->
             %% Uhm what is this?


### PR DESCRIPTION
Remove the starting up off a new blockchain_sync_handler stream in the event we hit disjoint_chain error when adding a block from gossip handler.  Instead call into blockchain worker and have it start a sync handler only if one is not already running.

End result is that we only ever have a single running client sync handler which is managed from blockchain worker.