### PR TITLE
change tmp dir to be relative from _build dir

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -1532,7 +1532,8 @@ new_test() ->
     ?assertEqual({ok, Hash}, head_hash(Chain)),
     ?assertEqual({ok, Block}, head_block(Chain)),
     ?assertEqual({ok, Block}, get_block(Hash, Chain)),
-    ?assertEqual({ok, Block}, get_block(1, Chain)).
+    ?assertEqual({ok, Block}, get_block(1, Chain)),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 % ledger_test() ->
 %     Block = blockchain_block:new_genesis_block([]),
@@ -1576,7 +1577,8 @@ blocks_test() ->
 
     GenBlock = blockchain_block:new_genesis_block(VarTxns),
     GenHash = blockchain_block:hash_block(GenBlock),
-    {ok, Chain} = new(test_utils:tmp_dir("blocks_test"), GenBlock, undefined),
+    TmpDir = test_utils:tmp_dir("blocks_test"),
+    {ok, Chain} = new(TmpDir, GenBlock, undefined),
     Block = blockchain_block_v1:new(#{prev_hash => GenHash,
                                       height => 2,
                                       transactions => [],
@@ -1605,7 +1607,8 @@ blocks_test() ->
     ?assert(meck:validate(blockchain_election)),
     meck:unload(blockchain_election),
     ?assert(meck:validate(blockchain_swarm)),
-    meck:unload(blockchain_swarm).
+    meck:unload(blockchain_swarm),
+    test_utils:cleanup_tmp_dir(TmpDir).
 
 
 
@@ -1646,7 +1649,8 @@ get_block_test() ->
 
     GenBlock = blockchain_block:new_genesis_block(VarTxns),
     GenHash = blockchain_block:hash_block(GenBlock),
-    {ok, Chain} = new(test_utils:tmp_dir("get_block_test"), GenBlock, undefined),
+    TmpDir = test_utils:tmp_dir("get_block_test"),
+    {ok, Chain} = new(TmpDir, GenBlock, undefined),
     Block = blockchain_block_v1:new(#{prev_hash => GenHash,
                                       height => 2,
                                       transactions => [],
@@ -1671,7 +1675,8 @@ get_block_test() ->
     ?assert(meck:validate(blockchain_election)),
     meck:unload(blockchain_election),
     ?assert(meck:validate(blockchain_swarm)),
-    meck:unload(blockchain_swarm).
+    meck:unload(blockchain_swarm),
+    test_utils:cleanup_tmp_dir(TmpDir).
 
 
 -endif.

--- a/src/blockchain_poc_packet.erl
+++ b/src/blockchain_poc_packet.erl
@@ -208,56 +208,64 @@ encrypt_decrypt_multi_layer_poc_v4_test_() ->
     [{"no blockhash entropy", fun() ->
         TestDir = test_utils:tmp_dir("encrypt_decrypt_test_1"),
         Ledger = blockchain_ledger_v1:new(TestDir),
-        encrypt_decrypt(Ledger)
+        encrypt_decrypt(Ledger),
+        test_utils:cleanup_tmp_dir(TestDir)
       end},
      {"added blockhash entropy", fun() ->
          TestDir = test_utils:tmp_dir("encrypt_decrypt_test_2"),
          Ledger = blockchain_ledger_v1:new(TestDir),
          Ledger1 = blockchain_ledger_v1:new_context(Ledger),
          blockchain_ledger_v1:vars(#{?poc_version => 4}, [], Ledger1),
-         encrypt_decrypt(Ledger1)
+         encrypt_decrypt(Ledger1),
+         test_utils:cleanup_tmp_dir(TestDir)
       end}].
 
 encrypt_decrypt_single_layer_poc_v4_test_() ->
     [{"no blockhash entropy", fun() ->
         TestDir = test_utils:tmp_dir("encrypt_decrypt_test_1"),
         Ledger = blockchain_ledger_v1:new(TestDir),
-        encrypt_decrypt_single_layer(Ledger)
+        encrypt_decrypt_single_layer(Ledger),
+        test_utils:cleanup_tmp_dir(TestDir)
       end},
      {"added blockhash entropy", fun() ->
          TestDir = test_utils:tmp_dir("encrypt_decrypt_test_2"),
          Ledger = blockchain_ledger_v1:new(TestDir),
          Ledger1 = blockchain_ledger_v1:new_context(Ledger),
          blockchain_ledger_v1:vars(#{?poc_version => 4}, [], Ledger1),
-         encrypt_decrypt_single_layer(Ledger1)
+         encrypt_decrypt_single_layer(Ledger1),
+         test_utils:cleanup_tmp_dir(TestDir)
       end}].
 
 encrypt_decrypt_double_layer_poc_v4_test_() ->
     [{"no blockhash entropy", fun() ->
         TestDir = test_utils:tmp_dir("encrypt_decrypt_test_1"),
         Ledger = blockchain_ledger_v1:new(TestDir),
-        encrypt_decrypt_double_layer(Ledger)
+        encrypt_decrypt_double_layer(Ledger),
+        test_utils:cleanup_tmp_dir(TestDir)
       end},
      {"added blockhash entropy", fun() ->
          TestDir = test_utils:tmp_dir("encrypt_decrypt_test_2"),
          Ledger = blockchain_ledger_v1:new(TestDir),
          Ledger1 = blockchain_ledger_v1:new_context(Ledger),
          blockchain_ledger_v1:vars(#{?poc_version => 4}, [], Ledger1),
-         encrypt_decrypt_double_layer(Ledger1)
+         encrypt_decrypt_double_layer(Ledger1),
+         test_utils:cleanup_tmp_dir(TestDir)
       end}].
 
 encrypt_decrypt_test_() ->
     [{"no blockhash entropy", fun() ->
         TestDir = test_utils:tmp_dir("encrypt_decrypt_test_1"),
         Ledger = blockchain_ledger_v1:new(TestDir),
-        encrypt_decrypt(Ledger)
+        encrypt_decrypt(Ledger),
+        test_utils:cleanup_tmp_dir(TestDir)
       end},
      {"added blockhash entropy", fun() ->
          TestDir = test_utils:tmp_dir("encrypt_decrypt_test_2"),
          Ledger = blockchain_ledger_v1:new(TestDir),
          Ledger1 = blockchain_ledger_v1:new_context(Ledger),
          blockchain_ledger_v1:vars(#{?poc_version => 2}, [], Ledger1),
-         encrypt_decrypt(Ledger1)
+         encrypt_decrypt(Ledger1),
+         test_utils:cleanup_tmp_dir(TestDir)
       end}].
 
 encrypt_decrypt_single_layer(Ledger) ->

--- a/src/blockchain_poc_path.erl
+++ b/src/blockchain_poc_path.erl
@@ -561,6 +561,7 @@ target_test_() ->
               ),
 
              unload_meck(),
+             test_utils:cleanup_tmp_dir(BaseDir),
              ok
      end}.
 
@@ -596,6 +597,7 @@ neighbors_test() ->
      ),
     unload_meck(),
     catch blockchain_score_cache:stop(),
+    test_utils:cleanup_tmp_dir(BaseDir),
     ok.
 
 build_graph_test() ->
@@ -623,6 +625,7 @@ build_graph_test() ->
     TooFar = crypto:hash(sha256, erlang:term_to_binary(LL1)),
     ?assertNot(lists:member(TooFar, maps:keys(Graph))),
     unload_meck(),
+    test_utils:cleanup_tmp_dir(BaseDir),
     ok.
 
 build_graph_in_line_test() ->
@@ -680,6 +683,7 @@ build_graph_in_line_test() ->
      ),
     unload_meck(),
     catch blockchain_score_cache:stop(),
+    test_utils:cleanup_tmp_dir(BaseDir),
     ok.
 
 build_test() ->
@@ -709,6 +713,7 @@ build_test() ->
     ?assertNotEqual(Target, lists:last(Path)),
     unload_meck(),
     catch blockchain_score_cache:stop(),
+    test_utils:cleanup_tmp_dir(BaseDir),
     ok.
 
 build_only_2_test() ->
@@ -732,6 +737,7 @@ build_only_2_test() ->
     ?assertNotEqual(Target, lists:last(Path)),
     unload_meck(),
     catch blockchain_score_cache:stop(),
+    test_utils:cleanup_tmp_dir(BaseDir),
     ok.
 
 build_prob_test_() ->
@@ -782,6 +788,7 @@ build_prob_test_() ->
               ),
              unload_meck(),
              catch blockchain_score_cache:stop(),
+             test_utils:cleanup_tmp_dir(BaseDir),
              ok
      end}.
 
