### PR TITLE
add monitoring to gossip group to re-establish handlers

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -51,7 +51,7 @@
   0},
  {<<"libp2p">>,
   {git,"https://github.com/helium/erlang-libp2p.git",
-       {ref,"43bd014f21014a27f2ed8c150084775ec0ba1a9a"}},
+       {ref,"2e81c79ceb16c74e3dbcc19e982b5192817e50b0"}},
   0},
  {<<"libp2p_crypto">>,{pkg,<<"libp2p_crypto">>,<<"1.0.1">>},1},
  {<<"multiaddr">>,{pkg,<<"multiaddr">>,<<"1.1.3">>},1},

--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -372,11 +372,11 @@ handle_cast({integrate_genesis_block, GenesisBlock}, #state{blockchain={no_genes
             lager:info("blockchain started with ~p, consensus ~p", [lager:pr(Blockchain, blockchain), ConsensusAddrs]),
             {ok, GenesisHash} = blockchain:genesis_hash(Blockchain),
             ok = notify({integrate_genesis_block, GenesisHash}),
-            ok = add_handlers(Swarm, Blockchain),
+            {ok, GossipRef} = add_handlers(Swarm, Blockchain),
             ok = blockchain_txn_mgr:set_chain(Blockchain),
             true = libp2p_swarm:network_id(Swarm, GenesisHash),
             self() ! maybe_sync,
-            {noreply, State#state{blockchain=Blockchain}}
+            {noreply, State#state{blockchain=Blockchain, gossip_ref = GossipRef}}
     end;
 handle_cast(_, #state{blockchain={no_genesis, _}}=State) ->
     {noreply, State};


### PR DESCRIPTION
we don't monitor the gossip group, so when it fails, we don't re-establish the gossip handler, and then reject all incoming gossip connections, and all gossiped blocks, which breaks poc.