### PR TITLE
Refresh witnesses for random subset of hotspots

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -53,6 +53,12 @@
 %% outcome of threshold var application.
 -define(var_gw_inactivity_threshold, var_gw_inactivity_threshold).
 
+%% the number of blocks before a random subset of gatways refresh
+%% their witnesses
+-define(witness_refresh_interval, witness_refresh_interval).
+%% seeding the random number for witness_refresh_interval
+-define(witness_refresh_rand_n, witness_refresh_rand_n).
+
 %%%
 %%% meta vars
 %%%

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,24 @@
 %% -*- erlang -*-
 {cover_enabled, true}.
-{cover_enabled, true}.
 {cover_opts, [verbose]}.
+{cover_excl_mods,
+ [
+  blockchain_txn_handler,
+  blockchain_poc_target_v2, % obsolete
+
+  blockchain_poc_path_v2, % obsolete
+  blockchain_poc_path_v3, % obsolete
+
+  %% cli stuff
+  blockchain_console,
+  blockchain_cli_ledger,
+  blockchain_cli_peer,
+  blockchain_cli_txn,
+
+  %% test stuff
+  blockchain_worker_meck_original,
+  blockchain_event_meck_original
+ ]}.
 {cover_export_enabled, true}.
 {covertool, [{coverdata_files,
               [

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -566,6 +566,10 @@ validate_var(?election_seen_penalty, Value) ->
 %% ledger vars
 validate_var(?var_gw_inactivity_threshold, Value) ->
     validate_int(Value, "var_gw_inactivity_threshold", 15, 2880, false);
+validate_var(?witness_refresh_interval, Value) ->
+    validate_int(Value, "witness_refresh_interval", 10, 20000, false);
+validate_var(?witness_refresh_rand_n, Value) ->
+    validate_int(Value, "witness_refresh_rand_n", 50, 1000, false);
 
 %% meta vars
 validate_var(?vars_commit_delay, Value) ->

--- a/test/blockchain_ct_utils.erl
+++ b/test/blockchain_ct_utils.erl
@@ -325,7 +325,24 @@ raw_vars(Vars) ->
                 ?h3_neighbor_res => 12,
                 ?min_score => 0.15,
                 ?reward_version => 1,
-                ?allow_zero_amount => false
+                ?allow_zero_amount => false,
+                ?poc_version => 8,
+                ?poc_good_bucket_low => -132,
+                ?poc_good_bucket_high => -80,
+                ?poc_v5_target_prob_randomness_wt => 1.0,
+                ?poc_v4_target_prob_edge_wt => 0.0,
+                ?poc_v4_target_prob_score_wt => 0.0,
+                ?poc_v4_prob_rssi_wt => 0.0,
+                ?poc_v4_prob_time_wt => 0.0,
+                ?poc_v4_randomness_wt => 0.5,
+                ?poc_v4_prob_count_wt => 0.0,
+                ?poc_centrality_wt => 0.5,
+                ?poc_max_hop_cells => 2000,
+                ?poc_path_limit => 7,
+                ?poc_typo_fixes => true,
+                ?poc_target_hex_parent_res => 5,
+                ?witness_refresh_interval => 10,
+                ?witness_refresh_rand_n => 100
                },
 
     maps:merge(DefVars, Vars).

--- a/test/blockchain_simple_SUITE.erl
+++ b/test/blockchain_simple_SUITE.erl
@@ -1465,7 +1465,7 @@ chain_vars_test(Config) ->
 
     Ledger = blockchain:ledger(Chain),
 
-    Vars = #{poc_version => 2},
+    Vars = #{garbage_value => 2},
 
     ct:pal("priv_key ~p", [Priv]),
 
@@ -1484,7 +1484,7 @@ chain_vars_test(Config) ->
                 Block = test_utils:create_block(ConsensusMembers, []),
                 _ = blockchain_gossip_handler:add_block(Block, Chain, self()),
                 {ok, Height} = blockchain:height(Chain),
-                case blockchain:config(poc_version, Ledger) of % ignore "?"
+                case blockchain:config(garbage_value, Ledger) of % ignore "?"
                     {error, not_found} when Height < (Delay + 1) ->
                         ok;
                     {ok, 2} when Height >= (Delay + 1) ->
@@ -1505,7 +1505,7 @@ chain_vars_set_unset_test(Config) ->
 
     Ledger = blockchain:ledger(Chain),
 
-    Vars = #{poc_version => 2},
+    Vars = #{garbage_value => 2},
 
     ct:pal("priv_key ~p", [Priv]),
 
@@ -1524,7 +1524,7 @@ chain_vars_set_unset_test(Config) ->
                 Block = test_utils:create_block(ConsensusMembers, []),
                 _ = blockchain_gossip_handler:add_block(Block, Chain, self()),
                 {ok, Height} = blockchain:height(Chain),
-                case blockchain:config(poc_version, Ledger) of % ignore "?"
+                case blockchain:config(garbage_value, Ledger) of % ignore "?"
                     {error, not_found} when Height < (Delay + 1) ->
                         ok;
                     {ok, 2} when Height >= (Delay + 1) ->
@@ -1539,7 +1539,7 @@ chain_vars_set_unset_test(Config) ->
     {ok, Height} = blockchain:height(Chain),
     ct:pal("Height ~p", [Height]),
 
-    UnsetVarTxn = blockchain_txn_vars_v1:new(#{}, 4, #{unsets => [poc_version]}),
+    UnsetVarTxn = blockchain_txn_vars_v1:new(#{}, 4, #{unsets => [garbage_value]}),
     UnsetProof = blockchain_txn_vars_v1:create_proof(Priv, UnsetVarTxn),
     UnsetVarTxn1 = blockchain_txn_vars_v1:proof(UnsetVarTxn, UnsetProof),
 
@@ -1552,7 +1552,7 @@ chain_vars_set_unset_test(Config) ->
                 _ = blockchain_gossip_handler:add_block(Block1, Chain, self()),
                 {ok, Height1} = blockchain:height(Chain),
                 ct:pal("Height1 ~p", [Height1]),
-                case blockchain:config(poc_version, Ledger) of % ignore "?"
+                case blockchain:config(garbage_value, Ledger) of % ignore "?"
                     {ok, 2} when Height1 < (Height + Delay + 1) ->
                         ok;
                     {error, not_found} when Height1 >= (Height + Delay) ->


### PR DESCRIPTION
Attempt to refresh witnesses for a deterministically random subset of hotpots every X blocks.

`X` is configured via the `witness_refresh_interval` chain var.