### PR TITLE
Bump helium_proto

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -33,7 +33,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"6a68672f4d052e818931748628c1700ea29927bf"}},
+       {ref,"ea25165a8982e968c9fed6748634f0df7e0e1af9"}},
   0},
  {<<"inert">>,
   {git,"https://github.com/msantos/inert",


### PR DESCRIPTION
This flattens the package namespace for all protobufs to just be in the `helium` package. This should not matter to erlang since gpb doesn't really care the way we have it set up