### PR TITLE
remove explicit release

### DIFF
--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -313,12 +313,6 @@ new_snapshot(#ledger_v1{db=DB,
             {ok, Height} = current_height(Ledger),
             DelayedLedger = blockchain_ledger_v1:mode(delayed, Ledger),
             {ok, DelayedHeight} = current_height(DelayedLedger),
-            case ets:lookup(Cache, DelayedHeight - 1) of
-                [{_Height, {snapshot, OldSnapshot}}] ->
-                    rocksdb:release_snapshot(OldSnapshot);
-                _ ->
-                    ok
-            end,
             ets:delete(Cache, DelayedHeight - 1),
             ets:insert(Cache, {Height, {snapshot, SnapshotHandle}}),
             {ok, Ledger#ledger_v1{snapshot=SnapshotHandle}};


### PR DESCRIPTION
this is causing some problems with `run.sh`, let's revert it for now because we're pretty sure it isn't the major leaker.