@@ -801,6 +808,7 @@ build_failed_test() ->
     ?assertEqual({error, not_enough_gateways}, build(crypto:strong_rand_bytes(32), Target, Gateways, 1, Ledger)),
     unload_meck(),
     catch blockchain_score_cache:stop(),
+    test_utils:cleanup_tmp_dir(BaseDir),
     ok.
 
 build_with_default_score_test() ->
@@ -826,6 +834,7 @@ build_with_default_score_test() ->
     ?assert(lists:member(Target, Path)),
     unload_meck(),
     catch blockchain_score_cache:stop(),
+    test_utils:cleanup_tmp_dir(BaseDir),
     ok.
 
 active_gateways_test() ->
@@ -855,6 +864,7 @@ active_gateways_test() ->
 
     unload_meck(),
     catch blockchain_score_cache:stop(),
+    test_utils:cleanup_tmp_dir(BaseDir),
     ok.
 
 -ifdef(BROKEN).
@@ -886,6 +896,7 @@ active_gateways_low_score_test() ->
 
     unload_meck(),
     catch blockchain_score_cache:stop(),
+    test_utils:cleanup_tmp_dir(BaseDir),
     ok.
 -endif.
 
@@ -920,6 +931,7 @@ no_neighbor_test() ->
     ?assertEqual({error, not_enough_gateways}, build(crypto:strong_rand_bytes(32), Target, Gateways, 1, Ledger)),
     unload_meck(),
     catch blockchain_score_cache:stop(),
+    test_utils:cleanup_tmp_dir(BaseDir),
     ok.
 
 build_gateways(LatLongs, Ledger) ->

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -2208,12 +2208,14 @@ clean_all_hexes(Ledger) ->
 find_entry_test() ->
     BaseDir = test_utils:tmp_dir("find_entry_test"),
     Ledger = new(BaseDir),
-    ?assertEqual({error, not_found}, find_entry(<<"test">>, Ledger)).
+    ?assertEqual({error, not_found}, find_entry(<<"test">>, Ledger)),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 find_gateway_info_test() ->
     BaseDir = test_utils:tmp_dir("find_gateway_info_test"),
     Ledger = new(BaseDir),
-    ?assertEqual({error, not_found}, find_gateway_info(<<"address">>, Ledger)).
+    ?assertEqual({error, not_found}, find_gateway_info(<<"address">>, Ledger)),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 mode_test() ->
     BaseDir = test_utils:tmp_dir("mode_test"),
@@ -2225,12 +2227,14 @@ mode_test() ->
     ?assertEqual({ok, [1, 2, 3]}, consensus_members(Ledger)),
     Ledger2 = mode(delayed, Ledger1),
     Ledger3 = new_context(Ledger2),
-    ?assertEqual({error, not_found}, consensus_members(Ledger3)).
+    ?assertEqual({error, not_found}, consensus_members(Ledger3)),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 consensus_members_1_test() ->
     BaseDir = test_utils:tmp_dir("consensus_members_1_test"),
     Ledger = new(BaseDir),
-    ?assertEqual({error, not_found}, consensus_members(Ledger)).
+    ?assertEqual({error, not_found}, consensus_members(Ledger)),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 consensus_members_2_test() ->
     BaseDir = test_utils:tmp_dir("consensus_members_2_test"),
@@ -2238,7 +2242,8 @@ consensus_members_2_test() ->
     Ledger1 = new_context(Ledger),
     ok = consensus_members([1, 2, 3], Ledger1),
     ok = commit_context(Ledger1),
-    ?assertEqual({ok, [1, 2, 3]}, consensus_members(Ledger)).
+    ?assertEqual({ok, [1, 2, 3]}, consensus_members(Ledger)),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 active_gateways_test() ->
     BaseDir = test_utils:tmp_dir("active_gateways_test"),
@@ -2255,7 +2260,8 @@ add_gateway_test() ->
         {ok, _},
         find_gateway_info(<<"gw_address">>, Ledger)
     ),
-    ?assertEqual({error, gateway_already_active}, add_gateway(<<"owner_address">>, <<"gw_address">>, Ledger)).
+    ?assertEqual({error, gateway_already_active}, add_gateway(<<"owner_address">>, <<"gw_address">>, Ledger)),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 add_gateway_location_test() ->
     BaseDir = test_utils:tmp_dir("add_gateway_location_test"),
@@ -2267,7 +2273,8 @@ add_gateway_location_test() ->
     ?assertEqual(
        ok,
        add_gateway_location(<<"gw_address">>, 1, 1, Ledger2)
-    ).
+    ),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 credit_account_test() ->
     BaseDir = test_utils:tmp_dir("credit_account_test"),
@@ -2276,7 +2283,8 @@ credit_account_test() ->
     ok = credit_account(<<"address">>, 1000, Ledger1),
     ok = commit_context(Ledger1),
     {ok, Entry} = find_entry(<<"address">>, Ledger),
-    ?assertEqual(1000, blockchain_ledger_entry_v1:balance(Entry)).
+    ?assertEqual(1000, blockchain_ledger_entry_v1:balance(Entry)),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 debit_account_test() ->
     BaseDir = test_utils:tmp_dir("debit_account_test"),
@@ -2292,7 +2300,8 @@ debit_account_test() ->
     ok = commit_context(Ledger2),
     {ok, Entry} = find_entry(<<"address">>, Ledger),
     ?assertEqual(500, blockchain_ledger_entry_v1:balance(Entry)),
-    ?assertEqual(1, blockchain_ledger_entry_v1:nonce(Entry)).
+    ?assertEqual(1, blockchain_ledger_entry_v1:nonce(Entry)),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 credit_dc_test() ->
     BaseDir = test_utils:tmp_dir("credit_dc_test"),
@@ -2301,7 +2310,8 @@ credit_dc_test() ->
     ok = credit_dc(<<"address">>, 1000, Ledger1),
     ok = commit_context(Ledger1),
     {ok, Entry} = find_dc_entry(<<"address">>, Ledger),
-    ?assertEqual(1000, blockchain_ledger_data_credits_entry_v1:balance(Entry)).
+    ?assertEqual(1000, blockchain_ledger_data_credits_entry_v1:balance(Entry)),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 debit_fee_test() ->
     BaseDir = test_utils:tmp_dir("debit_fee_test"),
@@ -2315,7 +2325,8 @@ debit_fee_test() ->
     ok = commit_context(Ledger2),
     {ok, Entry} = find_dc_entry(<<"address">>, Ledger),
     ?assertEqual(500, blockchain_ledger_data_credits_entry_v1:balance(Entry)),
-    ?assertEqual(0, blockchain_ledger_data_credits_entry_v1:nonce(Entry)).
+    ?assertEqual(0, blockchain_ledger_data_credits_entry_v1:nonce(Entry)),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 credit_security_test() ->
     BaseDir = test_utils:tmp_dir("credit_security_test"),
@@ -2328,7 +2339,8 @@ credit_security_test() ->
     ),
     {ok, Entry} = find_security_entry(<<"address">>, Ledger),
     ?assertEqual(#{<<"address">> => Entry}, securities(Ledger)),
-    ?assertEqual(1000, blockchain_ledger_security_entry_v1:balance(Entry)).
+    ?assertEqual(1000, blockchain_ledger_security_entry_v1:balance(Entry)),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 debit_security_test() ->
     BaseDir = test_utils:tmp_dir("debit_security_test"),
@@ -2350,7 +2362,8 @@ debit_security_test() ->
     ),
     {ok, Entry} = find_security_entry(<<"address">>, Ledger),
     ?assertEqual(500, blockchain_ledger_security_entry_v1:balance(Entry)),
-    ?assertEqual(1, blockchain_ledger_security_entry_v1:nonce(Entry)).
+    ?assertEqual(1, blockchain_ledger_security_entry_v1:nonce(Entry)),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 fold_test() ->
     BaseDir = test_utils:tmp_dir("poc_test"),
@@ -2421,7 +2434,8 @@ fold_test() ->
     %% check cached and uncached reads
     ?assertEqual({ok, <<"bbb">>}, cache_get(Ledger, DCF, <<"aaa">>, [])),
 
