### PR TITLE
Data credits cleanup

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -4,7 +4,7 @@ set -e
 echo '--- :house_with_garden: Setting up the environment'
 
 . "$HOME/.asdf/asdf.sh"
-asdf local erlang 21.3
+asdf local erlang 22.1
 asdf local python 3.7.3
 asdf local ruby 2.6.2
 

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -4,7 +4,7 @@ set -e
 echo '--- :house_with_garden: Setting up the environment'
 
 . "$HOME/.asdf/asdf.sh"
-asdf local erlang 22.1
+asdf local erlang 22.1.8
 asdf local python 3.7.3
 asdf local ruby 2.6.2
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -33,7 +33,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"2d54abaa655ea236f1163a84dd63d9df21699ab9"}},
+       {ref,"23ac45fa8055137526b3a47ff185d9fd53aa2675"}},
   0},
  {<<"inert">>,
   {git,"https://github.com/msantos/inert",

--- a/rebar.lock
+++ b/rebar.lock
@@ -33,7 +33,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"a7f94538f21f9b16000022289c26fd7842539578"}},
+       {ref,"2d54abaa655ea236f1163a84dd63d9df21699ab9"}},
   0},
  {<<"inert">>,
   {git,"https://github.com/msantos/inert",

--- a/src/ledger/v1/blockchain_ledger_state_channel_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_state_channel_v1.erl
@@ -6,10 +6,11 @@
 -module(blockchain_ledger_state_channel_v1).
 
 -export([
-    new/4,
+    new/5,
     id/1, id/2,
     owner/1, owner/2,
     amount/1, amount/2,
+    nonce/1, nonce/2,
     expire_at_block/1, expire_at_block/2,
     serialize/1, deserialize/1
 ]).
@@ -22,30 +23,37 @@
     id :: binary(),
     owner :: binary(),
     amount :: non_neg_integer(),
-    expire_at_block :: pos_integer()
+    expire_at_block :: pos_integer(),
+    nonce :: non_neg_integer()
 }).
 
 -type state_channel() :: #ledger_state_channel_v1{}.
 
 -export_type([state_channel/0]).
 
--spec new(binary(), binary(), non_neg_integer(), pos_integer()) -> state_channel().
-new(ID, Owner, Amount, Timer) when ID /= undefined andalso
-                                   Owner /= undefined andalso
-                                   Amount /= undefined andalso
-                                   Timer /= undefined ->
+-spec new(ID :: binary(),
+          Owner :: binary(),
+          Amount :: non_neg_integer(),
+          ExpireAtBlock :: pos_integer(),
+          Nonce :: non_neg_integer()) -> state_channel().
+new(ID, Owner, Amount, ExpireAtBlock, Nonce) when ID /= undefined andalso
+                                                  Owner /= undefined andalso
+                                                  Amount /= undefined andalso
+                                                  ExpireAtBlock /= undefined andalso
+                                                  Nonce /= undefined ->
     #ledger_state_channel_v1{
-        id=ID,
-        owner=Owner,
-        amount=Amount,
-        expire_at_block=Timer
-    }.
+       id=ID,
+       owner=Owner,
+       amount=Amount,
+       expire_at_block=ExpireAtBlock,
+       nonce=Nonce
+      }.
 
 -spec id(state_channel()) -> binary().
 id(#ledger_state_channel_v1{id=ID}) ->
     ID.
 
--spec id(binary(), state_channel()) -> state_channel().
+-spec id(ID :: binary(), SC :: state_channel()) -> state_channel().
 id(ID, SC) ->
     SC#ledger_state_channel_v1{id=ID}.
 
@@ -53,7 +61,7 @@ id(ID, SC) ->
 owner(#ledger_state_channel_v1{owner=Owner}) ->
     Owner.
 
--spec owner(binary(), state_channel()) -> state_channel().
+-spec owner(Owner :: binary(), SC :: state_channel()) -> state_channel().
 owner(Owner, SC) ->
     SC#ledger_state_channel_v1{owner=Owner}.
 
@@ -61,17 +69,25 @@ owner(Owner, SC) ->
 amount(#ledger_state_channel_v1{amount=Amount}) ->
     Amount.
 
--spec amount(non_neg_integer(), state_channel()) -> state_channel().
+-spec amount(Amount :: non_neg_integer(), SC :: state_channel()) -> state_channel().
 amount(Amount, SC) ->
     SC#ledger_state_channel_v1{amount=Amount}.
 
 -spec expire_at_block(state_channel()) -> pos_integer().
-expire_at_block(#ledger_state_channel_v1{expire_at_block=Timer}) ->
-    Timer.
+expire_at_block(#ledger_state_channel_v1{expire_at_block=ExpireAtBlock}) ->
+    ExpireAtBlock.
 
--spec expire_at_block(pos_integer(), state_channel()) -> state_channel().
-expire_at_block(Timer, SC) ->
-    SC#ledger_state_channel_v1{expire_at_block=Timer}.
+-spec expire_at_block(ExpireAtBlock :: pos_integer(), SC :: state_channel()) -> state_channel().
+expire_at_block(ExpireAtBlock, SC) ->
+    SC#ledger_state_channel_v1{expire_at_block=ExpireAtBlock}.
+
+-spec nonce(state_channel()) -> non_neg_integer().
+nonce(#ledger_state_channel_v1{nonce=Nonce}) ->
+    Nonce.
+
+-spec nonce(Nonce :: non_neg_integer(), SC :: state_channel()) -> state_channel().
+nonce(Nonce, SC) ->
+    SC#ledger_state_channel_v1{nonce=Nonce}.
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -106,28 +122,34 @@ new_test() ->
         id = <<"id">>,
         owner = <<"owner">>,
         amount = 1,
-        expire_at_block = 10
+        expire_at_block = 10,
+        nonce = 1
     },
-    ?assertEqual(SC, new(<<"id">>, <<"owner">>, 1, 10)).
+    ?assertEqual(SC, new(<<"id">>, <<"owner">>, 1, 10, 1)).
 
 id_test() ->
-    SC = new(<<"id">>, <<"owner">>, 1, 10),
+    SC = new(<<"id">>, <<"owner">>, 1, 10, 1),
     ?assertEqual(<<"id">>, id(SC)),
     ?assertEqual(<<"id2">>, id(id(<<"id2">>, SC))).
 
 owner_test() ->
-    SC = new(<<"id">>, <<"owner">>, 1, 10),
+    SC = new(<<"id">>, <<"owner">>, 1, 10, 1),
     ?assertEqual(<<"owner">>, owner(SC)),
     ?assertEqual(<<"owner2">>, owner(owner(<<"owner2">>, SC))).
 
 amount_test() ->
-    SC = new(<<"id">>, <<"owner">>, 1, 10),
+    SC = new(<<"id">>, <<"owner">>, 1, 10, 1),
     ?assertEqual(1, amount(SC)),
     ?assertEqual(2, amount(amount(2, SC))).
 
 expire_at_block_test() ->
-    SC = new(<<"id">>, <<"owner">>, 1, 10),
+    SC = new(<<"id">>, <<"owner">>, 1, 10, 1),
     ?assertEqual(10, expire_at_block(SC)),
     ?assertEqual(20, expire_at_block(expire_at_block(20, SC))).
+
+nonce_test() ->
+    SC = new(<<"id">>, <<"owner">>, 1, 10, 1),
+    ?assertEqual(1, nonce(SC)),
+    ?assertEqual(2, nonce(nonce(2, SC))).
 
 -endif.

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -59,7 +59,7 @@
     dc_entries/1,
     find_dc_entry/2,
     credit_dc/3,
-    debit_dc/3,
+    debit_dc/4,
     debit_fee/3,
     check_dc_balance/3,
 
@@ -81,7 +81,7 @@
 
     find_state_channel/3, find_state_channels_by_owner/2,
     find_all_state_channels_by_owner/2,
-    add_state_channel/5,
+    add_state_channel/6,
     delete_state_channel/3,
 
     delay_vars/3,
@@ -1306,26 +1306,31 @@ credit_dc(Address, Amount, Ledger) ->
             Error
     end.
 
--spec debit_dc(Address :: libp2p_crypto:pubkey_bin(), Fee :: non_neg_integer(), Ledger :: ledger()) -> ok | {error, any()}.
-debit_dc(_Address, 0,_Ledger) ->
+-spec debit_dc(Address :: libp2p_crypto:pubkey_bin(),
+               Fee :: non_neg_integer(),
+               Nonce :: non_neg_integer(),
+               Ledger :: ledger()) -> ok | {error, any()}.
+debit_dc(_Address, 0, _Nonce, _Ledger) ->
     ok;
-debit_dc(Address, Fee, Ledger) ->
+debit_dc(Address, Fee, Nonce, Ledger) ->
     case ?MODULE:find_dc_entry(Address, Ledger) of
         {error, _}=Error ->
             Error;
         {ok, Entry} ->
-            Balance = blockchain_ledger_data_credits_entry_v1:balance(Entry),
-            case (Balance - Fee) >= 0 of
-                true ->
-                    Entry1 = blockchain_ledger_data_credits_entry_v1:new(
-                        blockchain_ledger_data_credits_entry_v1:nonce(Entry),
-                        (Balance - Fee)
-                    ),
-                    Bin = blockchain_ledger_data_credits_entry_v1:serialize(Entry1),
-                    EntriesCF = dc_entries_cf(Ledger),
-                    cache_put(Ledger, EntriesCF, Address, Bin);
+            case Nonce =:= blockchain_ledger_data_credits_entry_v1:nonce(Entry) + 1 of
                 false ->
-                    {error, {insufficient_balance, Fee, Balance}}
+                    {error, {bad_dc_nonce, {data_credit, Nonce, blockchain_ledger_data_credits_entry_v1:nonce(Entry)}}};
+                true ->
+                    Balance = blockchain_ledger_data_credits_entry_v1:balance(Entry),
+                    case (Balance - Fee) >= 0 of
+                        true ->
+                            Entry1 = blockchain_ledger_data_credits_entry_v1:new(Nonce, (Balance - Fee)),
+                            Bin = blockchain_ledger_data_credits_entry_v1:serialize(Entry1),
+                            EntriesCF = dc_entries_cf(Ledger),
+                            cache_put(Ledger, EntriesCF, Address, Bin);
+                        false ->
+                            {error, {insufficient_balance, Fee, Balance}}
+                    end
             end
     end.
 
@@ -1635,11 +1640,12 @@ find_all_state_channels_by_owner(Ledger, Owner) ->
                         Owner :: libp2p_crypto:pubkey_bin(),
                         Amount :: non_neg_integer(),
                         ExpireWithin :: pos_integer(),
+                        Nonce :: non_neg_integer(),
                         Ledger :: ledger()) -> ok | {error, any()}.
-add_state_channel(ID, Owner, Amount, ExpireWithin, Ledger) ->
+add_state_channel(ID, Owner, Amount, ExpireWithin, Nonce, Ledger) ->
     SCsCF = state_channels_cf(Ledger),
     {ok, CurrHeight} = ?MODULE:current_height(Ledger),
-    Routing = blockchain_ledger_state_channel_v1:new(ID, Owner, Amount, CurrHeight+ExpireWithin),
+    Routing = blockchain_ledger_state_channel_v1:new(ID, Owner, Amount, CurrHeight+ExpireWithin, Nonce),
     Bin = blockchain_ledger_state_channel_v1:serialize(Routing),
     Key = state_channel_key(ID, Owner),
     ok = cache_put(Ledger, SCsCF, Key, Bin),
@@ -2450,16 +2456,18 @@ state_channels_test() ->
     Ledger1 = new_context(Ledger),
     ID = crypto:strong_rand_bytes(32),
     Owner = <<"owner">>,
+    Nonce = 1,
 
     ?assertEqual({error, not_found}, find_state_channel(ID, Owner, Ledger1)),
     ?assertEqual({error, not_found}, find_state_channels_by_owner(Owner, Ledger1)),
 
     Ledger2 = new_context(Ledger),
-    ok = add_state_channel(ID, Owner, 12, 10, Ledger2),
+    ok = add_state_channel(ID, Owner, 12, 10, Nonce, Ledger2),
     ok = commit_context(Ledger2),
     {ok, SC} = find_state_channel(ID, Owner, Ledger),
     ?assertEqual(ID, blockchain_ledger_state_channel_v1:id(SC)),
     ?assertEqual(Owner, blockchain_ledger_state_channel_v1:owner(SC)),
+    ?assertEqual(Nonce, blockchain_ledger_state_channel_v1:nonce(SC)),
     ?assertEqual(12, blockchain_ledger_state_channel_v1:amount(SC)),
     ?assertEqual({ok, [ID]}, find_state_channels_by_owner(Owner, Ledger)),
 

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -1631,11 +1631,15 @@ find_all_state_channels_by_owner(Ledger, Owner) ->
     end.
 
 
--spec add_state_channel(binary(), libp2p_crypto:pubkey_bin(), non_neg_integer(), pos_integer(), ledger()) -> ok | {error, any()}.
-add_state_channel(ID, Owner, Amount, Timer, Ledger) ->
+-spec add_state_channel(ID :: binary(),
+                        Owner :: libp2p_crypto:pubkey_bin(),
+                        Amount :: non_neg_integer(),
+                        ExpireWithin :: pos_integer(),
+                        Ledger :: ledger()) -> ok | {error, any()}.
+add_state_channel(ID, Owner, Amount, ExpireWithin, Ledger) ->
     SCsCF = state_channels_cf(Ledger),
     {ok, CurrHeight} = ?MODULE:current_height(Ledger),
-    Routing = blockchain_ledger_state_channel_v1:new(ID, Owner, Amount, CurrHeight+Timer),
+    Routing = blockchain_ledger_state_channel_v1:new(ID, Owner, Amount, CurrHeight+ExpireWithin),
     Bin = blockchain_ledger_state_channel_v1:serialize(Routing),
     Key = state_channel_key(ID, Owner),
     ok = cache_put(Ledger, SCsCF, Key, Bin),

--- a/src/state_channel/blockchain_state_channels_client.erl
+++ b/src/state_channel/blockchain_state_channels_client.erl
@@ -11,30 +11,31 @@
 %% API Function Exports
 %% ------------------------------------------------------------------
 -export([
-    start_link/1,
-    credits/1,
-    packet/1,
-    response/1,
-    state_channel_update/1
-]).
+         start_link/1,
+         credits/1,
+         packet/1,
+         response/1,
+         state_channel_update/1
+        ]).
 
 %% ------------------------------------------------------------------
 %% gen_statem Function Exports
 %% ------------------------------------------------------------------
 -export([
-    init/1,
-    code_change/3,
-    callback_mode/0,
-    terminate/2
-]).
+         init/1,
+         code_change/3,
+         callback_mode/0,
+         terminate/2,
+         handle_common/3
+        ]).
 
 %% ------------------------------------------------------------------
 %% gen_statem callbacks Exports
 %% ------------------------------------------------------------------
 -export([
-    processing/3,
-    waiting/3
-]).
+         processing/3,
+         waiting/3
+        ]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -47,15 +48,17 @@
 -define(STATE_CHANNELS, <<"blockchain_state_channels_client.STATE_CHANNELS">>).
 
 -record(data, {
-    db :: rocksdb:db_handle() | undefined,
-    swarm :: pid(),
-    state_channels = #{} :: #{binary() => blockchain_state_channel_v1:state_channel()},
-    pending = undefined :: undefined | pending(),
-    packets = [] :: [any()]
-}).
+          db :: rocksdb:db_handle() | undefined,
+          swarm :: pid(),
+          state_channels = #{} :: state_channels(),
+          pending = undefined :: undefined | pending(),
+          packets = [] :: [packet()]
+         }).
 
 -type packet() :: #packet_pb{}.
