### PR TITLE
More state channel fixes

### DIFF
--- a/src/state_channel/blockchain_state_channels_server.erl
+++ b/src/state_channel/blockchain_state_channels_server.erl
@@ -194,7 +194,8 @@ handle_info(post_init, #state{chain=undefined, owner={Owner, _}, state_channels=
             LedgerSCs = convert_to_state_channels(blockchain_ledger_v1:find_all_state_channels_by_owner(Ledger, Owner)),
             {noreply, State#state{chain=Chain, state_channels=maps:merge(LedgerSCs, SCs)}}
     end;
-handle_info({blockchain_event, {add_block, BlockHash, _Syncing, _Ledger}}, #state{chain=Chain, owner={Owner, OwnerSigFun}, state_channels=SCs}=State0) ->
+handle_info({blockchain_event, {add_block, BlockHash, _Syncing, _Ledger}},
+            #state{chain=Chain, owner={Owner, OwnerSigFun}, state_channels=SCs}=State0) ->
     {Block, Txns} = get_state_channels_txns_from_block(Chain, BlockHash, Owner, SCs),
     BlockHeight = blockchain_block:height(Block),
     State1 = lists:foldl(
@@ -205,10 +206,9 @@ handle_info({blockchain_event, {add_block, BlockHash, _Syncing, _Ledger}}, #stat
                         Owner = blockchain_txn_state_channel_open_v1:owner(Txn),
                         Amount = blockchain_txn_state_channel_open_v1:amount(Txn),
                         ExpireWithin = blockchain_txn_state_channel_open_v1:expire_within(Txn),
-                        SC0 = blockchain_state_channel_v1:new(ID, Owner),
-                        SC1 = blockchain_state_channel_v1:credits(Amount, SC0),
-                        SC2 = blockchain_state_channel_v1:expire_at_block(BlockHeight + ExpireWithin, SC1),
-                        State#state{state_channels=maps:put(ID, SC2, SCs0)};
+                        SC0 = blockchain_state_channel_v1:new(ID, Owner, Amount, BlockHeight + ExpireWithin),
+                        SC1 = blockchain_state_channel_v1:sign(SC0, OwnerSigFun),
+                        State#state{state_channels=maps:put(ID, SC1, SCs0)};
                     blockchain_txn_state_channel_close_v1 ->
                         SC = blockchain_txn_state_channel_close_v1:state_channel(Txn),
                         ID = blockchain_state_channel_v1:id(SC),

--- a/src/state_channel/blockchain_state_channels_server.erl
+++ b/src/state_channel/blockchain_state_channels_server.erl
@@ -14,7 +14,8 @@
     start_link/1,
     credits/1, nonce/1,
     request/1,
-    packet/1
+    packet/1,
+    state_channels/0
 ]).
 
 -export([
@@ -81,6 +82,10 @@ request(Req) ->
 packet(Req) ->
     gen_server:cast(?SERVER, {packet, Req}).
 
+-spec state_channels() -> state_channels().
+state_channels() ->
+    gen_server:call(?SERVER, state_channels, infinity).
+
 %% Helper function for tests (remove)
 -spec burn(blockchain_state_channel_v1:id(), non_neg_integer()) -> ok.
 burn(ID, Amount) ->
@@ -117,6 +122,8 @@ handle_call({nonce, ID}, _From, #state{state_channels=SCs}=State) ->
         SC -> {ok, blockchain_state_channel_v1:nonce(SC)}
     end,
     {reply, Reply, State};
+handle_call(state_channels, _From, #state{state_channels=SCs}=State) ->
+    {reply, SCs, State};
 handle_call(_Msg, _From, State) ->
     lager:warning("rcvd unknown call msg: ~p from: ~p", [_Msg, _From]),
     {reply, ok, State}.

--- a/src/state_channel/v1/blockchain_helium_packet_v1.erl
+++ b/src/state_channel/v1/blockchain_helium_packet_v1.erl
@@ -15,7 +15,10 @@
          signal_strength/1,
          frequency/1,
          datarate/1,
-         snr/1
+         snr/1,
+
+         encode/1, decode/1
+
         ]).
 
 -include("blockchain.hrl").
@@ -87,6 +90,15 @@ datarate(#packet_pb{datarate=DR}) ->
 snr(#packet_pb{snr=SNR}) ->
     SNR.
 
+-spec encode(packet()) -> binary().
+encode(#packet_pb{}=Packet) ->
+    packet_pb:encode_msg(Packet).
+
+-spec decode(binary()) -> packet().
+decode(BinaryPacket) ->
+    packet_pb:decode_msg(BinaryPacket, packet_pb).
+
+
 %% ------------------------------------------------------------------
 %% Internal Function Definitions
 %% ------------------------------------------------------------------
@@ -97,7 +109,43 @@ snr(#packet_pb{snr=SNR}) ->
 -ifdef(TEST).
 
 new_test() ->
-    Packet = #packet_pb{oui=1, payload= <<"hello">>},
-    ?assertEqual(Packet, new(1, <<"hello">>)).
+    Packet = #packet_pb{oui=1, payload= <<"payload">>},
+    ?assertEqual(Packet, new(1, <<"payload">>)).
+
+oui_test() ->
+    Packet = new(1, <<"payload">>),
+    ?assertEqual(1, oui(Packet)).
+
+payload_test() ->
+    Packet = new(1, <<"payload">>),
+    ?assertEqual(<<"payload">>, payload(Packet)).
+
+type_test() ->
+    Packet = new(1, lorawan, <<"payload">>, 1000, 0.0, 0.0, "dr", 0.0),
+    ?assertEqual(lorawan, type(Packet)).
+
+timestamp_test() ->
+    Packet = new(1, lorawan, <<"payload">>, 1000, 0.0, 0.0, "dr", 0.0),
+    ?assertEqual(1000, timestamp(Packet)).
+
+signal_strength_test() ->
+    Packet = new(1, lorawan, <<"payload">>, 1000, 0.0, 0.0, "dr", 0.0),
+    ?assertEqual(0.0, signal_strength(Packet)).
+
+frequency_test() ->
+    Packet = new(1, lorawan, <<"payload">>, 1000, 0.0, 0.0, "dr", 0.0),
+    ?assertEqual(0.0, frequency(Packet)).
+
+datarate_test() ->
+    Packet = new(1, lorawan, <<"payload">>, 1000, 0.0, 0.0, "dr", 0.0),
+    ?assertEqual("dr", datarate(Packet)).
+
+snr_test() ->
+    Packet = new(1, lorawan, <<"payload">>, 1000, 0.0, 0.0, "dr", 0.0),
+    ?assertEqual(0.0, snr(Packet)).
+
+encode_decode_test() ->
+    Packet = new(1, lorawan, <<"payload">>, 1000, 0.0, 0.0, "dr", 0.0),
+    ?assertEqual(Packet, decode(encode(Packet))).
 
 -endif.

--- a/src/state_channel/v1/blockchain_state_channel_v1.erl
+++ b/src/state_channel/v1/blockchain_state_channel_v1.erl
@@ -6,7 +6,7 @@
 -module(blockchain_state_channel_v1).
 
 -export([
-    new/2,
+    new/2, new/4,
     zero_id/0, id/1,
     owner/1,
     credits/1, credits/2,
@@ -48,6 +48,22 @@ new(ID, Owner) ->
         root_hash= <<>>,
         state=open,
         expire_at_block=0
+    }.
+
+-spec new(ID :: binary(),
+          Owner :: libp2p_crypto:pubkey_bin(),
+          Credits :: non_neg_integer(),
+          ExpireAtBlock :: pos_integer()) -> state_channel().
+new(ID, Owner, Credits, ExpireAtBlock) ->
+    #blockchain_state_channel_v1_pb{
+        id=ID,
+        owner=Owner,
+        credits=Credits,
+        nonce=0,
+        balances=[],
+        root_hash= <<>>,
+        state=open,
+        expire_at_block=ExpireAtBlock
     }.
 
 -spec zero_id() -> binary().
@@ -180,7 +196,7 @@ validate_request(Request, SC) ->
     case ReqAmount > CalcAmount of
         true ->
             {error, wrong_amount};
-        false -> 
+        false ->
             SCCredits = ?MODULE:credits(SC),
             State = ?MODULE:state(SC),
             case State of


### PR DESCRIPTION
This addresses two issues with the state_channel work:

* Encapsulating the `helium_packet` into its own module. This avoids having to include the proto in tests and other modules.
* More importantly, the `state_channel_close` txn wouldn't fire on expiration because the state_channel signature was empty on creation, this fixes that as well.