-    ?assertEqual({ok, <<"bbb">>}, cache_get(Ledger, DCF, <<"key_1">>, [])).
+    ?assertEqual({ok, <<"bbb">>}, cache_get(Ledger, DCF, <<"key_1">>, [])),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 
 poc_test() ->
@@ -2519,7 +2533,7 @@ poc_test() ->
     ?assertEqual(OnionKeyHash1, blockchain_ledger_gateway_v2:last_poc_onion_key_hash(GwInfo1)),
     meck:unload(blockchain_swarm),
     meck:unload(blockchain),
-
+    test_utils:cleanup_tmp_dir(BaseDir),
     ok.
 
 commit(Fun, Ledger0) ->
@@ -2564,7 +2578,7 @@ routing_test() ->
 
     ?assertEqual({ok, [1]}, blockchain_ledger_v1:find_ouis(<<"owner">>, Ledger)),
     ?assertEqual({ok, [2]}, blockchain_ledger_v1:find_ouis(<<"owner2">>, Ledger)),
-
+    test_utils:cleanup_tmp_dir(BaseDir),
     ok.
 
 -endif.

--- a/src/transactions/v1/blockchain_txn_rewards_v1.erl
+++ b/src/transactions/v1/blockchain_txn_rewards_v1.erl
@@ -654,7 +654,9 @@ consensus_members_rewards_test() ->
     end),
     ?assertEqual(Rewards, consensus_members_rewards(Ledger, Vars)),
     ?assert(meck:validate(blockchain_ledger_v1)),
-    meck:unload(blockchain_ledger_v1).
+    meck:unload(blockchain_ledger_v1),
+    test_utils:cleanup_tmp_dir(BaseDir).
+
 
 
 securities_rewards_test() ->
@@ -679,7 +681,8 @@ securities_rewards_test() ->
     end),
     ?assertEqual(Rewards, securities_rewards(Ledger, Vars)),
     ?assert(meck:validate(blockchain_ledger_v1)),
-    meck:unload(blockchain_ledger_v1).
+    meck:unload(blockchain_ledger_v1),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 poc_challengers_rewards_1_test() ->
     Txns = [
@@ -885,7 +888,8 @@ poc_challengees_rewards_3_test() ->
         %% c gets 2 shares
         {gateway, poc_challengees, <<"c">>} => 44
     },
-    ?assertEqual(Rewards, poc_challengees_rewards(Txns, Vars, Ledger)).
+    ?assertEqual(Rewards, poc_challengees_rewards(Txns, Vars, Ledger)),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 poc_witnesses_rewards_test() ->
     BaseDir = test_utils:tmp_dir("poc_witnesses_rewards_test"),
@@ -935,7 +939,8 @@ poc_witnesses_rewards_test() ->
     Rewards = #{{gateway,poc_witnesses,<<"a">>} => 25,
                 {gateway,poc_witnesses,<<"b">>} => 25},
 
-    ?assertEqual(Rewards, poc_witnesses_rewards(Txns, EpochVars, Ledger)).
+    ?assertEqual(Rewards, poc_witnesses_rewards(Txns, EpochVars, Ledger)),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 old_poc_challengers_rewards_test() ->
     Txns = [
@@ -981,7 +986,8 @@ old_poc_challengees_rewards_version_1_test() ->
         {gateway, poc_challengees, <<"1">>} => 175,
         {gateway, poc_challengees, <<"2">>} => 175
     },
-    ?assertEqual(Rewards, poc_challengees_rewards(Txns, Vars, Ledger)).
+    ?assertEqual(Rewards, poc_challengees_rewards(Txns, Vars, Ledger)),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 old_poc_challengees_rewards_version_2_test() ->
     BaseDir = test_utils:tmp_dir("old_poc_challengees_rewards_version_2_test"),
@@ -1021,7 +1027,8 @@ old_poc_challengees_rewards_version_2_test() ->
         {gateway, poc_challengees, <<"1">>} => 175,
         {gateway, poc_challengees, <<"2">>} => 175
     },
-    ?assertEqual(Rewards, poc_challengees_rewards(Txns, Vars, Ledger)).
+    ?assertEqual(Rewards, poc_challengees_rewards(Txns, Vars, Ledger)),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 old_poc_witnesses_rewards_test() ->
     BaseDir = test_utils:tmp_dir("old_poc_witnesses_rewards_test"),
@@ -1049,7 +1056,8 @@ old_poc_witnesses_rewards_test() ->
         {gateway, poc_witnesses, <<"1">>} => 25,
         {gateway, poc_witnesses, <<"2">>} => 25
     },
-    ?assertEqual(Rewards, poc_witnesses_rewards(Txns, EpochVars, Ledger)).
+    ?assertEqual(Rewards, poc_witnesses_rewards(Txns, EpochVars, Ledger)),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 common_poc_vars() ->
     #{

--- a/test/assume_valid_SUITE.erl
+++ b/test/assume_valid_SUITE.erl
@@ -37,12 +37,7 @@ all() ->
 %% TEST CASE SETUP
 %%--------------------------------------------------------------------
 init_per_testcase(TestCase, Config) ->
-    {BaseDir, SimDir} = test_utils:ct_priv_base_dirs(?MODULE, TestCase, Config),
-    [
-        {basedir, BaseDir},
-        {simdir, SimDir}
-        | Config
-    ].
+    blockchain_ct_utils:ct_priv_base_dirs(?MODULE, TestCase, Config).
 
 
 
@@ -58,8 +53,8 @@ end_per_testcase(_, _Config) ->
 %%--------------------------------------------------------------------
 
 basic(Config) ->
-    BaseDir = proplists:get_value(basedir, Config),
-    SimDir = proplists:get_value(simdir, Config),
+    BaseDir = ?config(base_dir, Config),
+    SimDir = ?config(sim_dir, Config),
     ct:pal("ff suite base dir: ~p", [BaseDir]),
     ct:pal("ff suite base SIM dir: ~p", [SimDir]),
 
@@ -97,8 +92,8 @@ basic(Config) ->
     ok.
 
 wrong_height(Config) ->
-    BaseDir = proplists:get_value(basedir, Config),
-    SimDir = proplists:get_value(simdir, Config),
+    BaseDir = ?config(base_dir, Config),
+    SimDir = ?config(sim_dir, Config),
 
     Balance = 5000,
     BlocksN = 100,
@@ -135,8 +130,8 @@ wrong_height(Config) ->
 
 
 blockchain_restart(Config) ->
-    BaseDir = proplists:get_value(basedir, Config),
-    SimDir = proplists:get_value(simdir, Config),
+    BaseDir = ?config(base_dir, Config),
+    SimDir = ?config(sim_dir, Config),
 
     Balance = 5000,
     BlocksN = 100,
@@ -174,8 +169,8 @@ blockchain_restart(Config) ->
     ok.
 
 blockchain_almost_synced(Config) ->
-    BaseDir = proplists:get_value(basedir, Config),
-    SimDir = proplists:get_value(simdir, Config),
+    BaseDir = ?config(base_dir, Config),
+    SimDir = ?config(sim_dir, Config),
 
     Balance = 5000,
     BlocksN = 100,
@@ -214,8 +209,8 @@ blockchain_almost_synced(Config) ->
     ok.
 
 blockchain_crash_while_absorbing(Config) ->
-    BaseDir = proplists:get_value(basedir, Config),
-    SimDir = proplists:get_value(simdir, Config),
+    BaseDir = ?config(base_dir, Config),
+    SimDir = ?config(sim_dir, Config),
 
     Balance = 5000,
     BlocksN = 100,
@@ -279,8 +274,8 @@ blockchain_crash_while_absorbing(Config) ->
 
 
 blockchain_crash_while_absorbing_and_assume_valid_moves(Config) ->
-    BaseDir = proplists:get_value(basedir, Config),
-    SimDir = proplists:get_value(simdir, Config),
+    BaseDir = ?config(base_dir, Config),
+    SimDir = ?config(sim_dir, Config),
 
     Balance = 5000,
     BlocksN = 100,
@@ -343,8 +338,8 @@ blockchain_crash_while_absorbing_and_assume_valid_moves(Config) ->
     ok.
 
 overlapping_streams(Config) ->
-    BaseDir = proplists:get_value(basedir, Config),
-    SimDir = proplists:get_value(simdir, Config),
+    BaseDir = ?config(base_dir, Config),
+    SimDir = ?config(sim_dir, Config),
 
     Balance = 5000,
     BlocksN = 100,

