### PR TITLE
Sign state_channel before submitting state_close txn

### DIFF
--- a/src/state_channel/blockchain_state_channels_server.erl
+++ b/src/state_channel/blockchain_state_channels_server.erl
@@ -206,9 +206,8 @@ handle_info({blockchain_event, {add_block, BlockHash, _Syncing, _Ledger}},
                         Owner = blockchain_txn_state_channel_open_v1:owner(Txn),
                         Amount = blockchain_txn_state_channel_open_v1:amount(Txn),
                         ExpireWithin = blockchain_txn_state_channel_open_v1:expire_within(Txn),
-                        SC0 = blockchain_state_channel_v1:new(ID, Owner, Amount, BlockHeight + ExpireWithin),
-                        SC1 = blockchain_state_channel_v1:sign(SC0, OwnerSigFun),
-                        State#state{state_channels=maps:put(ID, SC1, SCs0)};
+                        SC = blockchain_state_channel_v1:new(ID, Owner, Amount, BlockHeight + ExpireWithin),
+                        State#state{state_channels=maps:put(ID, SC, SCs0)};
                     blockchain_txn_state_channel_close_v1 ->
                         SC = blockchain_txn_state_channel_close_v1:state_channel(Txn),
                         ID = blockchain_state_channel_v1:id(SC),
@@ -254,7 +253,8 @@ check_state_channel_expiration(BlockHeight, Owner, OwnerSigFun, SCs) ->
                 false ->
                     SC;
                 true ->
-                    SC1 = blockchain_state_channel_v1:state(closed, SC),
+                    SC0 = blockchain_state_channel_v1:state(closed, SC),
+                    SC1 = blockchain_state_channel_v1:sign(SC0, OwnerSigFun),
                     ok = close_state_channel(SC1, Owner, OwnerSigFun),
                     SC1
             end

--- a/src/state_channel/v1/blockchain_state_channel_request_v1.erl
+++ b/src/state_channel/v1/blockchain_state_channel_request_v1.erl
@@ -25,7 +25,7 @@
 -export_type([request/0]).
 
 -spec new(libp2p_crypto:pubkey_bin(), non_neg_integer(), non_neg_integer()) -> request().
-new(Payee, Amount, PayloadSize) -> 
+new(Payee, Amount, PayloadSize) ->
     #blockchain_state_channel_request_v1_pb{
         payee=Payee,
         amount=Amount,


### PR DESCRIPTION
If we sign the `state_channel` which we store in the `state_channels_server` at `open` txn it's bound to fail as the encoding would most likely change when the eventual `close` txn gets fired, because we'll have the state go from open -> closed and potentially have balances in the state_channel.

Instead sign the state_channel before issuing the `close` txn on expiration. I believe this is already done when there is an `add_request` so that should be fine.