### PR TITLE
Add payment_v2 transactions

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -236,3 +236,10 @@
 %% Maximum allowed h3 grid cells for a potential next hop
 -define(poc_max_hop_cells, poc_max_hop_cells).
 %% ------------------------------------------------------------------
+%%
+%%
+%% ------------------------------------------------------------------
+%% Txn Payment V2 vars
+%%
+%% Max payments allowed within a single payment_v2 transaction
+-define(max_payments, max_payments).

--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,7 @@
     {erlang_stats, ".*", {git, "https://github.com/helium/erlang-stats.git", {branch, "master"}}},
     {e2qc, ".*", {git, "https://github.com/project-fifo/e2qc", {branch, "master"}}},
     {vincenty, ".*", {git, "https://github.com/helium/vincenty", {branch, "master"}}},
-    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "master"}}}
+    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "rg/multi-payouts"}}}
 ]}.
 
 {erl_opts, [

--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,7 @@
     {erlang_stats, ".*", {git, "https://github.com/helium/erlang-stats.git", {branch, "master"}}},
     {e2qc, ".*", {git, "https://github.com/project-fifo/e2qc", {branch, "master"}}},
     {vincenty, ".*", {git, "https://github.com/helium/vincenty", {branch, "master"}}},
-    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "rg/multi-payouts"}}}
+    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "master"}}}
 ]}.
 
 {erl_opts, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -33,7 +33,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"0aea6a9e9016ffb8089ac4f49947136f2255f4c9"}},