--type pending() :: {blockchain_state_channel_request_v1:request(), packet(), pid(), reference()}.
+-type pending() :: {packet(), pid(), blockchain_state_channel_request_v1:request()}.
+-type state_channels() :: #{binary() => blockchain_state_channel_v1:state_channel()}.
+-type data() :: #data{}.
 
 %% ------------------------------------------------------------------
 %% API Function Definitions
@@ -63,150 +66,138 @@
 start_link(Args) ->
     gen_statem:start_link({local, ?SERVER}, ?SERVER, Args, []).
 
--spec credits(blockchain_state_channel_v1:id()) -> {ok, non_neg_integer()}.
+-spec credits(ID :: blockchain_state_channel_v1:id()) -> {ok, non_neg_integer()}.
 credits(ID) ->
     gen_statem:call(?SERVER, {credits, ID}).
 
--spec packet(packet()) -> ok.
+-spec packet(Packet :: packet()) -> ok.
 packet(Packet) ->
     gen_statem:cast(?SERVER, {packet, Packet}).
 
--spec response(blockchain_state_channel_response_v1:reponse()) -> ok.
+-spec response(Resp :: blockchain_state_channel_response_v1:reponse()) -> ok.
 response(Resp) ->
     gen_statem:cast(?SERVER, {response, Resp}).
 
--spec state_channel_update(blockchain_state_channel_update_v1:state_channel_update()) -> ok.
+-spec state_channel_update(SCUpdate :: blockchain_state_channel_update_v1:state_channel_update()) -> ok.
 state_channel_update(SCUpdate) ->
     gen_statem:cast(?SERVER, {state_channel_update, SCUpdate}).
 
 %% ------------------------------------------------------------------
-%% gen_statem Function Definitions
+%% Required callbacks for statem
 %% ------------------------------------------------------------------
 init(Args) ->
     lager:info("~p init with ~p", [?SERVER, Args]),
     Swarm = maps:get(swarm, Args),
     {ok, DB} = blockchain_state_channel_db:get(),