--- a/test/assume_valid_SUITE.erl
+++ b/test/assume_valid_SUITE.erl
@@ -37,7 +37,7 @@ all() ->
 %% TEST CASE SETUP
 %%--------------------------------------------------------------------
 init_per_testcase(TestCase, Config) ->
-    blockchain_ct_utils:ct_priv_base_dirs(?MODULE, TestCase, Config).
+    blockchain_ct_utils:init_base_dir_config(?MODULE, TestCase, Config).
 
 
 

--- a/test/assume_valid_SUITE.erl
+++ b/test/assume_valid_SUITE.erl
@@ -93,7 +93,7 @@ basic(Config) ->
     ?assertEqual({ok, 100}, blockchain:sync_height(Chain)),
     ok = blockchain:add_block(LastBlock, Chain),
     ?assertEqual({ok, 101}, blockchain:height(Chain)),
-    ?assertEqual({ok, 109}, blockchain:sync_height(Chain)),
+    ?assertEqual({ok, 101}, blockchain:sync_height(Chain)),
     ok.
 
 wrong_height(Config) ->

--- a/test/blockchain_ct_utils.erl
+++ b/test/blockchain_ct_utils.erl
@@ -1,4 +1,6 @@
 -module(blockchain_ct_utils).
+
+-include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include("include/blockchain_vars.hrl").
 
@@ -17,7 +19,8 @@
          init_per_testcase/2,
          end_per_testcase/2,
          create_vars/0, create_vars/1,
-         raw_vars/1
+         raw_vars/1,
+         ct_priv_base_dirs/3
         ]).
 
 pmap(F, L) ->
@@ -152,6 +155,7 @@ shuffle(List) ->
     [x || {_,x} <- lists:sort([{rand:uniform(), N} || N <- List])].
 
 init_per_testcase(TestCase, Config) ->
+
     os:cmd(os:find_executable("epmd")++" -daemon"),
     {ok, Hostname} = inet:gethostname(),
     case net_kernel:start([list_to_atom("runner-blockchain-" ++
@@ -252,7 +256,6 @@ init_per_testcase(TestCase, Config) ->
                                  ])
                   end, Nodes),
 
-
     [{nodes, Nodes}, {num_consensus_members, NumConsensusMembers} | Config].
 
 end_per_testcase(_TestCase, Config) ->
@@ -314,3 +317,20 @@ raw_vars(Vars) ->
 
     maps:merge(DefVars, Vars).
 
+
+%%--------------------------------------------------------------------
+%% @doc
+%% generate a tmp directory based off priv_data to be used as a scratch by common tests
+%% @end
+%%-------------------------------------------------------------------
+-spec ct_priv_base_dirs(atom(), atom(), list()) -> {list(), list()}.
+ct_priv_base_dirs(Mod, TestCase, Config)->
+    PrivDir = ?config(priv_dir, Config),
+    TCName = erlang:atom_to_list(TestCase),
+    BaseDir = PrivDir ++ "data/" ++ erlang:atom_to_list(Mod) ++ "_" ++ TCName,
+    SimDir = BaseDir ++ "_sim",
+    [
+        {base_dir, BaseDir},
+        {sim_dir, SimDir}
+        | Config
+    ].

--- a/test/blockchain_ct_utils.erl
+++ b/test/blockchain_ct_utils.erl
@@ -259,7 +259,7 @@ init_per_testcase(TestCase, Config) ->
     [{nodes, Nodes}, {num_consensus_members, NumConsensusMembers} | Config].
 
 end_per_testcase(_TestCase, Config) ->
-    Nodes = proplists:get_value(nodes, Config),
+    Nodes = ?config(nodes, Config),
     pmap(fun(Node) -> ct_slave:stop(Node) end, Nodes),
     ok.
 

--- a/test/blockchain_ct_utils.erl
+++ b/test/blockchain_ct_utils.erl
@@ -20,7 +20,7 @@
          end_per_testcase/2,
          create_vars/0, create_vars/1,
          raw_vars/1,
-         ct_priv_base_dirs/3
+         init_base_dir_config/3
         ]).
 
 pmap(F, L) ->
@@ -323,8 +323,8 @@ raw_vars(Vars) ->
 %% generate a tmp directory based off priv_data to be used as a scratch by common tests
 %% @end
 %%-------------------------------------------------------------------
--spec ct_priv_base_dirs(atom(), atom(), list()) -> {list(), list()}.
-ct_priv_base_dirs(Mod, TestCase, Config)->
+-spec init_base_dir_config(atom(), atom(), list()) -> {list(), list()}.
+init_base_dir_config(Mod, TestCase, Config)->
     PrivDir = ?config(priv_dir, Config),
     TCName = erlang:atom_to_list(TestCase),
     BaseDir = PrivDir ++ "data/" ++ erlang:atom_to_list(Mod) ++ "_" ++ TCName,

--- a/test/blockchain_dist_SUITE.erl
+++ b/test/blockchain_dist_SUITE.erl
@@ -35,7 +35,7 @@ end_per_suite(Config) ->
 %% ------------------------------------------------------------------
 
 init_per_testcase(TestCase, Config) ->
-    Config0 = blockchain_ct_utils:ct_priv_base_dirs(?MODULE, TestCase, Config),
+    Config0 = blockchain_ct_utils:init_base_dir_config(?MODULE, TestCase, Config),
     InitConfig = blockchain_ct_utils:init_per_testcase(TestCase, Config0),
     Nodes = proplists:get_value(nodes, InitConfig),
     Balance = 5000,

--- a/test/blockchain_dist_SUITE.erl
+++ b/test/blockchain_dist_SUITE.erl
@@ -37,9 +37,9 @@ end_per_suite(Config) ->
 init_per_testcase(TestCase, Config) ->
     Config0 = blockchain_ct_utils:init_base_dir_config(?MODULE, TestCase, Config),
     InitConfig = blockchain_ct_utils:init_per_testcase(TestCase, Config0),
-    Nodes = proplists:get_value(nodes, InitConfig),
+    Nodes = ?config(nodes, InitConfig),
     Balance = 5000,