+       {ref,"135132a454b91548ead7adbf7500c20c5b3957d2"}},
   0},
  {<<"inert">>,
   {git,"https://github.com/msantos/inert",

--- a/rebar.lock
+++ b/rebar.lock
@@ -33,7 +33,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"135132a454b91548ead7adbf7500c20c5b3957d2"}},
+       {ref,"004c16dfa7f0b0754053c6616d265ed8398e12bf"}},
   0},
  {<<"inert">>,
   {git,"https://github.com/msantos/inert",

--- a/rebar.lock
+++ b/rebar.lock
@@ -33,7 +33,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"004c16dfa7f0b0754053c6616d265ed8398e12bf"}},
+       {ref,"dd7a6af7cef23db24982b34cd4e05d9b26ec20d0"}},
   0},
  {<<"inert">>,
   {git,"https://github.com/msantos/inert",

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -734,6 +734,10 @@ validate_var(?reward_version, Value) ->
 validate_var(?max_bundle_size, Value) ->
     validate_int(Value, "max_bundle_size", 5, 100, false);
 
+%% txn payment_v2 vars
+validate_var(?max_payments, Value) ->
+    validate_int(Value, "max_payments", 5, 50, false);
+
 validate_var(Var, Value) ->
     %% something we don't understand, crash
     invalid_var(Var, Value).

--- a/src/transactions/v2/blockchain_payment_v2.erl
+++ b/src/transactions/v2/blockchain_payment_v2.erl
@@ -1,0 +1,64 @@
+%%%-------------------------------------------------------------------
+%% @doc
+%% == Blockchain Payment V2 ==
+%%%-------------------------------------------------------------------
+-module(blockchain_payment_v2).
+
+-include("blockchain_utils.hrl").
+-include_lib("helium_proto/include/blockchain_txn_payment_v2_pb.hrl").
+
+-export([
+         new/2,
+         payee/1,
+         amount/1,
+         print/1
+        ]).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-type payment() :: #payment_pb{}.
+-type payments() :: [payment()].
+
+-export_type([payment/0, payments/0]).
+
+-spec new(Payee :: libp2p_crypto:pubkey_bin(),
+          Amount :: non_neg_integer()) -> payment().
+new(Payee, Amount) when Amount > 0 ->
+    #payment_pb{
+       payee=Payee,
+       amount=Amount
+      }.
+
+-spec payee(Payment :: payment()) -> libp2p_crypto:pubkey_bin().
+payee(Payment) ->
+    Payment#payment_pb.payee.
+
+-spec amount(Payment :: payment()) -> non_neg_integer().
+amount(Payment) ->
+    Payment#payment_pb.amount.
+
+print(undefined) ->
+    <<"type=payment undefined">>;
+print(#payment_pb{payee=Payee, amount=Amount}) ->
+    io_lib:format("type=payment payee: ~p amount: ~p", [?TO_B58(Payee), Amount]).
+
+%% ------------------------------------------------------------------
+%% EUNIT Tests
+%% ------------------------------------------------------------------
+-ifdef(TEST).
+
+new_test() ->
+    Payment = #payment_pb{payee= <<"payee">>, amount= 100},
+    ?assertEqual(Payment, new(<<"payee">>, 100)).
+
+payee_test() ->
+    Payment = new(<<"payee">>, 100),
+    ?assertEqual(<<"payee">>, ?MODULE:payee(Payment)).
+
+amount_test() ->
+    Payment = new(<<"payee">>, 100),
+    ?assertEqual(100, ?MODULE:amount(Payment)).
+
+-endif.

--- a/src/transactions/v2/blockchain_txn_payment_v2.erl
+++ b/src/transactions/v2/blockchain_txn_payment_v2.erl
@@ -198,7 +198,7 @@ do_is_valid_checks(Txn, Ledger, MaxPayments) ->
                                             end
                                     end;
                                 true ->
-                                    {error, invalid_transaction_self_payment_v2}
+                                    {error, self_payment}
                             end
                     end
             end

--- a/src/transactions/v2/blockchain_txn_payment_v2.erl
+++ b/src/transactions/v2/blockchain_txn_payment_v2.erl
@@ -175,7 +175,7 @@ do_is_valid_checks(Txn, Ledger, MaxPayments) ->
                     case LengthPayments > MaxPayments of
                         %% Check that we don't exceed max payments
                         true ->
-                            {error, {exceeded_max_payouts, LengthPayments, MaxPayments}};
+                            {error, {exceeded_max_payments, LengthPayments, MaxPayments}};
                         false ->
                             case lists:member(Payer, ?MODULE:payees(Txn)) of
                                 false ->

--- a/src/transactions/v2/blockchain_txn_payment_v2.erl
+++ b/src/transactions/v2/blockchain_txn_payment_v2.erl
@@ -1,0 +1,296 @@
+%%%-------------------------------------------------------------------
+%% @doc
+%% == Blockchain Transaction Payment V2 ==
+%%
+%% Support payer_A -> [payee_X, payee_Y, payee_Z...] transactions
+%%
+%% @end
+%%%-------------------------------------------------------------------
+-module(blockchain_txn_payment_v2).
+
+-behavior(blockchain_txn).
+
+-include("blockchain_utils.hrl").
+-include("blockchain_vars.hrl").
+-include_lib("helium_proto/include/blockchain_txn_payment_v2_pb.hrl").
+
+-export([
+         new/4,
+         hash/1,
+         payer/1,
+         payments/1,
+         payees/1,
+         amounts/1,
+         total_amount/1,
+         fee/1,
+         nonce/1,
+         signature/1,
+         sign/2,
+         is_valid/2,
+         absorb/2,
+         print/1
+        ]).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-type txn_payment_v2() :: #blockchain_txn_payment_v2_pb{}.
+
+-export_type([txn_payment_v2/0]).
+
+-spec new(Payer :: libp2p_crypto:pubkey_bin(),
+          Payments :: blockchain_payment_v2:payments(),
+          Nonce :: non_neg_integer(),
+          Fee :: non_neg_integer()) -> txn_payment_v2().
+new(Payer, Payments, Nonce, Fee) ->
+    #blockchain_txn_payment_v2_pb{
+       payer=Payer,
+       payments=Payments,
+       nonce=Nonce,
+       fee=Fee,
+       signature = <<>>
+      }.
+
+-spec hash(txn_payment_v2()) -> blockchain_txn:hash().
+hash(Txn) ->
+    BaseTxn = Txn#blockchain_txn_payment_v2_pb{signature = <<>>},
+    EncodedTxn = blockchain_txn_payment_v2_pb:encode_msg(BaseTxn),
+    crypto:hash(sha256, EncodedTxn).
+
+-spec payer(txn_payment_v2()) -> libp2p_crypto:pubkey_bin().
+payer(Txn) ->
+    Txn#blockchain_txn_payment_v2_pb.payer.
+
+-spec payments(txn_payment_v2()) -> blockchain_payment_v2:payments().
+payments(Txn) ->
+    Txn#blockchain_txn_payment_v2_pb.payments.
+
+-spec payees(txn_payment_v2()) -> [libp2p_crypto:pubkey_bin()].
+payees(Txn) ->
+    [blockchain_payment_v2:payee(Payment) || Payment <- ?MODULE:payments(Txn)].
+
+-spec amounts(txn_payment_v2()) -> [pos_integer()].
+amounts(Txn) ->
+    [blockchain_payment_v2:amount(Payment) || Payment <- ?MODULE:payments(Txn)].
+
+-spec total_amount(txn_payment_v2()) -> pos_integer().
+total_amount(Txn) ->
+    lists:sum(?MODULE:amounts(Txn)).
+
+-spec fee(txn_payment_v2()) -> non_neg_integer().
+fee(Txn) ->
+    Txn#blockchain_txn_payment_v2_pb.fee.
+
+-spec nonce(txn_payment_v2()) -> non_neg_integer().
+nonce(Txn) ->
+    Txn#blockchain_txn_payment_v2_pb.nonce.
+
+-spec signature(txn_payment_v2()) -> binary().
+signature(Txn) ->
+    Txn#blockchain_txn_payment_v2_pb.signature.
+
+-spec sign(txn_payment_v2(), libp2p_crypto:sig_fun()) -> txn_payment_v2().
+sign(Txn, SigFun) ->
+    EncodedTxn = blockchain_txn_payment_v2_pb:encode_msg(Txn),
+    Txn#blockchain_txn_payment_v2_pb{signature=SigFun(EncodedTxn)}.
+
+-spec is_valid(txn_payment_v2(), blockchain:blockchain()) -> ok | {error, any()}.
+is_valid(Txn, Chain) ->
+    Ledger = blockchain:ledger(Chain),
+    case blockchain:config(?max_payments, Ledger) of
+        {ok, M} when is_integer(M) ->
+            do_is_valid_checks(Txn, Ledger, M);
+        _ ->
+            {error, {invalid, max_payments_not_set}}
+    end.
+
+
+-spec absorb(txn_payment_v2(), blockchain:blockchain()) -> ok | {error, any()}.
+absorb(Txn, Chain) ->
+    Ledger = blockchain:ledger(Chain),
+    TotAmount = ?MODULE:total_amount(Txn),
+    Fee = ?MODULE:fee(Txn),
+    Payer = ?MODULE:payer(Txn),
+    Nonce = ?MODULE:nonce(Txn),
+
+    case blockchain_ledger_v1:debit_fee(Payer, Fee, Ledger) of
+        {error, _Reason}=Error ->
+            Error;
+        ok ->
+            case blockchain_ledger_v1:debit_account(Payer, TotAmount, Nonce, Ledger) of
+                {error, _Reason}=Error ->
+                    Error;
+                ok ->
+                    Payments = ?MODULE:payments(Txn),
+                    ok = lists:foreach(fun(Payment) ->
+                                               PayeePubkeyBin = blockchain_payment_v2:payee(Payment),
+                                               PayeeAmount = blockchain_payment_v2:amount(Payment),
+                                               blockchain_ledger_v1:credit_account(PayeePubkeyBin, PayeeAmount, Ledger)
+                                       end, Payments)
+            end
+    end.
+
+-spec print(txn_payment_v2()) -> iodata().
+print(undefined) -> <<"type=payment_v2, undefined">>;
+print(#blockchain_txn_payment_v2_pb{payer=Payer,
+                                    fee=Fee,
+                                    payments=Payments,
+                                    nonce=Nonce,
+                                    signature = S}=Txn) ->
+    io_lib:format("type=payment_v2, payer=~p, total_amount: ~p, fee=~p, nonce=~p, signature=~s~n payments: ~s",
+                  [?TO_B58(Payer), ?MODULE:total_amount(Txn), Fee, Nonce, ?TO_B58(S), print_payments(Payments)]).
+
+print_payments(Payments) ->
+    string:join(lists:map(fun(Payment) ->
+                                  blockchain_payment_v2:print(Payment)
+                          end,
+                          Payments), "\n\t").
+
+
+%% ------------------------------------------------------------------
+%% Internal Functions
+%% ------------------------------------------------------------------
+-spec do_is_valid_checks(Txn :: txn_payment_v2(),
+                         Ledger :: blockchain_ledger_v1:ledger(),
+                         MaxPayments :: pos_integer()) -> ok | {error, any()}.
+do_is_valid_checks(Txn, Ledger, MaxPayments) ->
+    Payer = ?MODULE:payer(Txn),
+    Signature = ?MODULE:signature(Txn),
+    Payments = ?MODULE:payments(Txn),
+    PubKey = libp2p_crypto:bin_to_pubkey(Payer),
+    BaseTxn = Txn#blockchain_txn_payment_v2_pb{signature = <<>>},
+    EncodedTxn = blockchain_txn_payment_v2_pb:encode_msg(BaseTxn),
+
+    case libp2p_crypto:verify(EncodedTxn, Signature, PubKey) of
+        false ->
+            {error, bad_signature};
+        true ->
+            LengthPayments = length(Payments),
+            case LengthPayments == 0 of
+                true ->
+                    %% Check that there are payments
+                    {error, zero_payees};
+                false ->
+                    case LengthPayments > MaxPayments of
+                        %% Check that we don't exceed max payments
+                        true ->
+                            {error, {exceeded_max_payouts, LengthPayments, MaxPayments}};
+                        false ->
+                            case lists:member(Payer, ?MODULE:payees(Txn)) of
+                                false ->
+                                    TotAmount = ?MODULE:total_amount(Txn),
+                                    Fee = ?MODULE:fee(Txn),
+                                    case blockchain_ledger_v1:transaction_fee(Ledger) of
+                                        {error, _}=Error0 ->
+                                            Error0;
+                                        {ok, MinerFee} ->
+                                            case (TotAmount >= 0) andalso (Fee >= MinerFee) of
+                                                false ->
+                                                    {error, invalid_transaction};
+                                                true ->
+                                                    case blockchain_ledger_v1:check_dc_balance(Payer, Fee, Ledger) of
+                                                        {error, _}=Error1 ->
+                                                            Error1;
+                                                        ok ->
+                                                            blockchain_ledger_v1:check_balance(Payer, TotAmount, Ledger)
+                                                    end
+                                            end
+                                    end;
+                                true ->
+                                    {error, invalid_transaction_self_payment_v2}
+                            end
+                    end
+            end
+    end.
+
+
+%% ------------------------------------------------------------------
+%% EUNIT Tests
+%% ------------------------------------------------------------------
+-ifdef(TEST).
+
+new_test() ->
+    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
+                blockchain_payment_v2:new(<<"y">>, 20),
+                blockchain_payment_v2:new(<<"z">>, 30)],
+
+    Tx = #blockchain_txn_payment_v2_pb{
+            payer= <<"payer">>,
+            payments=Payments,
+            fee=10,
+            nonce=1,
+            signature = <<>>
+           },
+    New = new(<<"payer">>, Payments, 1, 10),
+    ?assertEqual(Tx, New).
+
+payer_test() ->
+    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
+                blockchain_payment_v2:new(<<"y">>, 20),
+                blockchain_payment_v2:new(<<"z">>, 30)],
+    Tx = new(<<"payer">>, Payments, 1, 10),
+    ?assertEqual(<<"payer">>, payer(Tx)).
+
+payments_test() ->
+    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
+                blockchain_payment_v2:new(<<"y">>, 20),
+                blockchain_payment_v2:new(<<"z">>, 30)],
+    Tx = new(<<"payer">>, Payments, 1, 10),
+    ?assertEqual(Payments, ?MODULE:payments(Tx)).
+
+payees_test() ->
+    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
+                blockchain_payment_v2:new(<<"y">>, 20),
+                blockchain_payment_v2:new(<<"z">>, 30)],
+    Tx = new(<<"payer">>, Payments, 1, 10),
+    ?assertEqual([<<"x">>, <<"y">>, <<"z">>], ?MODULE:payees(Tx)).
+
+amounts_test() ->
+    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
+                blockchain_payment_v2:new(<<"y">>, 20),
+                blockchain_payment_v2:new(<<"z">>, 30)],
+    Tx = new(<<"payer">>, Payments, 1, 10),
+    ?assertEqual([10, 20, 30], ?MODULE:amounts(Tx)).
+
+total_amount_test() ->
+    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
+                blockchain_payment_v2:new(<<"y">>, 20),
+                blockchain_payment_v2:new(<<"z">>, 30)],
+    Tx = new(<<"payer">>, Payments, 1, 10),
+    ?assertEqual(60, total_amount(Tx)).
+
+fee_test() ->
+    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
+                blockchain_payment_v2:new(<<"y">>, 20),
+                blockchain_payment_v2:new(<<"z">>, 30)],
+    Tx = new(<<"payer">>, Payments, 1, 10),
+    ?assertEqual(10, fee(Tx)).
+
+nonce_test() ->
+    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
+                blockchain_payment_v2:new(<<"y">>, 20),
+                blockchain_payment_v2:new(<<"z">>, 30)],
+    Tx = new(<<"payer">>, Payments, 1, 10),
+    ?assertEqual(1, nonce(Tx)).
+
+signature_test() ->
+    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
+                blockchain_payment_v2:new(<<"y">>, 20),
+                blockchain_payment_v2:new(<<"z">>, 30)],
+    Tx = new(<<"payer">>, Payments, 1, 10),
+    ?assertEqual(<<>>, signature(Tx)).
+
+sign_test() ->
+    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
+                blockchain_payment_v2:new(<<"y">>, 20),
+                blockchain_payment_v2:new(<<"z">>, 30)],
+    #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
+    Tx0 = new(<<"payer">>, Payments, 1, 10),
+    SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
+    Tx1 = sign(Tx0, SigFun),
+    Sig1 = signature(Tx1),
+    EncodedTx1 = blockchain_txn_payment_v2_pb:encode_msg(Tx1#blockchain_txn_payment_v2_pb{signature = <<>>}),
+    ?assert(libp2p_crypto:verify(EncodedTx1, Sig1, PubKey)).
+
+-endif.

--- a/test/blockchain_payment_v2_SUITE.erl
+++ b/test/blockchain_payment_v2_SUITE.erl
@@ -137,10 +137,10 @@ single_payee_test(Config) ->
 same_payees_test(Config) ->
     BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
-    Balance = ?config(balance, Config),
+    _Balance = ?config(balance, Config),
     BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
+    _Swarm = ?config(swarm, Config),
 
     %% Test a payment transaction, add a block and check balances
     [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
@@ -156,23 +156,7 @@ same_payees_test(Config) ->
     SignedTx = blockchain_txn_payment_v2:sign(Tx, SigFun),
 
     ct:pal("~s", [blockchain_txn:print(SignedTx)]),
-
-    Block = test_utils:create_block(ConsensusMembers, [SignedTx]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
-
-    ?assertEqual({ok, blockchain_block:hash_block(Block)}, blockchain:head_hash(Chain)),
-    ?assertEqual({ok, Block}, blockchain:head_block(Chain)),
-    ?assertEqual({ok, 2}, blockchain:height(Chain)),
-
-    ?assertEqual({ok, Block}, blockchain:get_block(2, Chain)),
-
-    Ledger = blockchain:ledger(Chain),
-
-    {ok, NewEntry0} = blockchain_ledger_v1:find_entry(Recipient, Ledger),
-    ?assertEqual(Balance + 2*Amount, blockchain_ledger_entry_v1:balance(NewEntry0)),
-
-    {ok, NewEntry1} = blockchain_ledger_v1:find_entry(Payer, Ledger),
-    ?assertEqual(Balance - 2*Amount, blockchain_ledger_entry_v1:balance(NewEntry1)),
+    ?assertEqual({error, duplicate_payees}, blockchain_txn_payment_v2:is_valid(SignedTx, Chain)),
     ok.
 
 different_payees_test(Config) ->

--- a/test/blockchain_payment_v2_SUITE.erl
+++ b/test/blockchain_payment_v2_SUITE.erl
@@ -1,0 +1,287 @@
+-module(blockchain_payment_v2_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include("blockchain_vars.hrl").
+
+-export([all/0, init_per_testcase/2, end_per_testcase/2]).
+
+-export([
+         single_payee_test/1,
+         same_payees_test/1,
+         different_payees_test/1,
+         empty_payees_test/1,
+         zero_payment_test/1,
+         negative_payment_test/1
+        ]).
+
+all() ->
+    [
+     single_payee_test,
+     same_payees_test,
+     different_payees_test,
+     empty_payees_test,
+     zero_payment_test,
+     negative_payment_test
+    ].
+
+%%--------------------------------------------------------------------
+%% TEST CASE SETUP
+%%--------------------------------------------------------------------
+
+init_per_testcase(TestCase, Config) ->
+    Config0 = blockchain_ct_utils:init_base_dir_config(?MODULE, TestCase, Config),
+    Balance = 5000,
+    {ok, Sup, {PrivKey, PubKey}, Opts} = test_utils:init(?config(base_dir, Config0)),
+
+    ExtraVars = #{?max_payments => 20},
+
+    {ok, GenesisMembers, ConsensusMembers, Keys} = test_utils:init_chain(Balance, {PrivKey, PubKey}, true, ExtraVars),
+
+    Chain = blockchain_worker:blockchain(),
+    Swarm = blockchain_swarm:swarm(),
+    N = length(ConsensusMembers),
+
+    % Check ledger to make sure everyone has the right balance
+    Ledger = blockchain:ledger(Chain),
+    Entries = blockchain_ledger_v1:entries(Ledger),
+    _ = lists:foreach(fun(Entry) ->
+                              Balance = blockchain_ledger_entry_v1:balance(Entry),
+                              0 = blockchain_ledger_entry_v1:nonce(Entry)
+                      end, maps:values(Entries)),
+
+    [
+     {balance, Balance},
+     {sup, Sup},
+     {pubkey, PubKey},
+     {privkey, PrivKey},
+     {opts, Opts},
+     {chain, Chain},
+     {swarm, Swarm},
+     {n, N},
+     {consensus_members, ConsensusMembers},
+     {genesis_members, GenesisMembers},
+     Keys
+     | Config0
+    ].
+
+%%--------------------------------------------------------------------
+%% TEST CASE TEARDOWN
+%%--------------------------------------------------------------------
+
+end_per_testcase(_, Config) ->
+    Sup = ?config(sup, Config),
+    % Make sure blockchain saved on file = in memory
+    case erlang:is_process_alive(Sup) of
+        true ->
+            true = erlang:exit(Sup, normal),
+            ok = test_utils:wait_until(fun() -> false =:= erlang:is_process_alive(Sup) end);
+        false ->
+            ok
+    end,
+    ok.
+
+%%--------------------------------------------------------------------
+%% TEST CASES
+%%--------------------------------------------------------------------
+
+single_payee_test(Config) ->
+    BaseDir = ?config(base_dir, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    Balance = ?config(balance, Config),
+    BaseDir = ?config(base_dir, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
+
+    %% Test a payment transaction, add a block and check balances
+    [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
+
+    %% Create a payment to a single payee
+    Recipient = blockchain_swarm:pubkey_bin(),
+    Amount = 2500,
+    Payment1 = blockchain_payment_v2:new(Recipient, Amount),
+
+    Tx = blockchain_txn_payment_v2:new(Payer, [Payment1], 1, 0),
+    SigFun = libp2p_crypto:mk_sig_fun(PayerPrivKey),
+    SignedTx = blockchain_txn_payment_v2:sign(Tx, SigFun),
+
+    ct:pal("~s", [blockchain_txn:print(SignedTx)]),
+
+    Block = test_utils:create_block(ConsensusMembers, [SignedTx]),
+    _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+
+    ?assertEqual({ok, blockchain_block:hash_block(Block)}, blockchain:head_hash(Chain)),
+    ?assertEqual({ok, Block}, blockchain:head_block(Chain)),
+    ?assertEqual({ok, 2}, blockchain:height(Chain)),
+
+    ?assertEqual({ok, Block}, blockchain:get_block(2, Chain)),
+
+    Ledger = blockchain:ledger(Chain),
+
+
+    {ok, NewEntry0} = blockchain_ledger_v1:find_entry(Recipient, Ledger),
+    ?assertEqual(Balance + Amount, blockchain_ledger_entry_v1:balance(NewEntry0)),
+
+    {ok, NewEntry1} = blockchain_ledger_v1:find_entry(Payer, Ledger),
+    ?assertEqual(Balance - Amount, blockchain_ledger_entry_v1:balance(NewEntry1)),
+    ok.
+
+same_payees_test(Config) ->
+    BaseDir = ?config(base_dir, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    Balance = ?config(balance, Config),
+    BaseDir = ?config(base_dir, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
+
+    %% Test a payment transaction, add a block and check balances
+    [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
+
+    %% Create a payment to a single payee TWICE
+    Recipient = blockchain_swarm:pubkey_bin(),
+    Amount = 1000,
+    Payment1 = blockchain_payment_v2:new(Recipient, Amount),
+    Payment2 = blockchain_payment_v2:new(Recipient, Amount),
+
+    Tx = blockchain_txn_payment_v2:new(Payer, [Payment1, Payment2], 1, 0),
+    SigFun = libp2p_crypto:mk_sig_fun(PayerPrivKey),
+    SignedTx = blockchain_txn_payment_v2:sign(Tx, SigFun),
+
+    ct:pal("~s", [blockchain_txn:print(SignedTx)]),
+
+    Block = test_utils:create_block(ConsensusMembers, [SignedTx]),
+    _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+
+    ?assertEqual({ok, blockchain_block:hash_block(Block)}, blockchain:head_hash(Chain)),
+    ?assertEqual({ok, Block}, blockchain:head_block(Chain)),
+    ?assertEqual({ok, 2}, blockchain:height(Chain)),
+
+    ?assertEqual({ok, Block}, blockchain:get_block(2, Chain)),
+
+    Ledger = blockchain:ledger(Chain),
+
+    {ok, NewEntry0} = blockchain_ledger_v1:find_entry(Recipient, Ledger),
+    ?assertEqual(Balance + 2*Amount, blockchain_ledger_entry_v1:balance(NewEntry0)),
+
+    {ok, NewEntry1} = blockchain_ledger_v1:find_entry(Payer, Ledger),
+    ?assertEqual(Balance - 2*Amount, blockchain_ledger_entry_v1:balance(NewEntry1)),
+    ok.
+
+different_payees_test(Config) ->
+    BaseDir = ?config(base_dir, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    Balance = ?config(balance, Config),
+    BaseDir = ?config(base_dir, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
+
+    %% Test a payment transaction, add a block and check balances
+    [_, {Payer, {_, PayerPrivKey, _}}, {Recipient2, _} |_] = ConsensusMembers,
+
+    %% Create a payment to a payee1
+    Recipient1 = blockchain_swarm:pubkey_bin(),
+    Amount1 = 1000,
+    Payment1 = blockchain_payment_v2:new(Recipient1, Amount1),
+
+    %% Create a payment to the other payee2
+    Amount2 = 2000,
+    Payment2 = blockchain_payment_v2:new(Recipient2, Amount2),
+
+    Tx = blockchain_txn_payment_v2:new(Payer, [Payment1, Payment2], 1, 0),
+    SigFun = libp2p_crypto:mk_sig_fun(PayerPrivKey),
+    SignedTx = blockchain_txn_payment_v2:sign(Tx, SigFun),
+
+    ct:pal("~s", [blockchain_txn:print(SignedTx)]),
+
+    Block = test_utils:create_block(ConsensusMembers, [SignedTx]),
+    _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+
+    ?assertEqual({ok, blockchain_block:hash_block(Block)}, blockchain:head_hash(Chain)),
+    ?assertEqual({ok, Block}, blockchain:head_block(Chain)),
+    ?assertEqual({ok, 2}, blockchain:height(Chain)),
+
+    ?assertEqual({ok, Block}, blockchain:get_block(2, Chain)),
+
+    Ledger = blockchain:ledger(Chain),
+
+    {ok, NewEntry1} = blockchain_ledger_v1:find_entry(Recipient1, Ledger),
+    ?assertEqual(Balance + Amount1, blockchain_ledger_entry_v1:balance(NewEntry1)),
+
+    {ok, NewEntry2} = blockchain_ledger_v1:find_entry(Recipient2, Ledger),
+    ?assertEqual(Balance + Amount2, blockchain_ledger_entry_v1:balance(NewEntry2)),
+
+    {ok, NewEntry0} = blockchain_ledger_v1:find_entry(Payer, Ledger),
+    ?assertEqual(Balance - Amount1 - Amount2, blockchain_ledger_entry_v1:balance(NewEntry0)),
+    ok.
+
+empty_payees_test(Config) ->
+    BaseDir = ?config(base_dir, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    Balance = ?config(balance, Config),
+    BaseDir = ?config(base_dir, Config),
+    Chain = ?config(chain, Config),
+    Swarm = ?config(swarm, Config),
+
+    %% Test a payment transaction, add a block and check balances
+    [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
+
+    Tx = blockchain_txn_payment_v2:new(Payer, [], 1, 0),
+    SigFun = libp2p_crypto:mk_sig_fun(PayerPrivKey),
+    SignedTx = blockchain_txn_payment_v2:sign(Tx, SigFun),
+
+    ct:pal("~s", [blockchain_txn:print(SignedTx)]),
+    ?assertEqual({error, zero_payees}, blockchain_txn_payment_v2:is_valid(SignedTx, Chain)),
+
+    Block = test_utils:create_block(ConsensusMembers, [SignedTx]),
+    _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+
+    ?assertEqual({ok, blockchain_block:hash_block(Block)}, blockchain:head_hash(Chain)),
+    ?assertEqual({ok, Block}, blockchain:head_block(Chain)),
+    ?assertEqual({ok, 2}, blockchain:height(Chain)),
+
+    ?assertEqual({ok, Block}, blockchain:get_block(2, Chain)),
+
+    Ledger = blockchain:ledger(Chain),
+
+    %% Payer balance must not be deducted
+    {ok, NewEntry1} = blockchain_ledger_v1:find_entry(Payer, Ledger),
+    ?assertEqual(Balance, blockchain_ledger_entry_v1:balance(NewEntry1)),
+    ok.
+
+zero_payment_test(Config) ->
+    BaseDir = ?config(base_dir, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    BaseDir = ?config(base_dir, Config),
+
+    %% Test a payment transaction, add a block and check balances
+    [_, {_Payer, {_, _PayerPrivKey, _}}, {Recipient2, _} |_] = ConsensusMembers,
+
+    %% Create a payment to a payee1
+    Recipient1 = blockchain_swarm:pubkey_bin(),
+    Amount1 = 1000,
+    _Payment1 = blockchain_payment_v2:new(Recipient1, Amount1),
+
+    %% Create a payment to the other payee2. This should blow up.
+    Amount2 = 0,
+
+    ?assertException(error, function_clause, blockchain_payment_v2:new(Recipient2, Amount2)),
+    ok.
+
+negative_payment_test(Config) ->
+    BaseDir = ?config(base_dir, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+    BaseDir = ?config(base_dir, Config),
+
+    %% Test a payment transaction, add a block and check balances
+    [_, {_Payer, {_, _PayerPrivKey, _}}, {Recipient2, _} |_] = ConsensusMembers,
+
+    %% Create a payment to a payee1
+    Recipient1 = blockchain_swarm:pubkey_bin(),
+    Amount1 = 1000,
+    _Payment1 = blockchain_payment_v2:new(Recipient1, Amount1),
+
+    %% Create a payment to the other payee2. This should also blow up.
+    Amount2 = -100,
+
+    ?assertException(error, function_clause, blockchain_payment_v2:new(Recipient2, Amount2)),
+    ok.

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -5,7 +5,8 @@
 -include("blockchain_vars.hrl").
 
 -export([
-    init/1, init_chain/2, init_chain/3,
+    init/1,
+    init_chain/2, init_chain/3, init_chain/4,
     generate_keys/1, generate_keys/2,
     wait_until/1, wait_until/3,
     create_block/2,
@@ -35,9 +36,12 @@ init(BaseDir) ->
     {ok, Sup, {PrivKey, PubKey}, Opts}.
 
 init_chain(Balance, Keys) ->
-    init_chain(Balance, Keys, true).
+    init_chain(Balance, Keys, true, #{}).
 
-init_chain(Balance, {PrivKey, PubKey}, InConsensus) ->
+init_chain(Balance, Keys, InConsensus) ->
+    init_chain(Balance, Keys, InConsensus, #{}).
+
+init_chain(Balance, {PrivKey, PubKey}, InConsensus, ExtraVars) ->
     % Generate fake blockchains (just the keys)
     GenesisMembers = case InConsensus of
                          true ->
@@ -51,7 +55,7 @@ init_chain(Balance, {PrivKey, PubKey}, InConsensus) ->
                      end,
 
     % Create genesis block
-    {InitialVars, Keys} = blockchain_ct_utils:create_vars(#{}),
+    {InitialVars, Keys} = blockchain_ct_utils:create_vars(ExtraVars),
 
     GenPaymentTxs = [blockchain_txn_coinbase_v1:new(Addr, Balance)
                      || {Addr, _} <- GenesisMembers],


### PR DESCRIPTION
Adds a new transaction `blockchain_txn_payment_v2` which allows multi payee payment transactions. So we can eventually start supporting txns like: `payerA -> [payeeX, payeeY, payeeZ]`

Couple things to note:
1. The only nonce which we care about is the nonce for payerA
2. We check whether the whole txn is valid by summing the amounts being paid to X, Y and Z.
3. There is no internal ordering for the payout to X, Y or Z as it doesn't really matter I think.
4. A single payment looks like `payerA -> [payeeX]`
5. The max limit of number of payments in a single txn is configured via `max_payments` chain var.

Proto: https://github.com/helium/proto/pull/20