-    {ok, processing, #data{db=DB, swarm=Swarm}}.
+    %% Start in waiting state
+    Data = #data{db=DB, swarm=Swarm},
+    {ok, waiting, Data}.
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
-callback_mode() -> state_functions.
+callback_mode() ->
+    [state_functions, state_enter].
 
 terminate(_Reason, _Data) ->
     ok.
 
 %% ------------------------------------------------------------------
-%% gen_statem callbacks
+%% States
 %% ------------------------------------------------------------------
-
-processing(cast, {packet, Packet}, #data{packets=Packets}=Data) ->
-    ok = trigger_processing(),
-    {keep_state,  Data#data{packets=[Packet|Packets]}};
-processing(info, process_packet, #data{packets=[]}=Data) ->
-    lager:debug("nothing to process"),
-    {keep_state,  Data};
-processing(info, process_packet, #data{swarm=Swarm, packets=Packets}=Data) ->
-    Packet = lists:last(Packets),
-    lager:debug("processing", [Packet]),
+waiting(enter, _OldState, #data{packets=[]}) ->
+    %% There are no packets to process
+    keep_state_and_data;
+waiting(state_timeout, NextState, Data) ->
+    %% Switch state because of timeout
+    {next_state, NextState, Data};
+waiting(enter, _OldState, #data{packets=Packets, swarm=Swarm}=Data) ->
+    %% pop and process the first packet in Packets
+    [Packet | Rest] = Packets,
     case process_packet(Packet, Swarm) of
         {error, _Reason} ->
             lager:warning("failed to process packet ~p ~p", [Packet, _Reason]),
-            ok = trigger_processing(),
-            {keep_state,  Data};
+            {keep_state, Data, [postpone]};
         {ok, Pending} ->
-            {next_state, waiting, Data#data{pending=Pending, packets=lists:droplast(Packets)}}
-    end;
-processing(EventType, EventContent, Data) ->
-    handle_event(EventType, EventContent, Data).
+            NewData = Data#data{pending=Pending, packets=Rest},
+            {next_state, processing, NewData, [{state_timeout, timer:seconds(30), waiting}]}
+    end.
 
-waiting(cast, {packet, Packet}, #data{packets=Packets}=Data) ->
-    {keep_state,  Data#data{packets=[Packet|Packets]}};
-waiting(cast, {response, Resp}, #data{db=DB, swarm=Swarm, state_channels=SCs, pending={Req, _Packet, _Pid, TimeRef}=Pending}=Data) ->
-    lager:debug("received resp ~p", [Resp]),
-    case blockchain_state_channel_response_v1:req_hash(Resp) == blockchain_state_channel_request_v1:hash(Req) of
-        false ->
-            lager:warning("got unknown response ~p", [Resp]),
-            {keep_state,  Data};
-        true ->
-            erlang:cancel_timer(TimeRef),
-            case blockchain_state_channel_response_v1:accepted(Resp) of
-                false ->
-                    lager:info("request ~p got rejected, next...", [Req]),
-                    ok = trigger_processing(),
-                    {next_state, processing, Data#data{pending=undefined}};
-                true ->
-                    SCUpdate = blockchain_state_channel_response_v1:state_channel_update(Resp),
-                    UpdatedSC = blockchain_state_channel_update_v1:state_channel(SCUpdate),
-                    ID = blockchain_state_channel_v1:id(UpdatedSC),
-                    case validate_state_channel_update(maps:get(ID, SCs, undefined), UpdatedSC) of
-                        {error, _Reason} -> 
-                            lager:warning("state channel ~p is invalid ~p droping req", [UpdatedSC, _Reason]),
-                            ok = trigger_processing(),
-                            {next_state, processing, Data#data{pending=undefined}};
-                        ok ->
-                            ok = blockchain_state_channel_v1:save(DB, UpdatedSC),
-                            SC = maps:get(ID, SCs, undefined),
-                            {PubKeyBin, SigFun} = blockchain_utils:get_pubkeybin_sigfun(Swarm),
-                            case check_pending_request(SC, SCUpdate, Pending, PubKeyBin) of
-                                {error, _Reason} ->
-                                    lager:warning("state channel update did not match pending req ~p, dropping req", [_Reason]),
-                                    ok = trigger_processing(),
-                                    {next_state, processing, Data#data{pending=undefined}};
-                                ok ->
-                                    ok = send_packet(Pending, PubKeyBin, SigFun),
-                                    ok = trigger_processing(),
-                                    {next_state, processing, Data#data{state_channels=maps:put(ID, UpdatedSC, SCs),
-                                                                       pending=undefined}}
-                            end
-                    end
-            end
+processing(enter, _OldState, #data{pending=undefined}=Data) ->
+    %% Entered processing state with no request pending
+    %% Go back to waiting state
+    {next_state, waiting, Data};
+processing(cast, {response, _Resp}, #data{pending=undefined}=Data) ->
+    %% Got response when there is no request pending
+    %% Cool story?
+    {next_state, waiting, Data};
+processing(state_timeout, NextState, Data) ->
+    %% Switch state because of timeout
+    {next_state, NextState, Data};
+processing(cast, {response, Resp}, Data) ->
+    case handle_processing(Resp, Data) of
+        {error, _Reason} ->
+            lager:warning("failed to handle response ~p", [Resp]),
+            {next_state, waiting, Data#data{pending=undefined}};
+        {ok, NewStateChannels} ->
+            {next_state, waiting, Data#data{state_channels=NewStateChannels, pending=undefined}}
+    end.
+
+
+%% ------------------------------------------------------------------
+%% Common events
+%% ------------------------------------------------------------------
+handle_common({call,From}, {credits, ID}, #data{state_channels=SCs}) ->
+    Reply = case maps:get(ID, SCs, undefined) of
+                undefined ->
+                    {error, not_found};
+                SC ->
+                    {ok, blockchain_state_channel_v1:credits(SC)}
+            end,
+    {keep_state_and_data, [{reply, From, Reply}]};
+handle_common(cast, {state_channel_update, SCUpdate}, #data{db=DB, state_channels=SCs}=Data) ->
+    UpdatedSC = blockchain_state_channel_update_v1:state_channel(SCUpdate),
+    ID = blockchain_state_channel_v1:id(UpdatedSC),
+    lager:debug("received state channel update for ~p", [ID]),
+    case validate_state_channel_update(maps:get(ID, SCs, undefined), UpdatedSC) of
+        {error, _Reason} ->
+            lager:warning("state channel ~p is invalid ~p", [UpdatedSC, _Reason]),
+            keep_state_and_data;
+        ok ->
+            ok = blockchain_state_channel_v1:save(DB, UpdatedSC),
+            {keep_state, Data#data{state_channels=maps:put(ID, UpdatedSC, SCs)}}
     end;
-waiting(EventType, EventContent, Data) ->
-    handle_event(EventType, EventContent, Data).
+handle_common(cast, {packet, Packet}, #data{packets=[], swarm=Swarm}=Data) ->
+    %% We got a packet message while in either waiting/processing state
+    %% Process this packet immediately as we have no other packets to process
+    case process_packet(Packet, Swarm) of
+        {error, _Reason} ->
+            lager:warning("failed to process packet ~p ~p", [Packet, _Reason]),
+            NewData = Data#data{packets=[Packet]},
+            %% We'll process this packet later
+            {keep_state, NewData, [postpone]};
+        {ok, Pending} ->
+            %% We managed to get a pending request, go to processing
+            {next_state, processing, Data#data{pending=Pending}, [{state_timeout, timer:seconds(30), waiting}]}
+    end;
+handle_common(cast, {packet, Packet}, #data{packets=Packets}=Data) ->
+    %% We still have packets to process, add this received packet
+    %% at the end of Packets to get processed when possible
+    NewData = Data#data{packets=Packets ++ [Packet]},
+    {keep_state, NewData, [postpone]}.
 
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions
 %% ------------------------------------------------------------------
 
-handle_event({call, From}, {credits, ID}, #data{state_channels=SCs}=Data) ->
-    Reply = case maps:get(ID, SCs, undefined) of
-        undefined -> {error, not_found};
-        SC -> {ok, blockchain_state_channel_v1:credits(SC)}
-    end,
-    {keep_state, Data, [{reply, From, Reply}]};
-handle_event(cast, {state_channel_update, SCUpdate}, #data{db=DB, state_channels=SCs}=Data) ->
-    UpdatedSC = blockchain_state_channel_update_v1:state_channel(SCUpdate),
-    ID = blockchain_state_channel_v1:id(UpdatedSC),
-    lager:debug("received state channel update for ~p", [ID]),
-    case validate_state_channel_update(maps:get(ID, SCs, undefined), UpdatedSC) of
-        {error, _Reason} -> 
-            lager:warning("state channel ~p is invalid ~p", [UpdatedSC, _Reason]),
-            {keep_state, Data};
-        ok ->
-            ok = blockchain_state_channel_v1:save(DB, UpdatedSC),
-            {keep_state, Data#data{state_channels=maps:put(ID, UpdatedSC, SCs)}}
-    end;
-handle_event(info, {req_timeout, Req, Packet}, #data{pending={Req, Packet, _Pid, _TimeRef}}=Data) ->
-    lager:warning("request ~p timed out, dropping", [Req]),
-    ok = trigger_processing(),
-    {next_state, processing, Data#data{pending=undefined}};
-handle_event(_EventType, _EventContent, Data) ->
-    lager:warning("ignoring unknown event [~p] ~p", [_EventType, _EventContent]),
-    {keep_state, Data}.
-
--spec trigger_processing() -> ok.
-trigger_processing() ->
-    self() ! process_packet,
-    ok.
-
--spec validate_state_channel_update(blockchain_state_channel_v1:state_channel() | undefined, blockchain_state_channel_v1:state_channel()) -> ok | {error, any()}.
+-spec validate_state_channel_update(OldStateChannel :: blockchain_state_channel_v1:state_channel() | undefined,
+                                    NewStateChannel :: blockchain_state_channel_v1:state_channel()) -> ok | {error, any()}.
 validate_state_channel_update(undefined, NewStateChannel) ->
     blockchain_state_channel_v1:validate(NewStateChannel);
 validate_state_channel_update(OldStateChannel, NewStateChannel) ->
     case blockchain_state_channel_v1:validate(NewStateChannel) of
-        {error, _}=Error -> 
+        {error, _}=Error ->
             Error;
         ok ->
             NewNonce = blockchain_state_channel_v1:nonce(NewStateChannel),
@@ -217,29 +208,29 @@ validate_state_channel_update(OldStateChannel, NewStateChannel) ->
             end
     end.
 
--spec process_packet(packet(), pid()) -> {ok, pending()} | {error, any()}.
+-spec process_packet(Packet :: packet(),
+                     Swarm :: pid()) -> {ok, pending()} | {error, any()}.
 process_packet(#packet_pb{oui=OUI, payload=Payload}=Packet, Swarm) ->
     case find_routing(OUI) of
         {error, _Reason} ->
             lager:warning("failed to find router for oui ~p:~p", [OUI, _Reason]),
-             {error, _Reason};
+            {error, _Reason};
         {ok, Peer} ->
             case blockchain_state_channel_handler:dial(Swarm, Peer, []) of
                 {error, _Reason} ->
                     lager:warning("failed to dial ~p:~p", [Peer, _Reason]),
                     {error, _Reason};
-                {ok, Pid} ->
+                {ok, Stream} ->
                     {PubKeyBin, _SigFun} = blockchain_utils:get_pubkeybin_sigfun(Swarm),
                     Amount = calculate_dc_amount(PubKeyBin, OUI, Payload),
                     Req = blockchain_state_channel_request_v1:new(PubKeyBin, Amount, erlang:byte_size(Payload)),
                     lager:info("sending payment req ~p to ~p", [Req, Peer]),
-                    ok = blockchain_state_channel_handler:send_request(Pid, Req),
-                    TimeRef = erlang:send_after(timer:seconds(30), self(), {req_timeout, Req, Packet}),
-                    {ok, {Req, Packet, Pid, TimeRef}}
+                    ok = blockchain_state_channel_handler:send_request(Stream, Req),
+                    {ok, {Packet, Stream, Req}}
             end
     end.
 
--spec find_routing(non_neg_integer()) -> {ok, string()} | {error, any()}.
+-spec find_routing(OUI :: non_neg_integer()) -> {ok, string()} | {error, any()}.
 find_routing(OUI) ->
     Chain = blockchain_worker:blockchain(),
     Ledger = blockchain:ledger(Chain),
@@ -252,7 +243,9 @@ find_routing(OUI) ->
             {ok, erlang:binary_to_list(Address)}
     end.
 
--spec calculate_dc_amount(libp2p_crypto:pubkey_to_bin(), non_neg_integer(), binary()) -> non_neg_integer().
+-spec calculate_dc_amount(PubKeyBin :: libp2p_crypto:pubkey_to_bin(),
+                          OUI :: non_neg_integer(),
+                          Payload :: binary()) -> non_neg_integer().
 calculate_dc_amount(PubKeyBin, OUI, Payload) ->
     Chain = blockchain_worker:blockchain(),
     Ledger = blockchain:ledger(Chain),
@@ -269,9 +262,11 @@ calculate_dc_amount(PubKeyBin, OUI, Payload) ->
             end
     end.
 
--spec check_pending_request(blockchain_state_channel_v1:state_channel() | undefined,
-                            blockchain_state_channel_update_v1:state_channel_update(), pending(), libp2p_crypto:pubkey_bin()) -> ok | {error, any()}.
-check_pending_request(SC, SCUpdate, {Req, Packet, _Pid, _TimeRef}, PubkeyBin) ->
+-spec check_pending_request(SC :: blockchain_state_channel_v1:state_channel() | undefined,
+                            SCUpdate :: blockchain_state_channel_update_v1:state_channel_update(),
+                            Pending :: pending(),
+                            PubkeyBin :: libp2p_crypto:pubkey_bin()) -> ok | {error, any()}.
+check_pending_request(SC, SCUpdate, {Packet, _Stream, Req}, PubkeyBin) ->
     UpdatedSC = blockchain_state_channel_update_v1:state_channel(SCUpdate),
     case {check_root_hash(Packet, SCUpdate, PubkeyBin), check_balance(Req, SC, UpdatedSC)} of
         {false, _} -> {error, bad_root_hash};
@@ -279,7 +274,9 @@ check_pending_request(SC, SCUpdate, {Req, Packet, _Pid, _TimeRef}, PubkeyBin) ->
         {true, true} -> ok
     end.
 
--spec check_root_hash(packet(), blockchain_state_channel_update_v1:state_channel_update(), libp2p_crypto:pubkey_bin()) -> boolean().
+-spec check_root_hash(Packet :: packet(),
+                      SCUpdate :: blockchain_state_channel_update_v1:state_channel_update(),
+                      PubKeyBin :: libp2p_crypto:pubkey_bin()) -> boolean().
 check_root_hash(#packet_pb{payload=Payload}, SCUpdate, PubkeyBin) ->
     UpdatedSC = blockchain_state_channel_update_v1:state_channel(SCUpdate),
     RootHash = blockchain_state_channel_v1:root_hash(UpdatedSC),
@@ -289,9 +286,9 @@ check_root_hash(#packet_pb{payload=Payload}, SCUpdate, PubkeyBin) ->
     Value = <<PubkeyBin/binary, PayloadSize>>,
     skewed:verify(skewed:hash_value(Value), [Hash], RootHash).
 
--spec check_balance(blockchain_state_channel_request_v1:request(),
-                    blockchain_state_channel_v1:state_channel() | undefined,
-                    blockchain_state_channel_v1:state_channel()) -> boolean().
+-spec check_balance(Req :: blockchain_state_channel_request_v1:request(),
+                    SC :: blockchain_state_channel_v1:state_channel() | undefined,
+                    UpdateSC :: blockchain_state_channel_v1:state_channel()) -> boolean().
 check_balance(Req, SC, UpdateSC) ->
     ReqPayee = blockchain_state_channel_request_v1:payee(Req),
     ReqPayloadSize = blockchain_state_channel_request_v1:payload_size(Req),
@@ -302,21 +299,63 @@ check_balance(Req, SC, UpdateSC) ->
             ReqPayloadSize == 0;
         {ok, NewBalance} ->
             OldBalance = case SC == undefined of
-                false ->
-                    case blockchain_state_channel_v1:balance(ReqPayee, SC) of
-                        {ok, B} -> B;
-                        _ -> 0
-                    end;
-                true -> 0
-            end,
+                             false ->
+                                 case blockchain_state_channel_v1:balance(ReqPayee, SC) of
+                                     {ok, B} -> B;
+                                     _ -> 0
+                                 end;
+                             true -> 0
+                         end,
             NewBalance-OldBalance >= ReqPayloadSize
     end.
 
--spec send_packet(pending(), libp2p_crypto:pubkey_bin(), function()) -> ok.
-send_packet({_Req, Packet, Pid, _TimeRef}, PubKeyBin, SigFun) ->
+-spec send_packet(Pending :: pending(),
+                  PubkeyBin :: libp2p_crypto:pubkey_bin(),
+                  SigFun :: function()) -> ok.
+send_packet({Packet, Stream, _Req}, PubKeyBin, SigFun) ->
     PacketMsg0 = blockchain_state_channel_packet_v1:new(Packet, PubKeyBin),
     PacketMsg1 = blockchain_state_channel_packet_v1:sign(PacketMsg0, SigFun),
-    blockchain_state_channel_handler:send_packet(Pid, PacketMsg1).
+    blockchain_state_channel_handler:send_packet(Stream, PacketMsg1).
+
+-spec handle_processing(Resp :: blockchain_state_channel_response_v1:response(),
+                        Data :: data()) -> {error, any()} | {ok, state_channels()}.
+handle_processing(Resp,
+                  #data{db=DB,
+                        swarm=Swarm,
+                        pending={_Packet, _Stream, Req}=Pending,
+                        state_channels=SCs}) ->
+    case blockchain_state_channel_response_v1:req_hash(Resp) == blockchain_state_channel_request_v1:hash(Req) of
+        false ->
+            {error, hash_mismatch};
+        true ->
+            case blockchain_state_channel_response_v1:accepted(Resp) of
+                false ->
+                    lager:info("request ~p got rejected, next...", [Req]),
+                    {error, request_rejected};
+                true ->
+                    SCUpdate = blockchain_state_channel_response_v1:state_channel_update(Resp),
+                    UpdatedSC = blockchain_state_channel_update_v1:state_channel(SCUpdate),
+                    ID = blockchain_state_channel_v1:id(UpdatedSC),
+                    case validate_state_channel_update(maps:get(ID, SCs, undefined), UpdatedSC) of
+                        {error, _Reason}=E0 ->
+                            lager:warning("state channel ~p is invalid ~p droping req", [UpdatedSC, _Reason]),
+                            E0;
+                        ok ->
+                            ok = blockchain_state_channel_v1:save(DB, UpdatedSC),
+                            SC = maps:get(ID, SCs, undefined),
+                            {PubKeyBin, SigFun} = blockchain_utils:get_pubkeybin_sigfun(Swarm),
+                            case check_pending_request(SC, SCUpdate, Pending, PubKeyBin) of
+                                {error, _Reason}=E1 ->
+                                    lager:warning("state channel update did not match pending req ~p, dropping req", [_Reason]),
+                                    E1;
+                                ok ->
+                                    ok = send_packet(Pending, PubKeyBin, SigFun),
+                                    NewStateChannels = maps:put(ID, UpdatedSC, SCs),
+                                    {ok, NewStateChannels}
+                            end
+                    end
+            end
+    end.
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/state_channel/blockchain_state_channels_server.erl
+++ b/src/state_channel/blockchain_state_channels_server.erl
@@ -490,9 +490,11 @@ convert_to_state_channels(LedgerSCs) ->
                      Owner = blockchain_ledger_state_channel_v1:owner(LedgerStateChannel),
                      Amount = blockchain_ledger_state_channel_v1:amount(LedgerStateChannel),
                      ExpireAt = blockchain_ledger_state_channel_v1:expire_at_block(LedgerStateChannel),
+                     Nonce = blockchain_ledger_state_channel_v1:nonce(LedgerStateChannel),
                      SC0 = blockchain_state_channel_v1:new(ID, Owner),
                      SC1 = blockchain_state_channel_v1:credits(Amount, SC0),
-                     blockchain_state_channel_v1:expire_at_block(ExpireAt, SC1)
+                     SC2 = blockchain_state_channel_v1:nonce(Nonce, SC1),
+                     blockchain_state_channel_v1:expire_at_block(ExpireAt, SC2)
              end,
              LedgerSCs).
 

--- a/src/state_channel/v1/blockchain_helium_packet_v1.erl
+++ b/src/state_channel/v1/blockchain_helium_packet_v1.erl
@@ -1,0 +1,103 @@
+%%%-------------------------------------------------------------------
+%% @doc
+%% == Blockchain Helium Packet ==
+%% @end
+%%%-------------------------------------------------------------------
+-module(blockchain_helium_packet_v1).
+
+-export([
+         new/0, new/2, %% only for testing, where we set only the oui and payload
+         new/8,
+         oui/1,
+         type/1,
+         payload/1,
+         timestamp/1,
+         signal_strength/1,
+         frequency/1,
+         datarate/1,
+         snr/1
+        ]).
+
+-include("blockchain.hrl").
+-include_lib("helium_proto/include/packet_pb.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-type packet() :: #packet_pb{}.
+-export_type([packet/0]).
+
+-spec new() -> packet().
+new() ->
+    #packet_pb{}.
+
+-spec new(OUI :: non_neg_integer(), Payload :: binary()) -> packet().
+new(OUI, Payload) ->
+    #packet_pb{oui=OUI, payload=Payload}.
+
+-spec new(OUI :: non_neg_integer(),
+          Type :: longfi | lorawan,
+          Payload :: binary(),
+          TimeStamp :: non_neg_integer(),
+          SignalStrength :: float(),
+          Frequency :: float(),
+          DataRate :: string(),
+          SNR :: float()) -> packet().
+new(OUI, Type, Payload, TimeStamp, SignalStrength, Frequency, DataRate, SNR) ->
+    #packet_pb{
+       oui=OUI,
+       type=Type,
+       payload=Payload,
+       timestamp=TimeStamp,
+       signal_strength=SignalStrength,
+       frequency=Frequency,
+       datarate=DataRate,
+       snr=SNR}.
+
+-spec oui(packet()) -> non_neg_integer().
+oui(#packet_pb{oui=OUI}) ->
+    OUI.
+
+-spec type(packet()) -> lorawan | longfi.
+type(#packet_pb{type=Type}) ->
+    Type.
+
+-spec payload(packet()) -> binary().
+payload(#packet_pb{payload=Payload}) ->
+    Payload.
+
+-spec timestamp(packet()) -> non_neg_integer().
+timestamp(#packet_pb{timestamp=TS}) ->
+    TS.
+
+-spec signal_strength(packet()) -> float().
+signal_strength(#packet_pb{signal_strength=SS}) ->
+    SS.
+
+-spec frequency(packet()) -> float().
+frequency(#packet_pb{frequency=Freq}) ->
+    Freq.
+
+-spec datarate(packet()) -> string().
+datarate(#packet_pb{datarate=DR}) ->
+    DR.
+
+-spec snr(packet()) -> float().
+snr(#packet_pb{snr=SNR}) ->
+    SNR.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+
+%% ------------------------------------------------------------------
+%% EUNIT Tests
+%% ------------------------------------------------------------------
+-ifdef(TEST).
+
+new_test() ->
+    Packet = #packet_pb{oui=1, payload= <<"hello">>},
+    ?assertEqual(Packet, new(1, <<"hello">>)).
+
+-endif.

--- a/src/state_channel/v1/blockchain_state_channel_packet_v1.erl
+++ b/src/state_channel/v1/blockchain_state_channel_packet_v1.erl
@@ -14,24 +14,22 @@
 
 -include("blockchain.hrl").
 -include_lib("helium_proto/include/blockchain_state_channel_v1_pb.hrl").
--include_lib("helium_proto/include/packet_pb.hrl").
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
--type helium_packet() :: #packet_pb{}.
 -type packet() :: #blockchain_state_channel_packet_v1_pb{}.
 -export_type([packet/0]).
 
--spec new(helium_packet(), libp2p_crypto:pubkey_bin()) -> packet().
-new(Packet, Hotspot) -> 
+-spec new(blockchain_helium_packet_v1:packet(), libp2p_crypto:pubkey_bin()) -> packet().
+new(Packet, Hotspot) ->
     #blockchain_state_channel_packet_v1_pb{
         packet=Packet,
         hotspot=Hotspot
     }.
 
--spec packet(packet()) -> helium_packet().
+-spec packet(packet()) -> blockchain_helium_packet_v1:packet().
 packet(#blockchain_state_channel_packet_v1_pb{packet=Packet}) ->
     Packet.
 
@@ -80,39 +78,39 @@ decode(BinaryPacket) ->
 
 new_test() ->
     Packet = #blockchain_state_channel_packet_v1_pb{
-        packet= #packet_pb{},
+        packet= blockchain_helium_packet_v1:new(),
         hotspot = <<"hotspot">>
     },
-    ?assertEqual(Packet, new(#packet_pb{}, <<"hotspot">>)).
+    ?assertEqual(Packet, new(blockchain_helium_packet_v1:new(), <<"hotspot">>)).
 
 hotspot_test() ->
-    Packet = new(#packet_pb{}, <<"hotspot">>),
+    Packet = new(blockchain_helium_packet_v1:new(), <<"hotspot">>),
     ?assertEqual(<<"hotspot">>, hotspot(Packet)).
 
 packet_test() ->
-    Packet = new(#packet_pb{}, <<"hotspot">>),
-    ?assertEqual(#packet_pb{}, packet(Packet)).
+    Packet = new(blockchain_helium_packet_v1:new(), <<"hotspot">>),
+    ?assertEqual(blockchain_helium_packet_v1:new(), packet(Packet)).
 
 signature_test() ->
-    Packet = new(#packet_pb{}, <<"hotspot">>),
+    Packet = new(blockchain_helium_packet_v1:new(), <<"hotspot">>),
     ?assertEqual(<<>>, signature(Packet)).
 
 sign_test() ->
     #{secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
-    Packet = new(#packet_pb{}, <<"hotspot">>),
+    Packet = new(blockchain_helium_packet_v1:new(), <<"hotspot">>),
     ?assertNotEqual(<<>>, signature(sign(Packet, SigFun))).
 
 validate_test() ->
     #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
     PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
-    Packet0 = new(#packet_pb{}, PubKeyBin),
+    Packet0 = new(blockchain_helium_packet_v1:new(), PubKeyBin),
     Packet1 = sign(Packet0, SigFun),
     ?assertEqual(true, validate(Packet1)).
 
 encode_decode_test() ->
-    Packet = new(#packet_pb{}, <<"hotspot">>),
+    Packet = new(blockchain_helium_packet_v1:new(), <<"hotspot">>),
     ?assertEqual(Packet, decode(encode(Packet))).
 
 -endif.

--- a/src/state_channel/v1/blockchain_state_channel_update_v1.erl
+++ b/src/state_channel/v1/blockchain_state_channel_update_v1.erl
@@ -22,7 +22,7 @@
 -export_type([state_channel_update/0]).
 
 -spec new(blockchain_state_channel_v1:state_channel(), skewed:hash()) -> state_channel_update().
-new(SC, Hash) -> 
+new(SC, Hash) ->
     #blockchain_state_channel_update_v1_pb{
         state_channel=SC,
         previous_hash=Hash

--- a/src/transactions/v1/blockchain_txn_state_channel_close_v1.erl
+++ b/src/transactions/v1/blockchain_txn_state_channel_close_v1.erl
@@ -105,7 +105,7 @@ absorb(Txn, Chain) ->
     SC = ?MODULE:state_channel(Txn),
     ID = blockchain_state_channel_v1:id(SC),
     Owner = blockchain_state_channel_v1:owner(SC),
-    ok = blockchain_ledger_v1:close_state_channel(ID, Owner, Ledger),
+    ok = blockchain_ledger_v1:delete_state_channel(ID, Owner, Ledger),
     case blockchain_state_channel_v1:credits(SC) of
         Credits when Credits > 0 ->
             blockchain_ledger_v1:credit_dc(Owner, Credits, Ledger);

--- a/src/transactions/v1/blockchain_txn_state_channel_open_v1.erl
+++ b/src/transactions/v1/blockchain_txn_state_channel_open_v1.erl
@@ -15,7 +15,7 @@
     id/1,
     owner/1,
     amount/1,
-    expire_at_block/1,
+    expire_within/1,
     fee/1,
     signature/1,
     sign/2,
@@ -29,17 +29,19 @@
 -endif.
 
 -define(TO_B58(X), libp2p_crypto:bin_to_b58(X)).
+-define(APPROX_BLOCKS_IN_WEEK, 10080).
+-define(MIN_EXPIRE_WITHIN, 10).
 
 -type txn_state_channel_open() :: #blockchain_txn_state_channel_open_v1_pb{}.
 -export_type([txn_state_channel_open/0]).
 
 -spec new(binary(), libp2p_crypto:pubkey_bin(), non_neg_integer(), pos_integer()) -> txn_state_channel_open().
-new(ID, Owner, Amount, ExpireAt) ->
+new(ID, Owner, Amount, ExpireWithin) ->
     #blockchain_txn_state_channel_open_v1_pb{
         id=ID,
         owner=Owner,
         amount=Amount,
-        expire_at_block=ExpireAt,
+        expire_within=ExpireWithin,
         signature = <<>>
     }.
 
@@ -61,9 +63,9 @@ owner(Txn) ->
 amount(Txn) ->
     Txn#blockchain_txn_state_channel_open_v1_pb.amount.
 
--spec expire_at_block(txn_state_channel_open()) -> pos_integer().
-expire_at_block(Txn) ->
-    Txn#blockchain_txn_state_channel_open_v1_pb.expire_at_block.
+-spec expire_within(txn_state_channel_open()) -> pos_integer().
+expire_within(Txn) ->
+    Txn#blockchain_txn_state_channel_open_v1_pb.expire_within.
 
 -spec fee(txn_state_channel_open()) -> 0.
 fee(_Txn) ->
@@ -91,10 +93,8 @@ is_valid(Txn, Chain) ->
         false ->
             {error, bad_signature};
         true ->
-            ExpireAt = ?MODULE:expire_at_block(Txn),
-            {ok, CurrHeight} = blockchain_ledger_v1:current_height(Ledger),
-            % 10080: approximate number of blocks in a week (1/min)
-            case ExpireAt > CurrHeight+10 andalso ExpireAt < CurrHeight+10080 of
+            ExpireWithin = ?MODULE:expire_within(Txn),
+            case ExpireWithin > ?MIN_EXPIRE_WITHIN andalso ExpireWithin < ?APPROX_BLOCKS_IN_WEEK of
                 false ->
                     {error, invalid_expire_at_block};
                 true ->
@@ -127,24 +127,24 @@ absorb(Txn, Chain) ->
     ID = ?MODULE:id(Txn),
     Owner = ?MODULE:owner(Txn),
     Amount = ?MODULE:amount(Txn),
-    ExpireAt = ?MODULE:expire_at_block(Txn),
+    ExpireWithin = ?MODULE:expire_within(Txn),
     case blockchain_state_channel_v1:zero_id() == ID andalso Amount == 0 of
         true ->
-            blockchain_ledger_v1:add_state_channel(ID, Owner, Amount, ExpireAt, Ledger);
+            blockchain_ledger_v1:add_state_channel(ID, Owner, Amount, ExpireWithin, Ledger);
         false ->
             case blockchain_ledger_v1:debit_dc(Owner, Amount, Ledger) of
                 {error, _}=Error ->
                     Error;
                 ok ->
-                    blockchain_ledger_v1:add_state_channel(ID, Owner, Amount, ExpireAt, Ledger)
+                    blockchain_ledger_v1:add_state_channel(ID, Owner, Amount, ExpireWithin, Ledger)
             end
     end.
 
 -spec print(txn_state_channel_open()) -> iodata().
 print(undefined) -> <<"type=state_channel_open, undefined">>;
-print(#blockchain_txn_state_channel_open_v1_pb{id=ID, owner=Owner, amount=Amount, expire_at_block=ExpireAt}) ->
-    io_lib:format("type=state_channel_open, id=~p, owner=~p, amount=~p, expire_at_block=~p",
-                  [ID, ?TO_B58(Owner), Amount, ExpireAt]).
+print(#blockchain_txn_state_channel_open_v1_pb{id=ID, owner=Owner, amount=Amount, expire_within=ExpireWithin}) ->
+    io_lib:format("type=state_channel_open, id=~p, owner=~p, amount=~p, expire_within=~p",
+                  [ID, ?TO_B58(Owner), Amount, ExpireWithin]).
 
  %% ------------------------------------------------------------------
 %% EUNIT Tests
@@ -156,7 +156,7 @@ new_test() ->
         id = <<"id">>,
         owner= <<"owner">>,
         amount=666,
-        expire_at_block=10,
+        expire_within=10,
         signature = <<>>
     },
     ?assertEqual(Tx, new(<<"id">>, <<"owner">>, 666, 10)).

--- a/src/transactions/v1/blockchain_txn_state_channel_open_v1.erl
+++ b/src/transactions/v1/blockchain_txn_state_channel_open_v1.erl
@@ -10,11 +10,12 @@
 -include_lib("helium_proto/include/blockchain_txn_state_channel_open_v1_pb.hrl").
 
 -export([
-    new/4,
+    new/5,
     hash/1,
     id/1,
     owner/1,
     amount/1,
+    nonce/1,
     expire_within/1,
     fee/1,
     signature/1,
@@ -35,53 +36,64 @@
 -type txn_state_channel_open() :: #blockchain_txn_state_channel_open_v1_pb{}.
 -export_type([txn_state_channel_open/0]).
 
--spec new(binary(), libp2p_crypto:pubkey_bin(), non_neg_integer(), pos_integer()) -> txn_state_channel_open().
-new(ID, Owner, Amount, ExpireWithin) ->
+-spec new(ID :: binary(),
+          Owner :: libp2p_crypto:pubkey_bin(),
+          Amount :: non_neg_integer(),
+          ExpireWithin :: pos_integer(),
+          Nonce :: non_neg_integer()) -> txn_state_channel_open().
+new(ID, Owner, Amount, ExpireWithin, Nonce) ->
     #blockchain_txn_state_channel_open_v1_pb{
         id=ID,
         owner=Owner,
         amount=Amount,
         expire_within=ExpireWithin,
+        nonce=Nonce,
         signature = <<>>
     }.
 
--spec hash(txn_state_channel_open()) -> blockchain_txn:hash().
+-spec hash(Txn :: txn_state_channel_open()) -> blockchain_txn:hash().
 hash(Txn) ->
     BaseTxn = Txn#blockchain_txn_state_channel_open_v1_pb{signature = <<>>},
     EncodedTxn = blockchain_txn_state_channel_open_v1_pb:encode_msg(BaseTxn),
     crypto:hash(sha256, EncodedTxn).
 
--spec id(txn_state_channel_open()) -> binary().
+-spec id(Txn :: txn_state_channel_open()) -> binary().
 id(Txn) ->
     Txn#blockchain_txn_state_channel_open_v1_pb.id.
 
--spec owner(txn_state_channel_open()) -> libp2p_crypto:pubkey_bin().
+-spec owner(Txn :: txn_state_channel_open()) -> libp2p_crypto:pubkey_bin().
 owner(Txn) ->
     Txn#blockchain_txn_state_channel_open_v1_pb.owner.
 
--spec amount(txn_state_channel_open()) -> integer().
+-spec amount(Txn :: txn_state_channel_open()) -> integer().
 amount(Txn) ->
     Txn#blockchain_txn_state_channel_open_v1_pb.amount.
 
--spec expire_within(txn_state_channel_open()) -> pos_integer().
+-spec nonce(Txn :: txn_state_channel_open()) -> non_neg_integer().
+nonce(Txn) ->
+    Txn#blockchain_txn_state_channel_open_v1_pb.nonce.
+
+-spec expire_within(Txn :: txn_state_channel_open()) -> pos_integer().
 expire_within(Txn) ->
     Txn#blockchain_txn_state_channel_open_v1_pb.expire_within.
 
--spec fee(txn_state_channel_open()) -> 0.
+-spec fee(Txn :: txn_state_channel_open()) -> 0.
 fee(_Txn) ->
     0.
 
--spec signature(txn_state_channel_open()) -> binary().
+-spec signature(Txn :: txn_state_channel_open()) -> binary().
 signature(Txn) ->
     Txn#blockchain_txn_state_channel_open_v1_pb.signature.
 
--spec sign(txn_state_channel_open(), libp2p_crypto:sig_fun()) -> txn_state_channel_open().
+-spec sign(Txn :: txn_state_channel_open(),
+           SigFun :: libp2p_crypto:sig_fun()) -> txn_state_channel_open().
 sign(Txn, SigFun) ->
     EncodedTxn = blockchain_txn_state_channel_open_v1_pb:encode_msg(Txn),
     Txn#blockchain_txn_state_channel_open_v1_pb{signature=SigFun(EncodedTxn)}.
 
 % TODO: Make timer limits chain vars
--spec is_valid(txn_state_channel_open(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec is_valid(Txn :: txn_state_channel_open(),
+               Chain :: blockchain:blockchain()) -> ok | {error, any()}.
 is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Owner = ?MODULE:owner(Txn),
@@ -106,7 +118,19 @@ is_valid(Txn, Chain) ->
                                 A when A < 0 ->
                                     {error, bad_amount};
                                 A when A > 0 ->
-                                    blockchain_ledger_v1:check_dc_balance(Owner, Amount, Ledger);
+                                    case blockchain_ledger_v1:find_dc_entry(Owner, Ledger) of
+                                        {error, _}=Err0 ->
+                                            Err0;
+                                        {ok, DCEntry} ->
+                                            TxnNonce = ?MODULE:nonce(Txn),
+                                            NextLedgerNonce = blockchain_ledger_data_credits_entry_v1:nonce(DCEntry) + 1,
+                                            case TxnNonce =:= NextLedgerNonce of
+                                                false ->
+                                                    {error, {bad_nonce, {state_channel_open, TxnNonce, NextLedgerNonce}}};
+                                                true ->
+                                                    blockchain_ledger_v1:check_dc_balance(Owner, Amount, Ledger)
+                                            end
+                                    end;
                                 0 ->
                                     case blockchain_state_channel_v1:zero_id() == ID of
                                         false -> {error, mistmaching_id};
@@ -114,29 +138,31 @@ is_valid(Txn, Chain) ->
                                     end
                             end;
                         {ok, _} ->
-                            {error, state_channel_already_exist};
+                            {error, state_channel_already_exists};
                         {error, _}=Err ->
                             Err
                     end
             end
     end.
 
--spec absorb(txn_state_channel_open(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec absorb(Txn :: txn_state_channel_open(),
+             Chain :: blockchain:blockchain()) -> ok | {error, any()}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     ID = ?MODULE:id(Txn),
     Owner = ?MODULE:owner(Txn),
     Amount = ?MODULE:amount(Txn),
     ExpireWithin = ?MODULE:expire_within(Txn),
+    Nonce = ?MODULE:nonce(Txn),
     case blockchain_state_channel_v1:zero_id() == ID andalso Amount == 0 of
         true ->
-            blockchain_ledger_v1:add_state_channel(ID, Owner, Amount, ExpireWithin, Ledger);
+            blockchain_ledger_v1:add_state_channel(ID, Owner, Amount, ExpireWithin, Nonce, Ledger);
         false ->
-            case blockchain_ledger_v1:debit_dc(Owner, Amount, Ledger) of
+            case blockchain_ledger_v1:debit_dc(Owner, Amount, Nonce, Ledger) of
                 {error, _}=Error ->
                     Error;
                 ok ->
-                    blockchain_ledger_v1:add_state_channel(ID, Owner, Amount, ExpireWithin, Ledger)
+                    blockchain_ledger_v1:add_state_channel(ID, Owner, Amount, ExpireWithin, Nonce, Ledger)
             end
     end.
 
@@ -157,29 +183,30 @@ new_test() ->
         owner= <<"owner">>,
         amount=666,
         expire_within=10,
+        nonce=1,
         signature = <<>>
     },
-    ?assertEqual(Tx, new(<<"id">>, <<"owner">>, 666, 10)).
+    ?assertEqual(Tx, new(<<"id">>, <<"owner">>, 666, 10, 1)).
 
 id_test() ->
-    Tx = new(<<"id">>, <<"owner">>, 666, 10),
+    Tx = new(<<"id">>, <<"owner">>, 666, 10, 1),
     ?assertEqual(<<"id">>, id(Tx)).
 
 owner_test() ->
-    Tx = new(<<"id">>, <<"owner">>, 666, 10),
+    Tx = new(<<"id">>, <<"owner">>, 666, 10, 1),
     ?assertEqual(<<"owner">>, owner(Tx)).
 
 amount_test() ->
-    Tx = new(<<"id">>, <<"owner">>, 666, 10),
+    Tx = new(<<"id">>, <<"owner">>, 666, 10, 1),
     ?assertEqual(666, amount(Tx)).
 
 signature_test() ->
-    Tx = new(<<"id">>, <<"owner">>, 666, 10),
+    Tx = new(<<"id">>, <<"owner">>, 666, 10, 1),
     ?assertEqual(<<>>, signature(Tx)).
 
 sign_test() ->
     #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    Tx0 = new(<<"id">>, <<"owner">>, 666, 10),
+    Tx0 = new(<<"id">>, <<"owner">>, 666, 10, 1),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     Tx1 = sign(Tx0, SigFun),
     Sig1 = signature(Tx1),

--- a/test/blockchain_state_channel_SUITE.erl
+++ b/test/blockchain_state_channel_SUITE.erl
@@ -75,7 +75,7 @@ init_per_testcase(Test, Config) ->
 
     ok = check_genesis_block(InitConfig, GenesisBlock),
     ConsensusMembers = get_consensus_members(InitConfig, ConsensusAddrs),
-    [{consensus_memebers, ConsensusMembers} | InitConfig].
+    [{consensus_members, ConsensusMembers} | InitConfig].
 
 %%--------------------------------------------------------------------
 %% TEST CASE TEARDOWN
@@ -147,7 +147,7 @@ basic_test(Config) ->
 
 zero_test(Config) ->
     [RouterNode, GatewayNode1|_] = proplists:get_value(nodes, Config, []),
-    ConsensusMembers = proplists:get_value(consensus_memebers, Config),
+    ConsensusMembers = proplists:get_value(consensus_members, Config),
 
     % Step 1: Create OUI txn
     {ok, RouterPubkey, RouterSigFun, _} = ct_rpc:call(RouterNode, blockchain_swarm, keys, []),
@@ -229,7 +229,7 @@ zero_test(Config) ->
 
 full_test(Config) ->
     [RouterNode, GatewayNode1|_] = proplists:get_value(nodes, Config, []),
-    ConsensusMembers = proplists:get_value(consensus_memebers, Config),
+    ConsensusMembers = proplists:get_value(consensus_members, Config),
 
     % Some madness to make submit txn work and "create a block"
     Self = self(),
@@ -259,10 +259,13 @@ full_test(Config) ->
     ID = crypto:strong_rand_bytes(32),
     SCOpenTxn = blockchain_txn_state_channel_open_v1:new(ID, RouterPubkeyBin, TotalDC, 100),
     SignedSCOpenTxn = blockchain_txn_state_channel_open_v1:sign(SCOpenTxn, RouterSigFun),
+    ct:pal("SignedSCOpenTxn: ~p", [SignedSCOpenTxn]),
 
     % Step 3: Adding block
     RouterChain = ct_rpc:call(RouterNode, blockchain_worker, blockchain, []),
+    ct:pal("RouterChain: ~p", [RouterChain]),
     Block0 = ct_rpc:call(RouterNode, test_utils, create_block, [ConsensusMembers, [SignedOUITxn, SignedSCOpenTxn]]),
+    ct:pal("Block0: ~p", [Block0]),
     _ = ct_rpc:call(RouterNode, blockchain_gossip_handler, add_block, [RouterSwarm, Block0, RouterChain, Self]),
 
     ok = blockchain_ct_utils:wait_until(fun() ->
@@ -346,7 +349,7 @@ full_test(Config) ->
 
 expired_test(Config) ->
     [RouterNode, GatewayNode1|_] = proplists:get_value(nodes, Config, []),
-    ConsensusMembers = proplists:get_value(consensus_memebers, Config),
+    ConsensusMembers = proplists:get_value(consensus_members, Config),
 
     % Some madness to make submit txn work and "create a block"
     Self = self(),

--- a/test/blockchain_state_channel_SUITE.erl
+++ b/test/blockchain_state_channel_SUITE.erl
@@ -14,7 +14,6 @@
 ]).
 
 -include("blockchain.hrl").
--include_lib("helium_proto/include/packet_pb.hrl").
 
 %%--------------------------------------------------------------------
 %% COMMON TEST CALLBACK FUNCTIONS
@@ -200,7 +199,7 @@ zero_test(Config) ->
     ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])),
 
     % Step 6: Sending packet with same OUI
-    Packet0 = #packet_pb{oui=1},
+    Packet0 = blockchain_helium_packet_v1:new(1, <<"sup">>),
     ok = ct_rpc:call(GatewayNode1, blockchain_state_channels_client, packet, [Packet0]),
 
     % Step 7: Checking state channel on server/client (balance did not update but nonce did)
@@ -216,7 +215,7 @@ zero_test(Config) ->
 
      % Step 8: Sending packet with same OUI and a payload
     Payload1 = crypto:strong_rand_bytes(120),
-    Packet1 = #packet_pb{oui=1, payload=Payload1},
+    Packet1 = blockchain_helium_packet_v1:new(1, Payload1),
     ok = ct_rpc:call(GatewayNode1, blockchain_state_channels_client, packet, [Packet1]),
 
     % Step 9: Checking state channel on server/client (balance did not update but nonce did)
@@ -291,7 +290,7 @@ full_test(Config) ->
     % Step 5: Sending 1 packet
     ok = ct_rpc:call(RouterNode, blockchain_state_channels_server, packet_forward, [Self]),
     Payload0 = crypto:strong_rand_bytes(120),
-    Packet0 = #packet_pb{oui=1, payload=Payload0},
+    Packet0 = blockchain_helium_packet_v1:new(1, Payload0),
     ok = ct_rpc:call(GatewayNode1, blockchain_state_channels_client, packet, [Packet0]),
 
     % Step 6: Checking state channel on server/client
@@ -317,7 +316,7 @@ full_test(Config) ->
     % Step 5: Sending 1 packet
     ok = ct_rpc:call(RouterNode, blockchain_state_channels_server, packet_forward, [undefined]),
     Payload1 = crypto:strong_rand_bytes(120),
-    Packet1 = #packet_pb{oui=1, payload=Payload1},
+    Packet1 = blockchain_helium_packet_v1:new(1, Payload1),
     ok = ct_rpc:call(GatewayNode1, blockchain_state_channels_client, packet, [Packet1]),
 
     % Step 6: Checking state channel on server/client
@@ -408,7 +407,7 @@ expired_test(Config) ->
     % Step 5: Sending 1 packet
     ok = ct_rpc:call(RouterNode, blockchain_state_channels_server, packet_forward, [Self]),
     Payload0 = crypto:strong_rand_bytes(120),
-    Packet0 = #packet_pb{oui=1, payload=Payload0},
+    Packet0 = blockchain_helium_packet_v1:new(1, Payload0),
     ok = ct_rpc:call(GatewayNode1, blockchain_state_channels_client, packet, [Packet0]),
 
     % Step 6: Checking state channel on server/client
@@ -525,7 +524,7 @@ replay_test(Config) ->
     % Step 5: Sending 1 packet
     ok = ct_rpc:call(RouterNode, blockchain_state_channels_server, packet_forward, [Self]),
     Payload0 = crypto:strong_rand_bytes(120),
-    Packet0 = #packet_pb{oui=1, payload=Payload0},
+    Packet0 = blockchain_helium_packet_v1:new(1, Payload0),
     ok = ct_rpc:call(GatewayNode1, blockchain_state_channels_client, packet, [Packet0]),
 
     % Step 6: Checking state channel on server/client
@@ -551,7 +550,7 @@ replay_test(Config) ->
     % Step 5: Sending 1 packet
     ok = ct_rpc:call(RouterNode, blockchain_state_channels_server, packet_forward, [undefined]),
     Payload1 = crypto:strong_rand_bytes(120),
-    Packet1 = #packet_pb{oui=1, payload=Payload1},
+    Packet1 = blockchain_helium_packet_v1:new(1, Payload1),
     ok = ct_rpc:call(GatewayNode1, blockchain_state_channels_client, packet, [Packet1]),
 
     % Step 6: Checking state channel on server/client

--- a/test/blockchain_state_channel_SUITE.erl
+++ b/test/blockchain_state_channel_SUITE.erl
@@ -190,7 +190,7 @@ zero_test(Config) ->
     ?assertEqual(ID, blockchain_ledger_state_channel_v1:id(SC)),
     ?assertEqual(RouterPubkeyBin, blockchain_ledger_state_channel_v1:owner(SC)),
     ?assertEqual(0, blockchain_ledger_state_channel_v1:amount(SC)),
-    
+
     ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, credits, [ID])),
     ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])),
 
@@ -276,7 +276,7 @@ full_test(Config) ->
     ?assertEqual(ID, blockchain_ledger_state_channel_v1:id(SC)),
     ?assertEqual(RouterPubkeyBin, blockchain_ledger_state_channel_v1:owner(SC)),
     ?assertEqual(TotalDC, blockchain_ledger_state_channel_v1:amount(SC)),
-    
+
     ?assertEqual({ok, TotalDC}, ct_rpc:call(RouterNode, blockchain_state_channels_server, credits, [ID])),
     ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])),
 
@@ -393,7 +393,7 @@ expired_test(Config) ->
     ?assertEqual(ID, blockchain_ledger_state_channel_v1:id(SC)),
     ?assertEqual(RouterPubkeyBin, blockchain_ledger_state_channel_v1:owner(SC)),
     ?assertEqual(TotalDC, blockchain_ledger_state_channel_v1:amount(SC)),
-    
+
     ?assertEqual({ok, TotalDC}, ct_rpc:call(RouterNode, blockchain_state_channels_server, credits, [ID])),
     ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])),
 
@@ -435,7 +435,7 @@ expired_test(Config) ->
         C = ct_rpc:call(RouterNode, blockchain_worker, blockchain, []),
         {ok, 22} == ct_rpc:call(RouterNode, blockchain, height, [C])
     end, 30, timer:seconds(1)),
-   
+
     % Step 8: Adding close txn to blockchain
     receive
         {txn, Txn} ->
@@ -457,7 +457,7 @@ expired_test(Config) ->
 
     ok = ct_rpc:call(RouterNode, meck, unload, [blockchain_worker]),
     ok.
-       
+
 
 %% ------------------------------------------------------------------
 %% Helper functions

--- a/test/blockchain_state_channel_SUITE.erl
+++ b/test/blockchain_state_channel_SUITE.erl
@@ -9,6 +9,7 @@
     basic_test/1,
     zero_test/1,
     full_test/1,
+    replay_test/1,
     expired_test/1
 ]).
 
@@ -24,6 +25,7 @@ all() ->
         basic_test,
         zero_test,
         full_test,
+        replay_test,
         expired_test
     ].
 
@@ -160,7 +162,7 @@ zero_test(Config) ->
 
     % Step 2: Create state channel open zero txn
     ID = blockchain_state_channel_v1:zero_id(),
-    SCOpenTxn = blockchain_txn_state_channel_open_v1:new(ID, RouterPubkeyBin, 0, 100),
+    SCOpenTxn = blockchain_txn_state_channel_open_v1:new(ID, RouterPubkeyBin, 0, 100, 1),
     SignedSCOpenTxn = blockchain_txn_state_channel_open_v1:sign(SCOpenTxn, RouterSigFun),
 
     % Step 3: Create add gateway txn (making Gateqay node a gateway and router 1 its owner)
@@ -175,7 +177,10 @@ zero_test(Config) ->
     SignedUpdateGWOuiTxn1 = blockchain_txn_update_gateway_oui_v1:oui_owner_sign(SignedUpdateGWOuiTxn0, RouterSigFun),
 
     % Step 4: Adding block
-    Block0 = ct_rpc:call(RouterNode, test_utils, create_block, [ConsensusMembers, [SignedOUITxn, SignedSCOpenTxn, SignedAddGatewayTxn1, SignedUpdateGWOuiTxn1]]),
+    Block0 = ct_rpc:call(RouterNode,
+                         test_utils,
+                         create_block,
+                         [ConsensusMembers, [SignedOUITxn, SignedSCOpenTxn, SignedAddGatewayTxn1, SignedUpdateGWOuiTxn1]]),
     RouterChain = ct_rpc:call(RouterNode, blockchain_worker, blockchain, []),
     _ = ct_rpc:call(RouterNode, blockchain_gossip_handler, add_block, [RouterSwarm, Block0, RouterChain, self()]),
 
@@ -257,7 +262,7 @@ full_test(Config) ->
     % Step 2: Create state channel open txn
     TotalDC = 10,
     ID = crypto:strong_rand_bytes(32),
-    SCOpenTxn = blockchain_txn_state_channel_open_v1:new(ID, RouterPubkeyBin, TotalDC, 100),
+    SCOpenTxn = blockchain_txn_state_channel_open_v1:new(ID, RouterPubkeyBin, TotalDC, 100, 1),
     SignedSCOpenTxn = blockchain_txn_state_channel_open_v1:sign(SCOpenTxn, RouterSigFun),
     ct:pal("SignedSCOpenTxn: ~p", [SignedSCOpenTxn]),
 
@@ -377,7 +382,7 @@ expired_test(Config) ->
     % Step 2: Create state channel open txn
     TotalDC = 10,
     ID = crypto:strong_rand_bytes(32),
-    SCOpenTxn = blockchain_txn_state_channel_open_v1:new(ID, RouterPubkeyBin, TotalDC, 20),
+    SCOpenTxn = blockchain_txn_state_channel_open_v1:new(ID, RouterPubkeyBin, TotalDC, 20, 1),
     SignedSCOpenTxn = blockchain_txn_state_channel_open_v1:sign(SCOpenTxn, RouterSigFun),
 
     % Step 3: Adding block
@@ -461,6 +466,144 @@ expired_test(Config) ->
     ok = ct_rpc:call(RouterNode, meck, unload, [blockchain_worker]),
     ok.
 
+replay_test(Config) ->
+    [RouterNode, GatewayNode1|_] = proplists:get_value(nodes, Config, []),
+    ConsensusMembers = proplists:get_value(consensus_members, Config),
+
+    % Some madness to make submit txn work and "create a block"
+    Self = self(),
+    ok = ct_rpc:call(RouterNode, meck, new, [blockchain_worker, [passthrough]]),
+    timer:sleep(10),
+    ok = ct_rpc:call(RouterNode, meck, expect, [blockchain_worker, submit_txn, fun(T) ->
+        Self ! {txn, T},
+        ok
+    end]),
+    ok = ct_rpc:call(RouterNode, blockchain_worker, submit_txn, [test]),
+    receive
+        {txn, test} -> ok
+    after 1000 ->
+        ct:fail("txn test timeout")
+    end,
+
+    % Step 1: Create OUI txn
+    {ok, RouterPubkey, RouterSigFun, _} = ct_rpc:call(RouterNode, blockchain_swarm, keys, []),
+    RouterPubkeyBin = libp2p_crypto:pubkey_to_bin(RouterPubkey),
+    RouterSwarm = ct_rpc:call(RouterNode, blockchain_swarm, swarm, []),
+    RouterP2PAddress = ct_rpc:call(RouterNode, libp2p_swarm, p2p_address, [RouterSwarm]),
+    OUITxn = blockchain_txn_oui_v1:new(RouterPubkeyBin, [erlang:list_to_binary(RouterP2PAddress)], 1, 1, 0),
+    SignedOUITxn = blockchain_txn_oui_v1:sign(OUITxn, RouterSigFun),
+
+    % Step 2: Create state channel open txn
+    TotalDC = 10,
+    ID = crypto:strong_rand_bytes(32),
+    SCOpenTxn = blockchain_txn_state_channel_open_v1:new(ID, RouterPubkeyBin, TotalDC, 100, 1),
+    SignedSCOpenTxn = blockchain_txn_state_channel_open_v1:sign(SCOpenTxn, RouterSigFun),
+    ct:pal("SignedSCOpenTxn: ~p", [SignedSCOpenTxn]),
+
+    % Step 3: Adding block
+    RouterChain = ct_rpc:call(RouterNode, blockchain_worker, blockchain, []),
+    ct:pal("RouterChain: ~p", [RouterChain]),
+    Block0 = ct_rpc:call(RouterNode, test_utils, create_block, [ConsensusMembers, [SignedOUITxn, SignedSCOpenTxn]]),
+    ct:pal("Block0: ~p", [Block0]),
+    _ = ct_rpc:call(RouterNode, blockchain_gossip_handler, add_block, [RouterSwarm, Block0, RouterChain, Self]),
+
+    ok = blockchain_ct_utils:wait_until(fun() ->
+        C = ct_rpc:call(GatewayNode1, blockchain_worker, blockchain, []),
+        {ok, 2} == ct_rpc:call(GatewayNode1, blockchain, height, [C])
+    end, 30, timer:seconds(1)),
+
+    % Step 4: Checking that state channel got created properly
+    RouterLedger = blockchain:ledger(RouterChain),
+    {ok, SC} = ct_rpc:call(RouterNode, blockchain_ledger_v1, find_state_channel, [ID, RouterPubkeyBin, RouterLedger]),
+    ?assertEqual(ID, blockchain_ledger_state_channel_v1:id(SC)),
+    ?assertEqual(RouterPubkeyBin, blockchain_ledger_state_channel_v1:owner(SC)),
+    ?assertEqual(TotalDC, blockchain_ledger_state_channel_v1:amount(SC)),
+
+    ?assertEqual({ok, TotalDC}, ct_rpc:call(RouterNode, blockchain_state_channels_server, credits, [ID])),
+    ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])),
+
+    % Step 5: Sending 1 packet
+    ok = ct_rpc:call(RouterNode, blockchain_state_channels_server, packet_forward, [Self]),
+    Payload0 = crypto:strong_rand_bytes(120),
+    Packet0 = #packet_pb{oui=1, payload=Payload0},
+    ok = ct_rpc:call(GatewayNode1, blockchain_state_channels_client, packet, [Packet0]),
+
+    % Step 6: Checking state channel on server/client
+    ok = blockchain_ct_utils:wait_until(fun() ->
+        ct:pal("MARKER1 ~p", [ct_rpc:call(RouterNode, blockchain_state_channels_server, credits, [ID])]),
+        {ok, 5} == ct_rpc:call(RouterNode, blockchain_state_channels_server, credits, [ID]) andalso
+        {ok, 1} == ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])
+    end, 30, timer:seconds(1)),
+
+    ok = blockchain_ct_utils:wait_until(fun() ->
+        ct:pal("MARKER2 ~p", [ct_rpc:call(GatewayNode1, blockchain_state_channels_client, credits, [ID])]),
+        {ok, 5} == ct_rpc:call(GatewayNode1, blockchain_state_channels_client, credits, [ID])
+    end, 30, timer:seconds(1)),
+
+    % Step 7: Making sure packet got transmitted
+    receive
+        {packet, P0} ->
+            ?assertEqual(Packet0, P0)
+    after 10000 ->
+        ct:fail("packet timeout")
+    end,
+
+    % Step 5: Sending 1 packet
+    ok = ct_rpc:call(RouterNode, blockchain_state_channels_server, packet_forward, [undefined]),
+    Payload1 = crypto:strong_rand_bytes(120),
+    Packet1 = #packet_pb{oui=1, payload=Payload1},
+    ok = ct_rpc:call(GatewayNode1, blockchain_state_channels_client, packet, [Packet1]),
+
+    % Step 6: Checking state channel on server/client
+    ok = blockchain_ct_utils:wait_until(fun() ->
+        {ok, 0} == ct_rpc:call(RouterNode, blockchain_state_channels_server, credits, [ID]) andalso
+        {ok, 2} == ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])
+    end, 30, timer:seconds(1)),
+
+    ok = blockchain_ct_utils:wait_until(fun() ->
+        {ok, 0} == ct_rpc:call(GatewayNode1, blockchain_state_channels_client, credits, [ID])
+    end, 30, timer:seconds(1)),
+
+    % Step 8: Adding close txn to blockchain
+    receive
+        {txn, Txn} ->
+            Block1 = ct_rpc:call(RouterNode, test_utils, create_block, [ConsensusMembers, [Txn]]),
+            _ = ct_rpc:call(RouterNode, blockchain_gossip_handler, add_block, [RouterSwarm, Block1, RouterChain, Self])
+    after 10000 ->
+        ct:fail("txn timeout")
+    end,
+
+    % Step 9: Waiting for close txn to be mine
+    ok = blockchain_ct_utils:wait_until(fun() ->
+        C = ct_rpc:call(RouterNode, blockchain_worker, blockchain, []),
+        {ok, 3} == ct_rpc:call(RouterNode, blockchain, height, [C])
+    end, 30, timer:seconds(1)),
+
+    ok = blockchain_ct_utils:wait_until(fun() ->
+        {error, not_found} == ct_rpc:call(RouterNode, blockchain_state_channels_server, credits, [ID])
+    end, 30, timer:seconds(1)),
+
+    % Step 10: Recreating the state channel open txn with the same nonce
+    RouterChain2 = ct_rpc:call(RouterNode, blockchain_worker, blockchain, []),
+    RouterLedger2 = blockchain:ledger(RouterChain2),
+
+    ct:pal("DCEntry: ~p", [ct_rpc:call(RouterNode, blockchain_ledger_v1, find_dc_entry, [RouterPubkeyBin, RouterLedger2])]),
+
+    ReplayTotalDC = 20,
+    ReplayID = crypto:strong_rand_bytes(32),
+    ReplaySCOpenTxn = blockchain_txn_state_channel_open_v1:new(ReplayID, RouterPubkeyBin, ReplayTotalDC, 100, 1),
+    ReplaySignedSCOpenTxn = blockchain_txn_state_channel_open_v1:sign(ReplaySCOpenTxn, RouterSigFun),
+    ct:pal("ReplaySignedSCOpenTxn: ~p", [ReplaySignedSCOpenTxn]),
+    ReplayIsValid = ct_rpc:call(RouterNode,
+                                blockchain_txn_state_channel_open_v1,
+                                is_valid,
+                                [ReplaySignedSCOpenTxn, RouterChain2]),
+
+    %% Step 11: check whether the replay sc open txn is valid?
+    ?assertEqual({error, {bad_nonce, {state_channel_open, 1, 2}}}, ReplayIsValid),
+
+    ok = ct_rpc:call(RouterNode, meck, unload, [blockchain_worker]),
+    ok.
 
 %% ------------------------------------------------------------------
 %% Helper functions


### PR DESCRIPTION
The existing blockchain_state_channels_client gen_statem design is unnecessarily convoluted when in doesn't need to be and can be accomplished with a gen_server behavior. We have already had some nasty issues with the `miner_poc_statem` in the past, just trying to avoid that here.

It's possible that there are timing concerns with the gen_server as well, but those can be mostly sorted out I believe. And if necessary we can back it up with an ets.

Furthermore, `blockchain_txn_state_channels_open_v1` transactions don't have a nonce associated allowing a replay attack, I've added support for that as well here. The nonce which gets incremented is still the nonce from the `data_credits_entry_v1` ledger entry.

Also included here are a few other bug fixes:
- Fetching state channels from ledger in the state_channel_server
- Closing state channel directly instead of sending self msgs