### PR TITLE
support nonce in htlc txns

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -33,7 +33,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"940d082796a1b1680162f4ad192b09199ea579a9"}},
+       {ref,"0aea6a9e9016ffb8089ac4f49947136f2255f4c9"}},
   0},
  {<<"inert">>,
   {git,"https://github.com/msantos/inert",

--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -22,7 +22,7 @@
     spend/3, spend/4,
     payment_txn/5, payment_txn/6,
     submit_txn/1, submit_txn/2,
-    create_htlc_txn/6,
+    create_htlc_txn/7,
     redeem_htlc_txn/3,
     peer_height/3,
     notify/1,
@@ -163,9 +163,9 @@ payment_txn(SigFun, PubkeyBin, Recipient, Amount, Fee, Nonce) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec create_htlc_txn(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), binary(), non_neg_integer(), non_neg_integer(), non_neg_integer()) -> ok.
-create_htlc_txn(Payee, PubkeyBin, Hashlock, Timelock, Amount, Fee) ->
-    gen_server:cast(?SERVER, {create_htlc_txn, Payee, PubkeyBin, Hashlock, Timelock, Amount, Fee}).
+-spec create_htlc_txn(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), binary(), non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()) -> ok.
+create_htlc_txn(Payee, PubkeyBin, Hashlock, Timelock, Amount, Fee, Nonce) ->
+    gen_server:cast(?SERVER, {create_htlc_txn, Payee, PubkeyBin, Hashlock, Timelock, Amount, Fee, Nonce}).
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -430,9 +430,9 @@ handle_cast({payment_txn, SigFun, PubkeyBin, Recipient, Amount, Fee, Nonce}, #st
             ok = send_txn(SignedPaymentTxn)
     end,
     {noreply, State};
-handle_cast({create_htlc_txn, Payee, PubkeyBin, Hashlock, Timelock, Amount, Fee}, #state{swarm=Swarm}=State) ->
+handle_cast({create_htlc_txn, Payee, PubkeyBin, Hashlock, Timelock, Amount, Fee, Nonce}, #state{swarm=Swarm}=State) ->
     Payer = libp2p_swarm:pubkey_bin(Swarm),
-    CreateTxn = blockchain_txn_create_htlc_v1:new(Payer, Payee, PubkeyBin, Hashlock, Timelock, Amount, Fee),
+    CreateTxn = blockchain_txn_create_htlc_v1:new(Payer, Payee, PubkeyBin, Hashlock, Timelock, Amount, Fee, Nonce),
     {ok, _PubKey, SigFun, _ECDHFun} = libp2p_swarm:keys(Swarm),
     SignedCreateHTLCTxn = blockchain_txn_create_htlc_v1:sign(CreateTxn, SigFun),
     ok = send_txn(SignedCreateHTLCTxn),

--- a/src/cli/blockchain_cli_ledger.erl
+++ b/src/cli/blockchain_cli_ledger.erl
@@ -153,7 +153,8 @@ ledger_create_htlc_helper(Flags, Address) ->
     Hashlock = blockchain_utils:hex_to_bin(list_to_binary(clean(proplists:get_value(hashlock, Flags)))),
     Timelock = list_to_integer(clean(proplists:get_value(timelock, Flags))),
     Fee = list_to_integer(clean(proplists:get_value(fee, Flags))),
-    blockchain_worker:create_htlc_txn(Payee, Address, Hashlock, Timelock, Amount, Fee).
+    Nonce = list_to_integer(clean(proplists:get_value(nonce, Flags))),
+    blockchain_worker:create_htlc_txn(Payee, Address, Hashlock, Timelock, Amount, Fee, Nonce).
 
 %%--------------------------------------------------------------------
 %% ledger redeem

--- a/src/ledger/v1/blockchain_ledger_htlc_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_htlc_v1.erl
@@ -6,7 +6,7 @@
 -module(blockchain_ledger_htlc_v1).
 
 -export([
-    new/0, new/5,
+    new/0, new/6,
     nonce/1, nonce/2,
     payer/1, payer/2,
     payee/1, payee/2,
@@ -42,12 +42,13 @@ new() ->
     #htlc_v1{}.
 
 -spec new(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), non_neg_integer(),
-          binary(), non_neg_integer()) -> htlc().
-new(Payer, Payee, Balance, Hashlock, Timelock) when Balance /= undefined ->
+          non_neg_integer(), binary(), non_neg_integer()) -> htlc().
+new(Payer, Payee, Balance, Nonce, Hashlock, Timelock) when Balance /= undefined ->
     #htlc_v1{
         payer=Payer,
         payee=Payee,
         balance=Balance,
+        nonce=Nonce,
         hashlock=Hashlock,
         timelock=Timelock
     }.
@@ -194,7 +195,7 @@ new_test() ->
         hashlock= <<"hashlock">>,
         timelock=13
     },
-    ?assertEqual(HTLC1, new(<<"payer">>, <<"payee">>, 12, <<"hashlock">>, 13)).
+    ?assertEqual(HTLC1, new(<<"payer">>, <<"payee">>, 12, 0, <<"hashlock">>, 13)).
 
 nonce_test() ->
     HTLC = new(),

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -70,7 +70,7 @@
     check_security_balance/3,
 
     find_htlc/2,
-    add_htlc/7,
+    add_htlc/8,
     redeem_htlc/3,
 
     get_oui_counter/1, increment_oui_counter/2,
@@ -1641,14 +1641,14 @@ find_htlc(Address, Ledger) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec add_htlc(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(),
-               non_neg_integer(),  binary(), non_neg_integer(), ledger()) -> ok | {error, any()}.
-add_htlc(Address, Payer, Payee, Amount, Hashlock, Timelock, Ledger) ->
+               non_neg_integer(), non_neg_integer(),  binary(), non_neg_integer(), ledger()) -> ok | {error, any()}.
+add_htlc(Address, Payer, Payee, Amount, Nonce, Hashlock, Timelock, Ledger) ->
     HTLCsCF = htlcs_cf(Ledger),
     case ?MODULE:find_htlc(Address, Ledger) of
         {ok, _} ->
             {error, address_already_exists};
         {error, _} ->
-            HTLC = blockchain_ledger_htlc_v1:new(Payer, Payee, Amount, Hashlock, Timelock),
+            HTLC = blockchain_ledger_htlc_v1:new(Payer, Payee, Amount, Nonce, Hashlock, Timelock),
             Bin = blockchain_ledger_htlc_v1:serialize(HTLC),
             cache_put(Ledger, HTLCsCF, Address, Bin)
     end.


### PR DESCRIPTION
NOTE: this PR is dependant on proto PR: https://github.com/helium/proto/pull/19

This adds a nonce to the create_htlc txn and uses this to avoid replays/double spends.