-    NumConsensusMembers = proplists:get_value(num_consensus_members, InitConfig),
+    NumConsensusMembers = ?config(num_consensus_members, InitConfig),
 
     %% accumulate the address of each node
     Addrs = lists:foldl(fun(Node, Acc) ->
@@ -88,8 +88,8 @@ end_per_testcase(_TestCase, Config) ->
 %% ------------------------------------------------------------------
 
 gossip_test(Config) ->
-    Nodes = proplists:get_value(nodes, Config),
-    ConsensusMembers = proplists:get_value(consensus_memebers, Config),
+    Nodes = ?config(nodes, Config),
+    ConsensusMembers = ?config(consensus_memebers, Config),
 
     %% let these two serve as dummys
     [FirstNode, SecondNode | _Rest] = Nodes,
@@ -140,7 +140,7 @@ gossip_test(Config) ->
 %% ------------------------------------------------------------------
 
 check_genesis_block(Config, GenesisBlock) ->
-    Nodes = proplists:get_value(nodes, Config),
+    Nodes = ?config(nodes, Config),
     lists:foreach(fun(Node) ->
                           Blockchain = ct_rpc:call(Node, blockchain_worker, blockchain, []),
                           {ok, HeadBlock} = ct_rpc:call(Node, blockchain, head_block, [Blockchain]),
@@ -152,7 +152,7 @@ check_genesis_block(Config, GenesisBlock) ->
                   end, Nodes).
 
 get_consensus_members(Config, ConsensusAddrs) ->
-    Nodes = proplists:get_value(nodes, Config),
+    Nodes = ?config(nodes, Config),
     lists:keysort(1, lists:foldl(fun(Node, Acc) ->
                                          Addr = ct_rpc:call(Node, blockchain_swarm, pubkey_bin, []),
                                          case lists:member(Addr, ConsensusAddrs) of

--- a/test/blockchain_dist_SUITE.erl
+++ b/test/blockchain_dist_SUITE.erl
@@ -35,9 +35,8 @@ end_per_suite(Config) ->
 %% ------------------------------------------------------------------
 
 init_per_testcase(TestCase, Config) ->
-    {BaseDir, SimDir} = test_utils:ct_priv_base_dirs(?MODULE, TestCase, Config),
-
-    InitConfig = blockchain_ct_utils:init_per_testcase(TestCase, Config),
+    Config0 = blockchain_ct_utils:ct_priv_base_dirs(?MODULE, TestCase, Config),
+    InitConfig = blockchain_ct_utils:init_per_testcase(TestCase, Config0),
     Nodes = proplists:get_value(nodes, InitConfig),
     Balance = 5000,
     NumConsensusMembers = proplists:get_value(num_consensus_members, InitConfig),
@@ -78,9 +77,7 @@ init_per_testcase(TestCase, Config) ->
     ok = check_genesis_block(InitConfig, GenesisBlock),
     ConsensusMembers = get_consensus_members(InitConfig, ConsensusAddrs),
     [
-        {consensus_memebers, ConsensusMembers},
-        {basedir, BaseDir},
-        {simdir, SimDir}
+        {consensus_memebers, ConsensusMembers}
         | InitConfig].
 
 end_per_testcase(_TestCase, Config) ->

--- a/test/blockchain_dist_SUITE.erl
+++ b/test/blockchain_dist_SUITE.erl
@@ -34,8 +34,10 @@ end_per_suite(Config) ->
 %% Configurations
 %% ------------------------------------------------------------------
 
-init_per_testcase(_TestCase, Config0) ->
-    InitConfig = blockchain_ct_utils:init_per_testcase(_TestCase, Config0),
+init_per_testcase(TestCase, Config) ->
+    {BaseDir, SimDir} = test_utils:ct_priv_base_dirs(?MODULE, TestCase, Config),
+
+    InitConfig = blockchain_ct_utils:init_per_testcase(TestCase, Config),
     Nodes = proplists:get_value(nodes, InitConfig),
     Balance = 5000,
     NumConsensusMembers = proplists:get_value(num_consensus_members, InitConfig),
@@ -75,7 +77,11 @@ init_per_testcase(_TestCase, Config0) ->
 
     ok = check_genesis_block(InitConfig, GenesisBlock),
     ConsensusMembers = get_consensus_members(InitConfig, ConsensusAddrs),
-    [{consensus_memebers, ConsensusMembers} | InitConfig].
+    [
+        {consensus_memebers, ConsensusMembers},
+        {basedir, BaseDir},
+        {simdir, SimDir}
+        | InitConfig].
 
 end_per_testcase(_TestCase, Config) ->
     blockchain_ct_utils:end_per_testcase(_TestCase, Config).

--- a/test/blockchain_fastforward_SUITE.erl
+++ b/test/blockchain_fastforward_SUITE.erl
@@ -31,13 +31,7 @@ all() ->
 %% TEST CASE SETUP
 %%--------------------------------------------------------------------
 init_per_testcase(TestCase, Config) ->
-    {BaseDir, SimDir} = test_utils:ct_priv_base_dirs(?MODULE, TestCase, Config),
-    [
-        {basedir, BaseDir},
-        {simdir, SimDir}
-        | Config
-    ].
-
+    blockchain_ct_utils:ct_priv_base_dirs(?MODULE, TestCase, Config).
 
 %%--------------------------------------------------------------------
 %% TEST CASE TEARDOWN
@@ -55,8 +49,8 @@ end_per_testcase(_, _Config) ->
 %% @end
 %%--------------------------------------------------------------------
 basic(Config) ->
-    BaseDir = proplists:get_value(basedir, Config),
-    SimDir = proplists:get_value(simdir, Config),
+    BaseDir = ?config(base_dir, Config),
+    SimDir = ?config(sim_dir, Config),
 
     Balance = 5000,
     BlocksN = 100,

--- a/test/blockchain_fastforward_SUITE.erl
+++ b/test/blockchain_fastforward_SUITE.erl
@@ -31,7 +31,7 @@ all() ->
 %% TEST CASE SETUP
 %%--------------------------------------------------------------------
 init_per_testcase(TestCase, Config) ->
-    blockchain_ct_utils:ct_priv_base_dirs(?MODULE, TestCase, Config).
+    blockchain_ct_utils:init_base_dir_config(?MODULE, TestCase, Config).
 
 %%--------------------------------------------------------------------
 %% TEST CASE TEARDOWN

--- a/test/blockchain_fastforward_SUITE.erl
+++ b/test/blockchain_fastforward_SUITE.erl
@@ -6,7 +6,7 @@
 -include("blockchain.hrl").
 
 -export([
-    all/0
+    all/0, init_per_testcase/2, end_per_testcase/2
 ]).
 
 -export([
@@ -16,6 +16,7 @@
 %%--------------------------------------------------------------------
 %% COMMON TEST CALLBACK FUNCTIONS
 %%--------------------------------------------------------------------
+
 
 %%--------------------------------------------------------------------
 %% @public
@@ -27,6 +28,24 @@ all() ->
     [basic].
 
 %%--------------------------------------------------------------------
+%% TEST CASE SETUP
+%%--------------------------------------------------------------------
+init_per_testcase(TestCase, Config) ->
+    {BaseDir, SimDir} = test_utils:ct_priv_base_dirs(?MODULE, TestCase, Config),
+    [
+        {basedir, BaseDir},
+        {simdir, SimDir}
+        | Config
+    ].
+
+
+%%--------------------------------------------------------------------
+%% TEST CASE TEARDOWN
+%%--------------------------------------------------------------------
+end_per_testcase(_, _Config) ->
+    ok.
+
+%%--------------------------------------------------------------------
 %% TEST CASES
 %%--------------------------------------------------------------------
 
@@ -35,8 +54,10 @@ all() ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
-basic(_Config) ->
-    BaseDir = "data/fastforward_SUITE/basic",
+basic(Config) ->
+    BaseDir = proplists:get_value(basedir, Config),
+    SimDir = proplists:get_value(simdir, Config),
+
     Balance = 5000,
     BlocksN = 100,
     {ok, Sup, {PrivKey, PubKey}, _Opts} = test_utils:init(BaseDir),
@@ -47,7 +68,8 @@ basic(_Config) ->
     % Simulate other chain with fastforward handler only
     {ok, SimSwarm} = libp2p_swarm:start(fastforward_SUITE_sim, [{libp2p_nat, [{enabled, false}]}]),
     ok = libp2p_swarm:listen(SimSwarm, "/ip4/0.0.0.0/tcp/0"),
-    SimDir = "data/fastforward_SUITE/basic_sim_a",
+
+
     {ok, Chain} = blockchain:new(SimDir, Genesis, undefined),
 
     % Add some blocks

--- a/test/blockchain_keys_SUITE.erl
+++ b/test/blockchain_keys_SUITE.erl
@@ -3,7 +3,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--export([all/0]).
+-export([all/0, init_per_testcase/2, end_per_testcase/2]).
 
 -export([
     keys_test/1
@@ -25,6 +25,25 @@ all() ->
     ].
 
 %%--------------------------------------------------------------------
+%% TEST CASE SETUP
+%%--------------------------------------------------------------------
+init_per_testcase(TestCase, Config) ->
+    {BaseDir, SimDir} = test_utils:ct_priv_base_dirs(?MODULE, TestCase, Config),
+    [
+        {basedir, BaseDir},
+        {simdir, SimDir}
+        | Config
+    ].
+
+
+%%--------------------------------------------------------------------
+%% TEST CASE TEARDOWN
+%%--------------------------------------------------------------------
+end_per_testcase(_, _Config) ->
+    ok.
+
+
+%%--------------------------------------------------------------------
 %% TEST CASES
 %%--------------------------------------------------------------------
 
@@ -33,8 +52,9 @@ all() ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
-keys_test(_Config) ->
-    BaseDir = "data/test_SUITE/keys_test",
+keys_test(Config) ->
+    BaseDir = proplists:get_value(basedir, Config),
+
     Balance = 5000,
     NumConsensusMembers = 7,
 

--- a/test/blockchain_keys_SUITE.erl
+++ b/test/blockchain_keys_SUITE.erl
@@ -28,7 +28,7 @@ all() ->
 %% TEST CASE SETUP
 %%--------------------------------------------------------------------
 init_per_testcase(TestCase, Config) ->
-    blockchain_ct_utils:ct_priv_base_dirs(?MODULE, TestCase, Config).
+    blockchain_ct_utils:init_base_dir_config(?MODULE, TestCase, Config).
 
 
 %%--------------------------------------------------------------------

--- a/test/blockchain_keys_SUITE.erl
+++ b/test/blockchain_keys_SUITE.erl
@@ -28,12 +28,7 @@ all() ->
 %% TEST CASE SETUP
 %%--------------------------------------------------------------------
 init_per_testcase(TestCase, Config) ->
-    {BaseDir, SimDir} = test_utils:ct_priv_base_dirs(?MODULE, TestCase, Config),
-    [
-        {basedir, BaseDir},
-        {simdir, SimDir}
-        | Config
-    ].
+    blockchain_ct_utils:ct_priv_base_dirs(?MODULE, TestCase, Config).
 
 
 %%--------------------------------------------------------------------
@@ -53,8 +48,7 @@ end_per_testcase(_, _Config) ->
 %% @end
 %%--------------------------------------------------------------------
 keys_test(Config) ->
-    BaseDir = proplists:get_value(basedir, Config),
-
+    BaseDir = ?config(base_dir, Config),
     Balance = 5000,
     NumConsensusMembers = 7,
 

--- a/test/blockchain_simple_SUITE.erl
+++ b/test/blockchain_simple_SUITE.erl
@@ -74,7 +74,7 @@ all() ->
 %%--------------------------------------------------------------------
 
 init_per_testcase(TestCase, Config) ->
-    Config0 = blockchain_ct_utils:ct_priv_base_dirs(?MODULE, TestCase, Config),
+    Config0 = blockchain_ct_utils:init_base_dir_config(?MODULE, TestCase, Config),
     Balance = 5000,
     {ok, Sup, {PrivKey, PubKey}, Opts} = test_utils:init(?config(base_dir, Config0)),
     %% two tests rely on the swarm not being in the consensus group, so exclude them here

--- a/test/blockchain_simple_SUITE.erl
+++ b/test/blockchain_simple_SUITE.erl
@@ -74,7 +74,8 @@ all() ->
 %%--------------------------------------------------------------------
 
 init_per_testcase(TestCase, Config) ->
-    BaseDir = "data/test_SUITE/" ++ erlang:atom_to_list(TestCase),
+    {BaseDir, SimDir} = test_utils:ct_priv_base_dirs(?MODULE, TestCase, Config),
+
     Balance = 5000,
     {ok, Sup, {PrivKey, PubKey}, Opts} = test_utils:init(BaseDir),
     %% two tests rely on the swarm not being in the consensus group, so exclude them here
@@ -94,6 +95,7 @@ init_per_testcase(TestCase, Config) ->
 
     [
         {basedir, BaseDir},
+        {simdir, SimDir},
         {balance, Balance},
         {sup, Sup},
         {pubkey, PubKey},
@@ -218,7 +220,8 @@ reload_test(Config) ->
     ok.
 
 restart_test(Config) ->
-    GenDir = "data/test_SUITE/restart2",
+    BaseDir = proplists:get_value(basedir, Config),
+    GenDir = BaseDir ++ "2",  %% create a second/alternative base dir
     ConsensusMembers = proplists:get_value(consensus_members, Config),
     Sup = proplists:get_value(sup, Config),
     Opts = proplists:get_value(opts, Config),

--- a/test/blockchain_simple_SUITE.erl
+++ b/test/blockchain_simple_SUITE.erl
@@ -111,7 +111,7 @@ init_per_testcase(TestCase, Config) ->
 %% TEST CASE TEARDOWN
 %%--------------------------------------------------------------------
 end_per_testcase(_, Config) ->
-    Sup = proplists:get_value(sup, Config),
+    Sup = ?config(sup, Config),
     % Make sure blockchain saved on file = in memory
     case erlang:is_process_alive(Sup) of
         true ->
@@ -133,11 +133,11 @@ end_per_testcase(_, Config) ->
 %%--------------------------------------------------------------------
 basic_test(Config) ->
     BaseDir = ?config(base_dir, Config),
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
-    Balance = proplists:get_value(balance, Config),
-    BaseDir = proplists:get_value(base_dir, Config),
-    Chain = proplists:get_value(chain, Config),
-    Swarm = proplists:get_value(swarm, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    Balance = ?config(balance, Config),
+    BaseDir = ?config(base_dir, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
 
     % Test a payment transaction, add a block and check balances
     [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
@@ -171,12 +171,12 @@ reload_test(Config) ->
     BaseDir = ?config(base_dir, Config),
 
     Balance = 5000,
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
-    Sup = proplists:get_value(sup, Config),
-    Opts = proplists:get_value(opts, Config),
-    Chain0 = proplists:get_value(chain, Config),
-    Swarm0 = proplists:get_value(swarm, Config),
-    N0 = proplists:get_value(n, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    Sup = ?config(sup, Config),
+    Opts = ?config(opts, Config),
+    Chain0 = ?config(chain, Config),
+    Swarm0 = ?config(swarm, Config),
+    N0 = ?config(n, Config),
 
     % Add some blocks
     lists:foreach(
@@ -222,11 +222,11 @@ restart_test(Config) ->
     BaseDir = ?config(base_dir, Config),
     GenDir = BaseDir ++ "2",  %% create a second/alternative base dir
 
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
-    Sup = proplists:get_value(sup, Config),
-    Opts = proplists:get_value(opts, Config),
-    Chain0 = proplists:get_value(chain, Config),
-    Swarm0 = proplists:get_value(swarm, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    Sup = ?config(sup, Config),
+    Opts = ?config(opts, Config),
+    Chain0 = ?config(chain, Config),
+    Swarm0 = ?config(swarm, Config),
     {ok, GenBlock} = blockchain:head_block(Chain0),
 
     % Add some blocks
@@ -283,13 +283,13 @@ restart_test(Config) ->
 htlc_payee_redeem_test(Config) ->
     BaseDir = ?config(base_dir, Config),
 
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
-    Balance = proplists:get_value(balance, Config),
-    BaseDir = proplists:get_value(base_dir, Config),
-    PubKey = proplists:get_value(pubkey, Config),
-    PrivKey = proplists:get_value(privkey, Config),
-    Chain = proplists:get_value(chain, Config),
-    Swarm = proplists:get_value(swarm, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    Balance = ?config(balance, Config),
+    BaseDir = ?config(base_dir, Config),
+    PubKey = ?config(pubkey, Config),
+    PrivKey = ?config(privkey, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
 
     % Create a Payer
     Payer = libp2p_crypto:pubkey_to_bin(PubKey),
@@ -351,13 +351,13 @@ htlc_payee_redeem_test(Config) ->
 htlc_payer_redeem_test(Config) ->
     BaseDir = ?config(base_dir, Config),
 
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
-    Balance = proplists:get_value(balance, Config),
-    BaseDir = proplists:get_value(base_dir, Config),
-    PubKey = proplists:get_value(pubkey, Config),
-    PrivKey = proplists:get_value(privkey, Config),
-    Chain = proplists:get_value(chain, Config),
-    Swarm = proplists:get_value(swarm, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    Balance = ?config(balance, Config),
+    BaseDir = ?config(base_dir, Config),
+    PubKey = ?config(pubkey, Config),
+    PrivKey = ?config(privkey, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
 
     % Create a Payer
     Payer = libp2p_crypto:pubkey_to_bin(PubKey),
@@ -416,17 +416,17 @@ htlc_payer_redeem_test(Config) ->
     ok.
 
 poc_request_test(Config) ->
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
-    PubKey = proplists:get_value(pubkey, Config),
-    PrivKey = proplists:get_value(privkey, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    PubKey = ?config(pubkey, Config),
+    PrivKey = ?config(privkey, Config),
     Owner = libp2p_crypto:pubkey_to_bin(PubKey),
-    Chain = proplists:get_value(chain, Config),
-    Swarm = proplists:get_value(swarm, Config),
-    Balance = proplists:get_value(balance, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
+    Balance = ?config(balance, Config),
 
     Ledger = blockchain:ledger(Chain),
     Rate = 1000000,
-    {Priv, _} = proplists:get_value(master_key, Config),
+    {Priv, _} = ?config(master_key, Config),
     Vars = #{token_burn_exchange_rate => Rate},
     VarTxn = blockchain_txn_vars_v1:new(Vars, 3),
     Proof = blockchain_txn_vars_v1:create_proof(Priv, VarTxn),
@@ -572,11 +572,11 @@ poc_request_test(Config) ->
     ok.
 
 bogus_coinbase_test(Config) ->
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
-    Balance = proplists:get_value(balance, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    Balance = ?config(balance, Config),
     [{FirstMemberAddr, _} | _] = ConsensusMembers,
-    Chain = proplists:get_value(chain, Config),
-    Swarm = proplists:get_value(swarm, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
 
     ?assertEqual({ok, 1}, blockchain:height(Chain)),
 
@@ -598,10 +598,10 @@ bogus_coinbase_test(Config) ->
     ok.
 
 bogus_coinbase_with_good_payment_test(Config) ->
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
     [{FirstMemberAddr, _} | _] = ConsensusMembers,
-    Chain = proplists:get_value(chain, Config),
-    Swarm = proplists:get_value(swarm, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
 
     %% Lets give the first member a bunch of coinbase tokens
     BogusCoinbaseTxn = blockchain_txn_coinbase_v1:new(FirstMemberAddr, 999999),
@@ -623,9 +623,9 @@ bogus_coinbase_with_good_payment_test(Config) ->
     ok.
 
 export_test(Config) ->
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
-    GenesisMembers = proplists:get_value(genesis_members, Config),
-    Balance = proplists:get_value(balance, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    GenesisMembers = ?config(genesis_members, Config),
+    Balance = ?config(balance, Config),
     [_,
      {Payer1, {PayerPubKey1, PayerPrivKey1, _}},
      {Payer2, {_, PayerPrivKey2, _}},
@@ -634,13 +634,13 @@ export_test(Config) ->
     Amount = 2500,
     Fee = 0,
     N = length(ConsensusMembers),
-    Chain = proplists:get_value(chain, Config),
-    Swarm = proplists:get_value(swarm, Config),
-    N = proplists:get_value(n, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
+    N = ?config(n, Config),
 
     Ledger = blockchain:ledger(Chain),
     Rate = 1000000,
-    {Priv, _} = proplists:get_value(master_key, Config),
+    {Priv, _} = ?config(master_key, Config),
     Vars = #{token_burn_exchange_rate => Rate},
     VarTxn = blockchain_txn_vars_v1:new(Vars, 3),
     Proof = blockchain_txn_vars_v1:create_proof(Priv, VarTxn),
@@ -781,11 +781,11 @@ export_test(Config) ->
 delayed_ledger_test(Config) ->
     BaseDir = ?config(base_dir, Config),
 
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
-    BaseDir = proplists:get_value(base_dir, Config),
-    Chain = proplists:get_value(chain, Config),
-    Swarm = proplists:get_value(swarm, Config),
-    Balance = proplists:get_value(balance, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    BaseDir = ?config(base_dir, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
+    Balance = ?config(balance, Config),
 
     Ledger = blockchain:ledger(Chain),
     ?assertEqual({ok, 1}, blockchain_ledger_v1:current_height(Ledger)),
@@ -868,10 +868,10 @@ delayed_ledger_test(Config) ->
 fees_since_test(Config) ->
     BaseDir = ?config(base_dir, Config),
 
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
-    BaseDir = proplists:get_value(base_dir, Config),
-    Chain = proplists:get_value(chain, Config),
-    Swarm = proplists:get_value(swarm, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    BaseDir = ?config(base_dir, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
 
     [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
     Payee = blockchain_swarm:pubkey_bin(),
@@ -906,11 +906,11 @@ fees_since_test(Config) ->
 security_token_test(Config) ->
     BaseDir = ?config(base_dir, Config),
 
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
-    Balance = proplists:get_value(balance, Config),
-    BaseDir = proplists:get_value(base_dir, Config),
-    Chain = proplists:get_value(chain, Config),
-    Swarm = proplists:get_value(swarm, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    Balance = ?config(balance, Config),
+    BaseDir = ?config(base_dir, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
 
     % Test a payment transaction, add a block and check balances
     [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
@@ -943,10 +943,10 @@ security_token_test(Config) ->
 routing_test(Config) ->
     BaseDir = ?config(base_dir, Config),
 
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
-    BaseDir = proplists:get_value(base_dir, Config),
-    Chain = proplists:get_value(chain, Config),
-    Swarm = proplists:get_value(swarm, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    BaseDir = ?config(base_dir, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
     Ledger = blockchain:ledger(Chain),
 
     [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
@@ -1010,11 +1010,11 @@ routing_test(Config) ->
 block_save_failed_test(Config) ->
     BaseDir = ?config(base_dir, Config),
 
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
-    Balance = proplists:get_value(balance, Config),
-    BaseDir = proplists:get_value(base_dir, Config),
-    Chain = proplists:get_value(chain, Config),
-    Swarm = proplists:get_value(swarm, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    Balance = ?config(balance, Config),
+    BaseDir = ?config(base_dir, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
 
      % Test a payment transaction, add a block and check balances
     [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
@@ -1055,11 +1055,11 @@ block_save_failed_test(Config) ->
 %%--------------------------------------------------------------------
 absorb_failed_test(Config) ->
     BaseDir = ?config(base_dir, Config),
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
-    Balance = proplists:get_value(balance, Config),
-    BaseDir = proplists:get_value(base_dir, Config),
-    Chain = proplists:get_value(chain, Config),
-    Swarm = proplists:get_value(swarm, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    Balance = ?config(balance, Config),
+    BaseDir = ?config(base_dir, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
 
     % Test a payment transaction, add a block and check balances
     [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
@@ -1114,10 +1114,10 @@ absorb_failed_test(Config) ->
 epoch_reward_test(Config) ->
     BaseDir = ?config(base_dir, Config),
 
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
-    BaseDir = proplists:get_value(base_dir, Config),
-    Chain = proplists:get_value(chain, Config),
-    Swarm = proplists:get_value(swarm, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    BaseDir = ?config(base_dir, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
 
     [_, {PubKeyBin, {_, _PrivKey, _}}|_] = ConsensusMembers,
 
@@ -1178,12 +1178,12 @@ epoch_reward_test(Config) ->
 election_test(Config) ->
     BaseDir = ?config(base_dir, Config),
 
-    %% ConsensusMembers = proplists:get_value(consensus_members, Config),
-    GenesisMembers = proplists:get_value(genesis_members, Config),
-    BaseDir = proplists:get_value(base_dir, Config),
-    %% Chain = proplists:get_value(chain, Config),
+    %% ConsensusMembers = ?config(consensus_members, Config),
+    GenesisMembers = ?config(genesis_members, Config),
+    BaseDir = ?config(base_dir, Config),
+    %% Chain = ?config(chain, Config),
     Chain = blockchain_worker:blockchain(),
-    _Swarm = proplists:get_value(swarm, Config),
+    _Swarm = ?config(swarm, Config),
     N = 7,
 
     %% make sure our generated alpha & beta values are the same each time
@@ -1239,10 +1239,10 @@ election_test(Config) ->
     ok.
 
 chain_vars_test(Config) ->
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
-    Chain = proplists:get_value(chain, Config),
-    Swarm = proplists:get_value(swarm, Config),
-    {Priv, _} = proplists:get_value(master_key, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
+    {Priv, _} = ?config(master_key, Config),
 
     Ledger = blockchain:ledger(Chain),
 
@@ -1280,10 +1280,10 @@ chain_vars_test(Config) ->
     ok.
 
 chain_vars_set_unset_test(Config) ->
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
-    Chain = proplists:get_value(chain, Config),
-    Swarm = proplists:get_value(swarm, Config),
-    {Priv, _} = proplists:get_value(master_key, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
+    {Priv, _} = ?config(master_key, Config),
 
     Ledger = blockchain:ledger(Chain),
 
@@ -1356,11 +1356,11 @@ chain_vars_set_unset_test(Config) ->
 token_burn_test(Config) ->
     BaseDir = ?config(base_dir, Config),
 
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
-    Balance = proplists:get_value(balance, Config),
-    BaseDir = proplists:get_value(base_dir, Config),
-    Chain = proplists:get_value(chain, Config),
-    Swarm = proplists:get_value(swarm, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    Balance = ?config(balance, Config),
+    BaseDir = ?config(base_dir, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
 
     [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
     Recipient = blockchain_swarm:pubkey_bin(),
@@ -1397,7 +1397,7 @@ token_burn_test(Config) ->
 
     % Step 3: Add exchange rate to ledger
     Rate = 1000000,
-    {Priv, _} = proplists:get_value(master_key, Config),
+    {Priv, _} = ?config(master_key, Config),
     Vars = #{token_burn_exchange_rate => Rate},
     VarTxn = blockchain_txn_vars_v1:new(Vars, 3),
     Proof = blockchain_txn_vars_v1:create_proof(Priv, VarTxn),
@@ -1458,11 +1458,11 @@ token_burn_test(Config) ->
 payer_test(Config) ->
     BaseDir = ?config(base_dir, Config),
 
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
-    Balance = proplists:get_value(balance, Config),
-    BaseDir = proplists:get_value(base_dir, Config),
-    Chain = proplists:get_value(chain, Config),
-    Swarm = proplists:get_value(swarm, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    Balance = ?config(balance, Config),
+    BaseDir = ?config(base_dir, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
 
     [_, {Payer, {_, PayerPrivKey, _}}, {Owner, {_, OwnerPrivKey, _}}|_] = ConsensusMembers,
     PayerSigFun = libp2p_crypto:mk_sig_fun(PayerPrivKey),
@@ -1472,7 +1472,7 @@ payer_test(Config) ->
 
     % Step 1: Add exchange rate to ledger
     Rate = 1000000,
-    {Priv, _} = proplists:get_value(master_key, Config),
+    {Priv, _} = ?config(master_key, Config),
     Vars = #{token_burn_exchange_rate => Rate},
 
     VarTxn = blockchain_txn_vars_v1:new(Vars, 3),
@@ -1582,17 +1582,17 @@ payer_test(Config) ->
     ok.
 
 poc_sync_interval_test(Config) ->
-    ConsensusMembers = proplists:get_value(consensus_members, Config),
-    PubKey = proplists:get_value(pubkey, Config),
-    PrivKey = proplists:get_value(privkey, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    PubKey = ?config(pubkey, Config),
+    PrivKey = ?config(privkey, Config),
     Owner = libp2p_crypto:pubkey_to_bin(PubKey),
-    Chain = proplists:get_value(chain, Config),
-    Swarm = proplists:get_value(swarm, Config),
-    Balance = proplists:get_value(balance, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
+    Balance = ?config(balance, Config),
 
     Ledger = blockchain:ledger(Chain),
     Rate = 1000000,
-    {Priv, _} = proplists:get_value(master_key, Config),
+    {Priv, _} = ?config(master_key, Config),
     VarTxn = fake_var_txn(Priv, 3, #{token_burn_exchange_rate => Rate}),
     Block2 = test_utils:create_block(ConsensusMembers, [VarTxn]),
     _ = blockchain_gossip_handler:add_block(Swarm, Block2, Chain, self()),

--- a/test/blockchain_sync_SUITE.erl
+++ b/test/blockchain_sync_SUITE.erl
@@ -30,7 +30,7 @@ all() ->
 %% TEST CASE SETUP
 %%--------------------------------------------------------------------
 init_per_testcase(TestCase, Config) ->
-    blockchain_ct_utils:ct_priv_base_dirs(?MODULE, TestCase, Config).
+    blockchain_ct_utils:init_base_dir_config(?MODULE, TestCase, Config).
 
 %%--------------------------------------------------------------------
 %% TEST CASE TEARDOWN

--- a/test/blockchain_sync_SUITE.erl
+++ b/test/blockchain_sync_SUITE.erl
@@ -6,7 +6,7 @@
 -include("blockchain.hrl").
 
 -export([
-    all/0
+    all/0, init_per_testcase/2, end_per_testcase/2
 ]).
 
 -export([
@@ -27,6 +27,24 @@ all() ->
     [basic].
 
 %%--------------------------------------------------------------------
+%% TEST CASE SETUP
+%%--------------------------------------------------------------------
+init_per_testcase(TestCase, Config) ->
+    {BaseDir, SimDir} = test_utils:ct_priv_base_dirs(?MODULE, TestCase, Config),
+    [
+        {basedir, BaseDir},
+        {simdir, SimDir}
+        | Config
+    ].
+
+
+%%--------------------------------------------------------------------
+%% TEST CASE TEARDOWN
+%%--------------------------------------------------------------------
+end_per_testcase(_, _Config) ->
+    ok.
+
+%%--------------------------------------------------------------------
 %% TEST CASES
 %%--------------------------------------------------------------------
 
@@ -35,8 +53,10 @@ all() ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
-basic(_Config) ->
-    BaseDir = "data/sync_SUITE/basic",
+basic(Config) ->
+    BaseDir = proplists:get_value(basedir, Config),
+    SimDir = proplists:get_value(simdir, Config),
+
     Balance = 5000,
     BlocksN = 100,
     {ok, Sup, {PrivKey, PubKey}, _Opts} = test_utils:init(BaseDir),
@@ -47,7 +67,6 @@ basic(_Config) ->
     % Simulate other chain with sync handler only
     {ok, SimSwarm} = libp2p_swarm:start(sync_SUITE_sim, [{libp2p_nat, [{enabled, false}]}]),
     ok = libp2p_swarm:listen(SimSwarm, "/ip4/0.0.0.0/tcp/0"),
-    SimDir = "data/sync_SUITE/basic_sim",
     Chain = blockchain:new(SimDir, Genesis, undefined),
 
     % Add some blocks

--- a/test/blockchain_sync_SUITE.erl
+++ b/test/blockchain_sync_SUITE.erl
@@ -30,13 +30,7 @@ all() ->
 %% TEST CASE SETUP
 %%--------------------------------------------------------------------
 init_per_testcase(TestCase, Config) ->
-    {BaseDir, SimDir} = test_utils:ct_priv_base_dirs(?MODULE, TestCase, Config),
-    [
-        {basedir, BaseDir},
-        {simdir, SimDir}
-        | Config
-    ].
-
+    blockchain_ct_utils:ct_priv_base_dirs(?MODULE, TestCase, Config).
 
 %%--------------------------------------------------------------------
 %% TEST CASE TEARDOWN
@@ -54,8 +48,8 @@ end_per_testcase(_, _Config) ->
 %% @end
 %%--------------------------------------------------------------------
 basic(Config) ->
-    BaseDir = proplists:get_value(basedir, Config),
-    SimDir = proplists:get_value(simdir, Config),
+    BaseDir = ?config(base_dir, Config),
+    SimDir = ?config(sim_dir, Config),
 
     Balance = 5000,
     BlocksN = 100,

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -10,7 +10,6 @@
     wait_until/1, wait_until/3,
     create_block/2,
     tmp_dir/0, tmp_dir/1,
-    ct_priv_base_dirs/3,
     cleanup_tmp_dir/1,
     nonl/1,
     create_payment_transaction/6,
@@ -178,20 +177,6 @@ tmp_dir(SubDir) ->
 cleanup_tmp_dir(Dir)->
     os:cmd("rm -rf " ++ Dir),
     ok.
-
-%%--------------------------------------------------------------------
-%% @doc
-%% generate a tmp directory based off priv_data to be used as a scratch by common tests
-%% @end
-%%-------------------------------------------------------------------
--spec ct_priv_base_dirs(atom(), atom(), list()) -> {list(), list()}.
-ct_priv_base_dirs(Mod, TestCase, Config)->
-    PrivDir = ?config(priv_dir, Config),
-    TCName = erlang:atom_to_list(TestCase),
-    BaseDir = PrivDir ++ "data/" ++ erlang:atom_to_list(Mod) ++ "_" ++ TCName,
-    SimDir = BaseDir ++ "_sim",
-    {BaseDir, SimDir}.
-
 
 
 nonl([$\n|T]) -> nonl(T);

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -153,7 +153,7 @@ signatures(ConsensusMembers, BinBlock) ->
      ).
 
 tmp_dir() ->
-    ?MODULE:nonl(os:cmd("mktemp -d")).
+    ?MODULE:nonl(os:cmd("mktemp -d ./_build/test/tmp/XXXXXXXX")).
 
 tmp_dir(Dir) ->
     filename:join(tmp_dir(), Dir).


### PR DESCRIPTION
Changes include:

1. Force common test to use priv_dir as the base scratch location. All logs, assets, artefacts such as DBs etc will be written relative to here.  Base dir data is included in the Config prop.   Each test has its own private scratch per run using a combination of the test module plus test case as the naming convention.

2. Tidied up CTs to use ?config macro when accessing data from Config prop

3.  For eunit tests, the existing tmp_dir functions have been modified to return a location relative to `_build` dir. Tests now also cleanup after themselves