### PR TITLE
ledger snapshots

### DIFF
--- a/include/blockchain.hrl
+++ b/include/blockchain.hrl
@@ -10,6 +10,9 @@
 -define(SUPPORTED_SYNC_PROTOCOLS, [?SYNC_PROTOCOL_V2, ?SYNC_PROTOCOL_V1]).
 -define(SUPPORTED_FASTFORWARD_PROTOCOLS, [?FASTFORWARD_PROTOCOL_V2, ?FASTFORWARD_PROTOCOL_V1]).
 
+-define(SNAPSHOT_PROTOCOL, "blockchain_snapshot/1.0.0").
+
+
 -define(TX_PROTOCOL, "blockchain_txn/1.0.0").
 -define(LOC_ASSERTION_PROTOCOL, "loc_assertion/1.0.0").
 -define(STATE_CHANNEL_PROTOCOL_V1, "state_channel/1.0.0").

--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -259,9 +259,9 @@
 -define(max_payments, max_payments).
 %% Var to switch off legacy payment txn
 -define(deprecate_payment_v1, deprecate_payment_v1).
+
 %% Set this var to false to disable zero amount txns (payment_v1, payment_v2, htlc_create)
 -define(allow_zero_amount, allow_zero_amount).
-
 
 %% ------------------------------------------------------------------
 %% State channel related vars
@@ -284,3 +284,12 @@
 -define(sc_grace_blocks, sc_grace_blocks).
 %% DC Payload size, set to 24
 -define(dc_payload_size, dc_payload_size).
+
+%% ------------------------------------------------------------------
+%% snapshot vars
+
+%% snapshot version, presence indicates if snapshots are enabled or not.
+-define(snapshot_version, snapshot_version).
+
+%% how often we attempt to take a snapshot of the ledger
+-define(snapshot_interval, snapshot_interval).

--- a/rebar.lock
+++ b/rebar.lock
@@ -37,7 +37,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"7f49ecc36c18baf4d960aaea0f260ddba5692ba3"}},
+       {ref,"c861a5bb97a219e91d90807968785bdc93aed9dd"}},
   0},
  {<<"inert">>,
   {git,"https://github.com/msantos/inert",

--- a/scripts/extensions/snapshot
+++ b/scripts/extensions/snapshot
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ -t 0 ] ; then
+    export CLIQUE_COLUMNS=`stty size 2>/dev/null | cut -d ' ' -f 2`
+fi
+relx_nodetool rpc blockchain_console command snapshot $@
+exit $?

--- a/src/blockchain_block_v1.erl
+++ b/src/blockchain_block_v1.erl
@@ -24,6 +24,7 @@
     rescue_signature/1,
     seen_votes/1,
     bba_completion/1,
+    snapshot_hash/1,
     verify_signatures/4, verify_signatures/5,
     is_rescue_block/1
 ]).
@@ -46,7 +47,8 @@
                        epoch_start => non_neg_integer(),
                        rescue_signature => binary(),
                        seen_votes => [{pos_integer(), binary()}],
-                       bba_completion => binary()
+                       bba_completion => binary(),
+                       snapshot_hash => binary()
                       }.
 
 -export_type([block/0, block_map/0]).
@@ -65,7 +67,7 @@ new(#{prev_hash := PrevHash,
       election_epoch := ElectionEpoch,
       epoch_start := EpochStart,
       seen_votes := Votes,
-      bba_completion := Completion}) ->
+      bba_completion := Completion} = Map) ->
     #blockchain_block_v1_pb{
        prev_hash = PrevHash,
        height = Height,
@@ -76,7 +78,8 @@ new(#{prev_hash := PrevHash,
        election_epoch = ElectionEpoch,
        epoch_start = EpochStart,
        seen_votes = [wrap_vote(V) || V <- lists:sort(Votes)],
-       bba_completion = Completion
+       bba_completion = Completion,
+       snapshot_hash = maps:get(snapshot_hash, Map, <<>>)
       }.
 
 -spec rescue(block_map())-> block().
@@ -153,6 +156,10 @@ seen_votes(Block) ->
 -spec bba_completion(block()) -> binary().
 bba_completion(Block) ->
     Block#blockchain_block_v1_pb.bba_completion.
+
+-spec snapshot_hash(block()) -> binary().
+snapshot_hash(Block) ->
+    Block#blockchain_block_v1_pb.snapshot_hash.
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/src/blockchain_swarm.erl
+++ b/src/blockchain_swarm.erl
@@ -90,7 +90,6 @@ gossip_peers() ->
 %% gen_server Function Definitions
 %% ------------------------------------------------------------------
 init(Args) ->
-    erlang:process_flag(trap_exit, true),
     lager:info("~p init with ~p", [?SERVER, Args]),
     {ok, Pid} = libp2p_swarm:start(?SWARM_NAME, Args),
     true = erlang:link(Pid),

--- a/src/cli/blockchain_cli_ledger.erl
+++ b/src/cli/blockchain_cli_ledger.erl
@@ -226,10 +226,10 @@ ledger_variables(Cmd, [], Flags) ->
                         [clique_status:text("variable not found")]
                 end;
             [_, _] when Flags == [{all, undefined}] ->
-                Vars = blockchain_ledger_v1:all_vars(Ledger),
+                Vars = blockchain_ledger_v1:snapshot_vars(Ledger),
                 [clique_status:text(
                    [io_lib:format("~s: ~p~n", [N, V])
-                    || {N, V} <- lists:sort(maps:to_list(Vars))])];
+                    || {N, V} <- lists:sort(Vars)])];
             _ ->
                 usage
         end

--- a/src/cli/blockchain_cli_registry.erl
+++ b/src/cli/blockchain_cli_registry.erl
@@ -2,6 +2,7 @@
 
 -define(CLI_MODULES, [
                       blockchain_cli_peer,
+                      blockchain_cli_snapshot,
                       blockchain_cli_ledger,
                       blockchain_cli_repair,
                       blockchain_cli_trace,

--- a/src/cli/blockchain_cli_snapshot.erl
+++ b/src/cli/blockchain_cli_snapshot.erl
@@ -1,0 +1,122 @@
+%%%-------------------------------------------------------------------
+%% @doc
+%% == Blockchain CLI Trace ==
+%% @end
+%%%-------------------------------------------------------------------
+-module(blockchain_cli_snapshot).
+
+-behavior(clique_handler).
+
+-export([register_cli/0]).
+
+-export([snapshot_take/1,
+         snapshot_load/1]).
+
+register_cli() ->
+    register_all_usage(),
+    register_all_cmds().
+
+register_all_usage() ->
+    lists:foreach(fun(Args) ->
+                          apply(clique, register_usage, Args)
+                  end,
+                  [
+                   snapshot_take_usage(),
+                   snapshot_load_usage(),
+                   snapshot_usage()
+                  ]).
+
+register_all_cmds() ->
+    lists:foreach(fun(Cmds) ->
+                          [apply(clique, register_command, Cmd) || Cmd <- Cmds]
+                  end,
+                  [
+                   snapshot_take_cmd(),
+                   snapshot_load_cmd(),
+                   snapshot_cmd()
+                  ]).
+%%
+%% trace
+%%
+
+snapshot_usage() ->
+    [["snapshot"],
+     ["blockchain snapshot commands\n\n",
+      "  snapshot take   - Take a snapshot at the current ledger height.\n",
+      "  snapshot load   - Load a snapshot from a file.\n"
+     ]
+    ].
+
+snapshot_cmd() ->
+    [
+     [["snapshot"], [], [], fun(_, _, _) -> usage end]
+    ].
+
+
+%%
+%% trace start
+%%
+
+snapshot_take_cmd() ->
+    [
+     [["snapshot", "take", '*'], [], [], fun snapshot_take/3]
+    ].
+
+snapshot_take_usage() ->
+    [["snapshot", "take"],
+     ["blockchain snapshot take <filename>\n\n",
+      "  Take a ledger snapshot at the current height and write it to filename\n"]
+    ].
+
+snapshot_take(["snapshot", "take", Filename], [], []) ->
+    Ret = snapshot_take(Filename),
+    [clique_status:text(io_lib:format("~p", [Ret]))];
+snapshot_take(_, _, _) ->
+    usage.
+
+snapshot_take(Filename) ->
+    Chain = blockchain_worker:blockchain(),
+    Ledger = blockchain:ledger(Chain),
+    DLedger = blockchain_ledger_v1:mode(delayed, Ledger),
+    {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
+    {ok, DHeight} = blockchain_ledger_v1:current_height(DLedger),
+    Blocks =
+        [begin
+             {ok, B} = blockchain:get_block(N, Chain),
+             B
+         end
+         || N <- lists:seq(DHeight, Height)],
+    {ok, Snapshot} = blockchain_ledger_snapshot_v1:snapshot(Ledger, Blocks),
+    {ok, BinSnap} = blockchain_ledger_snapshot_v1:serialize(Snapshot),
+    file:write_file(Filename, BinSnap).
+
+snapshot_load_cmd() ->
+    [
+     [["snapshot", "load", '*'], [], [], fun snapshot_load/3]
+    ].
+
+snapshot_load_usage() ->
+    [["snapshot", "load"],
+     ["blockchain snapshot take <filename>\n\n",
+      "  Take a ledger snapshot at the current height and write it to filename\n"]
+    ].
+
+snapshot_load(["snapshot", "load", Filename], [], []) ->
+    Ret = snapshot_load(Filename),
+    [clique_status:text(io_lib:format("~p", [Ret]))];
+snapshot_load(_, _, _) ->
+    usage.
+
+snapshot_load(Filename) ->
+    {ok, BinSnap} = file:read_file(Filename),
+    %% no reason to hang this forever
+    ok = blockchain_lock:acquire(15000),
+    try
+        {ok, Snapshot} = blockchain_ledger_snapshot_v1:deserialize(BinSnap),
+        Hash = blockchain_ledger_snapshot_v1:hash(Snapshot),
+
+        ok = blockchain_worker:install_snapshot(Hash, Snapshot)
+    after
+            blockchain_lock:release()
+    end,
+    ok.

--- a/src/handlers/blockchain_gossip_handler.erl
+++ b/src/handlers/blockchain_gossip_handler.erl
@@ -93,6 +93,9 @@ add_block(Block, Chain, Sender, SwarmTID) ->
         {error, block_higher_than_assumed_valid_height} ->
             %% harmless
             ok;
+        {error, no_ledger} ->
+            %% just ignore this, we don't care right now
+            ok;
         Error ->
             %% Uhm what is this?
             lager:error("Something bad happened: ~p", [Error])

--- a/src/handlers/blockchain_snapshot_handler.erl
+++ b/src/handlers/blockchain_snapshot_handler.erl
@@ -1,0 +1,104 @@
+%%%-------------------------------------------------------------------
+%% @doc
+%% == Blockchain Sybc Stream Handler ==
+%% @end
+%%%-------------------------------------------------------------------
+-module(blockchain_snapshot_handler).
+
+-behavior(libp2p_framed_stream).
+
+
+-include_lib("helium_proto/include/blockchain_snapshot_handler_pb.hrl").
+
+%% ------------------------------------------------------------------
+%% API Function Exports
+%% ------------------------------------------------------------------
+
+-export([
+    server/4,
+    client/2
+]).
+
+%% ------------------------------------------------------------------
+%% libp2p_framed_stream Function Exports
+%% ------------------------------------------------------------------
+-export([
+    init/3,
+    handle_data/3,
+    handle_info/3
+]).
+
+-record(state,
+        {
+         chain :: blockchain:blochain(),
+         hash :: any()
+        }).
+
+%% ------------------------------------------------------------------
+%% API Function Definitions
+%% ------------------------------------------------------------------
+client(Connection, Args) ->
+    libp2p_framed_stream:client(?MODULE, Connection, Args).
+
+server(Connection, Path, _TID, Args) ->
+    libp2p_framed_stream:server(?MODULE, Connection, [Path | Args]).
+
+%% ------------------------------------------------------------------
+%% libp2p_framed_stream Function Definitions
+%% ------------------------------------------------------------------
+init(client, _Conn, [Hash, Height, Chain]) ->
+    case blockchain_worker:sync_paused() of
+        false ->
+            {stop, sync_not_paused};
+        true ->
+            Msg = #blockchain_snapshot_req_pb{height = Height, hash = Hash},
+            {ok, #state{chain = Chain, hash = Hash},
+             blockchain_snapshot_handler_pb:encode_msg(Msg)}
+    end;
+init(server, _Conn, [_Path, _, Chain]) ->
+    {ok, #state{chain = Chain}}.
+
+handle_data(client, Data, #state{chain = Chain, hash = Hash} = State) ->
+    #blockchain_snapshot_resp_pb{snapshot = BinSnap} =
+        blockchain_snapshot_handler_pb:decode_msg(Data, blockchain_snapshot_resp_pb),
+    case blockchain_ledger_snapshot_v1:deserialize(BinSnap) of
+        {ok, Snapshot} ->
+            Height = blockchain_ledger_snapshot_v1:height(Snapshot),
+
+            case blockchain:add_snapshot(Snapshot, Chain) of
+                ok ->
+                    lager:info("retrieved and stored snapshot ~p, installing",
+                               [Height]),
+                    blockchain_worker:install_snapshot(Hash, Snapshot);
+                {error, Reason} ->
+                    lager:info("could not install retrieved snapshot ~p: ~p",
+                               [Height, Reason]),
+                    ok
+            end;
+        {error, Reason} ->
+            lager:info("could not deserialize retrieved snapshot ~p: ~p",
+                       [Reason]),
+            ok
+    end,
+    {stop, normal, State};
+handle_data(server, Data, #state{chain = Chain} = State) ->
+    case blockchain_snapshot_handler_pb:decode_msg(Data, blockchain_snapshot_req_pb) of
+        #blockchain_snapshot_req_pb{height = _Height, hash = Hash} ->
+            case blockchain:get_snapshot(Hash, Chain) of
+                {ok, Snap} ->
+                    lager:info("sending snapshot ~p", [Hash]),
+                    Msg = #blockchain_snapshot_resp_pb{snapshot = Snap},
+                    {noreply, State, blockchain_snapshot_handler_pb:encode_msg(Msg)};
+                {error, _Reason} ->
+                    lager:info("failed getting snapshot ~p : ~p", [Hash, _Reason]),
+                    {stop, normal, State}
+            end;
+        _Other ->
+            lager:info("unexpected snapshot message ~p", [_Other]),
+            %% There was some sort of error, just die
+            {stop, normal, State}
+    end.
+
+handle_info(_Type, _Msg, State) ->
+    lager:info("unhandled message ~p ~p", [_Type, _Msg]),
+    {noreply, State}.

--- a/src/handlers/blockchain_sync_handler.erl
+++ b/src/handlers/blockchain_sync_handler.erl
@@ -88,7 +88,7 @@ dial(Swarm, Chain, Peer, ProtocolVersion)->
 init(client, _Conn, [Path, Blockchain]) ->
     case blockchain_worker:sync_paused() of
         true ->
-            {stop, sync_paused};
+            {stop, normal};
         false ->
             BatchSize = application:get_env(blockchain, block_sync_batch_size, 5),
             BatchLimit = application:get_env(blockchain, block_sync_batch_limit, 40),

--- a/src/ledger/v1/blockchain_ledger_exporter_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_exporter_v1.erl
@@ -66,4 +66,4 @@ export_dcs(Ledger) ->
     ).
 
 export_chain_vars(Ledger) ->
-    lists:sort(maps:to_list(blockchain_ledger_v1:all_vars(Ledger))).
+    lists:sort(blockchain_ledger_v1:snapshot_vars(Ledger)).

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -1,0 +1,339 @@
+-module(blockchain_ledger_snapshot_v1).
+
+-export([
+         serialize/1,
+         deserialize/1,
+
+         snapshot/2,
+         import/3,
+
+         height/1,
+         hash/1,
+
+         diff/2
+        ]).
+
+
+%% this is temporary, something to work with easily while we nail the
+%% format and functionality down.  once it's final we can move on to a
+%% more permanent and less flexible format, like protobufs, or
+%% cauterize.
+
+-record(blockchain_snapshot_v1,
+        {
+         %% meta stuff here
+         previous_snapshot_hash :: binary(),
+         leading_hash :: binary(),
+
+         %% ledger stuff here
+         current_height :: pos_integer(),
+         transaction_fee :: non_neg_integer(),
+         consensus_members :: [libp2p_crypto:pubkey_bin()],
+
+         %% these are updated but never used.  Not sure what to do!
+         election_height :: pos_integer(),
+         election_epoch :: pos_integer(),
+
+         delayed_vars :: [any()],
+         threshold_txns :: [any()],
+
+         master_key :: binary(),
+         vars_nonce :: pos_integer(),
+         vars :: [any()],
+
+         gateways :: #{},
+         pocs :: [any()],
+
+         accounts :: [any()],
+         dc_accounts :: [any()],
+
+         token_burn_rate :: non_neg_integer(),
+
+         security_accounts :: [any()],
+
+         htlcs :: [any()],
+         %% htlc_nonce :: pos_integer(),
+
+         ouis :: [any()],
+         subnets :: [any()],
+         oui_counter :: pos_integer(),
+
+         hexes :: [any()],
+
+         state_channels :: [any()],
+
+         blocks :: [blockchain_block:block()]
+        }).
+
+snapshot(Ledger0, Blocks) ->
+    try
+        %% TODO: actually verify we're delayed here instead of
+        %% changing modes?
+        Ledger = blockchain_ledger_v1:mode(delayed, Ledger0),
+        {ok, CurrHeight} = blockchain_ledger_v1:current_height(Ledger),
+        {ok, TransactionFee} = blockchain_ledger_v1:transaction_fee(Ledger),
+        {ok, ConsensusMembers} = blockchain_ledger_v1:consensus_members(Ledger),
+        {ok, ElectionHeight} = blockchain_ledger_v1:election_height(Ledger),
+        {ok, ElectionEpoch} = blockchain_ledger_v1:election_epoch(Ledger),
+        {ok, MasterKey} = blockchain_ledger_v1:master_key(Ledger),
+        DelayedVars = blockchain_ledger_v1:snapshot_delayed_vars(Ledger),
+        ThresholdTxns = blockchain_ledger_v1:snapshot_threshold_txns(Ledger),
+        {ok, VarsNonce} = blockchain_ledger_v1:vars_nonce(Ledger),
+        Vars = blockchain_ledger_v1:snapshot_vars(Ledger),
+        Gateways = blockchain_ledger_v1:active_gateways(Ledger),
+        %% need to write these on the ledger side
+        PoCs = blockchain_ledger_v1:snapshot_pocs(Ledger),
+        Accounts = blockchain_ledger_v1:snapshot_accounts(Ledger),
+        DCAccounts = blockchain_ledger_v1:snapshot_dc_accounts(Ledger),
+        SecurityAccounts = blockchain_ledger_v1:snapshot_security_accounts(Ledger),
+
+        %%{ok, TokenBurnRate} = blockchain_ledger_v1:token_burn_exchange_rate(Ledger),
+
+        HTLCs = blockchain_ledger_v1:snapshot_htlcs(Ledger),
+        %% add once this is added
+        %% {ok, HTLCNonce} = blockchain_ledger_v1:htlc_nonce(Ledger),
+
+        OUIs = blockchain_ledger_v1:snapshot_ouis(Ledger),
+        Subnets = blockchain_ledger_v1:snapshot_subnets(Ledger),
+        {ok, OUICounter} = blockchain_ledger_v1:get_oui_counter(Ledger),
+
+        Hexes = blockchain_ledger_v1:snapshot_hexes(Ledger),
+
+        StateChannels = blockchain_ledger_v1:snapshot_state_channels(Ledger),
+
+        Snapshot =
+            #blockchain_snapshot_v1{
+               previous_snapshot_hash = <<>>,
+               leading_hash = <<>>,
+
+               current_height = CurrHeight,
+               transaction_fee = TransactionFee,
+               consensus_members = ConsensusMembers,
+
+               election_height = ElectionHeight,
+               election_epoch = ElectionEpoch,
+
+               delayed_vars = DelayedVars,
+               threshold_txns = ThresholdTxns,
+
+               master_key = MasterKey,
+               vars_nonce = VarsNonce,
+               vars = Vars,
+
+               gateways = Gateways,
+               pocs = PoCs,
+
+               accounts = Accounts,
+               dc_accounts = DCAccounts,
+
+               %%token_burn_rate = TokenBurnRate,
+               token_burn_rate = 0,
+
+               security_accounts = SecurityAccounts,
+
+               htlcs = HTLCs,
+               %% htlc_nonce = HTLCNonce,
+
+               ouis = OUIs,
+               subnets = Subnets,
+               oui_counter = OUICounter,
+
+               hexes = Hexes,
+
+               state_channels = StateChannels,
+
+               blocks = Blocks
+              },
+
+        {ok, Snapshot}
+    catch C:E:S ->
+            {error, {error_taking_snapshot, C, E, S}}
+    end.
+
+serialize(Snapshot) ->
+    serialize(Snapshot, blocks).
+
+serialize(Snapshot, BlocksP) ->
+    Snapshot1 = case BlocksP of
+                    blocks -> Snapshot;
+                    noblocks -> Snapshot#blockchain_snapshot_v1{blocks = []}
+                end,
+    Bin = term_to_binary(Snapshot1, [{compressed, 9}]),
+    BinSz = byte_size(Bin),
+
+    %% do some simple framing with version, size, & snap
+    Snap = <<1, %% version
+             BinSz:32/little-unsigned-integer, Bin/binary>>,
+    {ok, Snap}.
+
+deserialize(<<1,
+              %%SHASz:16/little-unsigned-integer, SHA:SHASz/binary,
+              BinSz:32/little-unsigned-integer, BinSnap:BinSz/binary>>) ->
+    try binary_to_term(BinSnap) of
+        #blockchain_snapshot_v1{} = Snapshot ->
+            {ok, Snapshot}
+    catch _:_ ->
+            {error, bad_snapshot_binary}
+    end.
+
+%% sha will be stored externally
+import(Chain, SHA,
+       #blockchain_snapshot_v1{
+          previous_snapshot_hash = <<>>,
+          leading_hash = <<>>,
+
+          current_height = CurrHeight,
+          transaction_fee = TransactionFee,
+          consensus_members = ConsensusMembers,
+
+          election_height = ElectionHeight,
+          election_epoch = ElectionEpoch,
+
+          delayed_vars = DelayedVars,
+          threshold_txns = ThresholdTxns,
+
+          master_key = MasterKey,
+          vars_nonce = VarsNonce,
+          vars = Vars,
+
+          gateways = Gateways,
+          pocs = PoCs,
+
+          accounts = Accounts,
+          dc_accounts = DCAccounts,
+
+          %%token_burn_rate = TokenBurnRate,
+
+          security_accounts = SecurityAccounts,
+
+          htlcs = HTLCs,
+          %% htlc_nonce = HTLCNonce,
+
+          ouis = OUIs,
+          subnets = Subnets,
+          oui_counter = OUICounter,
+
+          hexes = Hexes,
+
+          %% state_channels = StateChannels
+
+          blocks = Blocks
+         } = Snapshot) ->
+    Dir = blockchain:dir(Chain),
+    case hash(Snapshot) of
+        SHA ->
+            CLedger = blockchain:ledger(Chain),
+            Ledger0 =
+                case catch blockchain_ledger_v1:current_height(CLedger) of
+                    %% nothing in there, proceed
+                    {ok, 1} ->
+                        CLedger;
+                    _ ->
+                        blockchain_ledger_v1:clean(CLedger),
+                        blockchain_ledger_v1:new(Dir)
+                end,
+
+            %% we load up both with the same snapshot here, then sync the next 50
+            %% blocks and check that we're valid.
+            [begin
+                 Ledger1 = blockchain_ledger_v1:mode(Mode, Ledger0),
+                 Ledger = blockchain_ledger_v1:new_context(Ledger1),
+                 ok = blockchain_ledger_v1:current_height(CurrHeight, Ledger),
+                 ok = blockchain_ledger_v1:update_transaction_fee(TransactionFee, Ledger),
+                 ok = blockchain_ledger_v1:consensus_members(ConsensusMembers, Ledger),
+                 ok = blockchain_ledger_v1:election_height(ElectionHeight, Ledger),
+                 ok = blockchain_ledger_v1:election_epoch(ElectionEpoch, Ledger),
+                 ok = blockchain_ledger_v1:load_delayed_vars(DelayedVars, Ledger),
+                 ok = blockchain_ledger_v1:load_threshold_txns(ThresholdTxns, Ledger),
+                 ok = blockchain_ledger_v1:master_key(MasterKey, Ledger),
+                 ok = blockchain_ledger_v1:vars_nonce(VarsNonce, Ledger),
+                 ok = blockchain_ledger_v1:load_vars(Vars, Ledger),
+                 ok = blockchain_ledger_v1:load_gateways(Gateways, Ledger),
+                 %% need to write these on the ledger side
+                 ok = blockchain_ledger_v1:load_pocs(PoCs, Ledger),
+                 ok = blockchain_ledger_v1:load_accounts(Accounts, Ledger),
+                 ok = blockchain_ledger_v1:load_dc_accounts(DCAccounts, Ledger),
+                 ok = blockchain_ledger_v1:load_security_accounts(SecurityAccounts, Ledger),
+
+                 %% ok = blockchain_ledger_v1:token_burn_exchange_rate(TokenBurnRate, Ledger),
+
+                 ok = blockchain_ledger_v1:load_htlcs(HTLCs, Ledger),
+                 %% add once this is added
+                 %% {ok, HTLCNonce} = blockchain_ledger_v1:htlc_nonce(Ledger),
+
+                 ok = blockchain_ledger_v1:load_ouis(OUIs, Ledger),
+                 ok = blockchain_ledger_v1:load_subnets(Subnets, Ledger),
+                 ok = blockchain_ledger_v1:set_oui_counter(OUICounter, Ledger),
+
+                 ok = blockchain_ledger_v1:load_hexes(Hexes, Ledger),
+
+                 %% ok = blockchain_ledger_v1:load_state_channels(StateChannels, Ledger),
+                 blockchain_ledger_v1:commit_context(Ledger)
+             end
+             || Mode <- [delayed, active]],
+            Ledger2 = blockchain_ledger_v1:new_context(Ledger0),
+            Chain1 = blockchain:ledger(Ledger2, Chain),
+            {ok, Curr2} = blockchain_ledger_v1:current_height(Ledger2),
+            lager:info("ledger height is ~p after absorbing snapshot", [Curr2]),
+            lager:info("snapshot contains ~p blocks", [length(Blocks)]),
+
+            case Blocks of
+                [] ->
+                    %%ignore blocks in testing
+                    ok;
+                [Head | Tail] ->
+                    %% just store the head, we'll need it sometimes
+                    Ht = blockchain_block:height(Head),
+                    case blockchain:get_block(Ht, Chain) of
+                        {ok, _Block} ->
+                            %% already have it, don't need to store it again.
+                            ok;
+                        _ ->
+                            ok = blockchain:save_block(Head, Chain)
+                    end,
+                    lists:foreach(
+                      fun(Block) ->
+                              lager:info("loading block ~p", [blockchain_block:height(Block)]),
+                              Rescue = blockchain_block:is_rescue_block(Block),
+                              {ok, _Chain} = blockchain_txn:absorb_block(Block, Rescue, Chain1),
+                              ok = blockchain:save_block(Block, Chain1)
+                      end,
+                      %% XXX we get one too many blocks
+                      Tail)
+            end,
+            blockchain_ledger_v1:commit_context(Ledger2),
+            {ok, Curr3} = blockchain_ledger_v1:current_height(Ledger0),
+            lager:info("ledger height is ~p after absorbing blocks", [Curr3]),
+            {ok, Ledger0};
+        _ ->
+            {error, bad_snapshot_checksum}
+    end.
+
+height(#blockchain_snapshot_v1{current_height = Height}) ->
+    Height.
+
+hash(#blockchain_snapshot_v1{} = Snap) ->
+    {ok, BinSnap} = serialize(Snap, noblocks),
+    crypto:hash(sha256, BinSnap).
+
+diff(A, B) ->
+    Fields = record_info(fields, blockchain_snapshot_v1),
+    [_ | AL] = tuple_to_list(A),
+    [_ | BL] = tuple_to_list(B),
+    Comp = lists:zip3(Fields, AL, BL),
+    lists:foldl(
+      fun({Field, AI, BI}, Acc) ->
+              case AI == BI of
+                  true ->
+                      Acc;
+                  _ ->
+                      case Field of
+                          F when F == vars; F == security_accounts ->
+                              [{Field, AI, BI} | Acc];
+                          _ ->
+                              [Field | Acc]
+                      end
+              end
+      end,
+      [],
+      Comp).

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -17,19 +17,19 @@
 
     new_snapshot/1, context_snapshot/2, has_snapshot/2, release_snapshot/1, snapshot/1,
 
-    current_height/1, increment_height/2,
-    transaction_fee/1, update_transaction_fee/1,
+    current_height/1, current_height/2, increment_height/2,
+    transaction_fee/1, update_transaction_fee/1, update_transaction_fee/2,
     consensus_members/1, consensus_members/2,
     election_height/1, election_height/2,
     election_epoch/1, election_epoch/2,
     process_delayed_txns/3,
 
-    active_gateways/1,
+    active_gateways/1, load_gateways/2,
     entries/1,
     htlcs/1,
 
     master_key/1, master_key/2,
-    all_vars/1,
+
     vars/3,
     config/2,  % no version with default, use the set value or fail
     vars_nonce/1, vars_nonce/2,
@@ -77,8 +77,9 @@
     add_htlc/8,
     redeem_htlc/3,
 
-    get_oui_counter/1, increment_oui_counter/1,
+    get_oui_counter/1, set_oui_counter/2, increment_oui_counter/1,
     add_oui/5,
+
     find_routing/2, find_routing_for_packet/2, find_router_ouis/2,
     update_routing/4,
 
@@ -103,6 +104,33 @@
     remove_from_hex/3,
 
     clean_all_hexes/1,
+
+    %% snapshot save/restore stuff
+
+    snapshot_vars/1,
+    load_vars/2,
+    snapshot_pocs/1,
+    load_pocs/2,
+    snapshot_accounts/1,
+    load_accounts/2,
+    snapshot_dc_accounts/1,
+    load_dc_accounts/2,
+    snapshot_security_accounts/1,
+    load_security_accounts/2,
+    snapshot_htlcs/1,
+    load_htlcs/2,
+    snapshot_ouis/1,
+    load_ouis/2,
+    snapshot_subnets/1,
+    load_subnets/2,
+    snapshot_state_channels/1,
+    load_state_channels/2,
+    snapshot_hexes/1,
+    load_hexes/2,
+    snapshot_delayed_vars/1,
+    load_delayed_vars/2,
+    snapshot_threshold_txns/1,
+    load_threshold_txns/2,
 
     clean/1, close/1,
     compact/1
@@ -504,6 +532,11 @@ current_height(Ledger) ->
             Error
     end.
 
+-spec current_height(pos_integer(), ledger()) -> ok | {error, any()}.
+current_height(Height, Ledger) ->
+    DefaultCF = default_cf(Ledger),
+    cache_put(Ledger, DefaultCF, ?CURRENT_HEIGHT, <<Height:64/integer-unsigned-big>>).
+
 -spec increment_height(blockchain_block:block(), ledger()) -> ok | {error, any()}.
 increment_height(Block, Ledger) ->
     DefaultCF = default_cf(Ledger),
@@ -515,7 +548,6 @@ increment_height(Block, Ledger) ->
             Height1 = erlang:max(BlockHeight, Height0),
             cache_put(Ledger, DefaultCF, ?CURRENT_HEIGHT, <<Height1:64/integer-unsigned-big>>)
     end.
-
 
 -spec transaction_fee(ledger()) -> {ok, pos_integer()} | {error, any()}.
 transaction_fee(Ledger) ->
@@ -535,6 +567,11 @@ update_transaction_fee(Ledger) ->
     %% TODO - based on the average of usage fees
     DefaultCF = default_cf(Ledger),
     cache_put(Ledger, DefaultCF, ?TRANSACTION_FEE, <<0:64/integer-unsigned-big>>).
+
+-spec update_transaction_fee(pos_integer(), ledger()) -> ok.
+update_transaction_fee(Fee, Ledger) ->
+    DefaultCF = default_cf(Ledger),
+    cache_put(Ledger, DefaultCF, ?TRANSACTION_FEE, <<Fee:64/integer-unsigned-big>>).
 
 -spec consensus_members(ledger()) -> {ok, [libp2p_crypto:pubkey_bin()]} | {error, any()}.
 consensus_members(Ledger) ->
@@ -616,6 +653,7 @@ process_delayed_txns(Block, Ledger, Chain) ->
               end
       end,
       PendingTxns),
+    cache_delete(Ledger, DefaultCF, block_name(Block)),
     ok.
 
 delay_vars(Effective, Vars, Ledger) ->
@@ -686,6 +724,17 @@ active_gateways(Ledger) ->
       #{}
      ).
 
+-spec load_gateways(active_gateways(), ledger()) -> ok | {error, _}.
+load_gateways(Gws, Ledger) ->
+    AGwsCF = active_gateways_cf(Ledger),
+    maps:map(
+      fun(Address, Gw) ->
+              Bin = blockchain_ledger_gateway_v2:serialize(Gw),
+              cache_put(Ledger, AGwsCF, Address, Bin)
+      end,
+      Gws),
+    ok.
+
 -spec entries(ledger()) -> entries().
 entries(Ledger) ->
     EntriesCF = entries_cf(Ledger),
@@ -741,16 +790,6 @@ master_key(Ledger) ->
 master_key(NewKey, Ledger) ->
     DefaultCF = default_cf(Ledger),
     cache_put(Ledger, DefaultCF, ?MASTER_KEY, NewKey).
-
-all_vars(Ledger) ->
-    CF = default_cf(Ledger),
-    cache_fold(Ledger, CF,
-               fun({<<"$var_", Name/binary>>, BValue}, Acc) ->
-                       Value = binary_to_term(BValue),
-                       maps:put(Name, Value, Acc)
-               end, #{},
-               [{start, {seek, <<"$var_">>}},
-                {iterate_upper_bound, <<"$var`">>}]).
 
 vars(Vars, Unset, Ledger) ->
     DefaultCF = default_cf(Ledger),
@@ -1683,6 +1722,11 @@ get_oui_counter(Ledger) ->
             Error
     end.
 
+-spec set_oui_counter(pos_integer(), ledger()) -> ok | {error, _}.
+set_oui_counter(Count, Ledger) ->
+    DefaultCF = default_cf(Ledger),
+    cache_put(Ledger, DefaultCF, ?OUI_COUNTER, <<Count:32/little-unsigned-integer>>).
+
 -spec increment_oui_counter(ledger()) -> {ok, pos_integer()} | {error, any()}.
 increment_oui_counter(Ledger) ->
     case ?MODULE:get_oui_counter(Ledger) of
@@ -1935,7 +1979,7 @@ allocate_subnet(Size, _Itr, {error, invalid_iterator}, {LastBase, LastSize}) ->
 clean(#ledger_v1{dir=Dir, db=DB}=L) ->
     delete_context(L),
     DBDir = filename:join(Dir, ?DB_FILE),
-    ok = rocksdb:close(DB),
+    catch ok = rocksdb:close(DB),
     rocksdb:destroy(DBDir, []).
 
 close(#ledger_v1{db=DB}) ->
@@ -1978,8 +2022,11 @@ state_channel_key(ID, Owner) ->
 %% need to prefix to keep people from messing with existing names on accident
 %% @end
 %%--------------------------------------------------------------------
-var_name(Name) ->
-    <<"$var_", (atom_to_binary(Name, utf8))/binary>>.
+var_name(Name) when is_atom(Name) ->
+    <<"$var_", (atom_to_binary(Name, utf8))/binary>>;
+%% binary clause for snapshot import
+var_name(Name) when is_binary(Name) ->
+    <<"$var_", Name/binary>>.
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -2369,6 +2416,252 @@ subnet_lookup(Itr, DevAddr, {ok, <<Base:25/integer-unsigned-big, Mask:23/integer
     end;
 subnet_lookup(_, _, _) ->
     error.
+
+%% extract and load section for snapshots.  note that for determinism
+%% reasons, we need to not use maps, but sorted lists
+
+snapshot_vars(Ledger) ->
+    CF = default_cf(Ledger),
+    lists:sort(
+      maps:to_list(
+        cache_fold(
+          Ledger, CF,
+          fun({<<"$var_", Name/binary>>, BValue}, Acc) ->
+                  Value = binary_to_term(BValue),
+                  maps:put(Name, Value, Acc)
+          end, #{},
+          [{start, {seek, <<"$var_">>}},
+           {iterate_upper_bound, <<"$var`">>}]))).
+
+load_vars(Vars, Ledger) ->
+    vars(maps:from_list(Vars), [], Ledger),
+    ok.
+
+snapshot_delayed_vars(Ledger) ->
+    CF = default_cf(Ledger),
+    {ok, Height} = current_height(Ledger),
+    lists:sort(
+      maps:to_list(
+        cache_fold(
+          Ledger, CF,
+          fun({<<"$block_", HashHeightBin/binary>>, BP}, Acc) ->
+                  %% there is a long standing bug not deleting
+                  %% these lists once processed, just fixed as
+                  %% this code was written, so we need to ignore
+                  %% old ones till we're past all of this
+                  HashHeight = binary_to_integer(HashHeightBin),
+                  case HashHeight >= Height of
+                      true ->
+                          Hashes = binary_to_term(BP),
+                          Val = lists:sort(
+                                  lists:map(
+                                    fun(Hash) ->
+                                            {ok, Bin} = cache_get(Ledger, CF, Hash, []),
+                                            {Hash, binary_to_term(Bin)}
+                                    end,
+                                    Hashes)),
+                          maps:put(HashHeight, Val, Acc);
+                      false ->
+                          Acc
+                  end
+          end, #{},
+          %% we could iterate from the correct block if I had
+          %% encoded the blocks correctly, but I didn't
+          [{start, {seek, <<"$block_">>}},
+           {iterate_upper_bound, <<"$block`">>}]))).
+
+load_delayed_vars(DVars, Ledger) ->
+    CF = default_cf(Ledger),
+    maps:map(
+      fun(Height, HashesAndVars) ->
+              {Hashes, _Vars} = lists:unzip(HashesAndVars),
+              BHashes = term_to_binary(Hashes),
+              ok = cache_put(Ledger, CF, block_name(Height), BHashes),
+              lists:foreach(
+                fun({Hash, Vars}) ->
+                        cache_put(Ledger, CF, Hash, term_to_binary(Vars))
+                end, HashesAndVars)
+      end, maps:from_list(DVars)),
+    ok.
+
+snapshot_threshold_txns(Ledger) ->
+    CF = default_cf(Ledger),
+    lists:sort(scan_threshold_txns(Ledger, CF)).
+
+load_threshold_txns(Txns, Ledger) ->
+    lists:map(fun(T) -> save_threshold_txn(T, Ledger) end, Txns),
+    ok.
+
+snapshot_pocs(Ledger) ->
+    PoCsCF = pocs_cf(Ledger),
+    lists:sort(
+      maps:to_list(
+        cache_fold(
+          Ledger, PoCsCF,
+          fun({OnionKeyHash, BValue}, Acc) ->
+                  List = binary_to_term(BValue),
+                  Value = lists:map(fun blockchain_ledger_poc_v2:deserialize/1, List),
+                  maps:put(OnionKeyHash, Value, Acc)
+          end, #{},
+          []))).
+
+load_pocs(PoCs, Ledger) ->
+    PoCsCF = pocs_cf(Ledger),
+    maps:map(
+      fun(OnionHash, P) ->
+              BPoC = term_to_binary(lists:map(fun blockchain_ledger_poc_v2:serialize/1, P)),
+              cache_put(Ledger, PoCsCF, OnionHash, BPoC)
+      end,
+      maps:from_list(PoCs)),
+    ok.
+
+snapshot_accounts(Ledger) ->
+    lists:sort(maps:to_list(entries(Ledger))).
+
+load_accounts(Accounts, Ledger) ->
+    EntriesCF = entries_cf(Ledger),
+    maps:map(
+      fun(Address, Entry) ->
+              BEntry = blockchain_ledger_entry_v1:serialize(Entry),
+              cache_put(Ledger, EntriesCF, Address, BEntry)
+      end,
+      maps:from_list(Accounts)),
+    ok.
+
+snapshot_dc_accounts(Ledger) ->
+    lists:sort(maps:to_list(dc_entries(Ledger))).
+
+load_dc_accounts(DCAccounts, Ledger) ->
+    EntriesCF = dc_entries_cf(Ledger),
+    maps:map(
+      fun(Address, Entry) ->
+              BEntry = blockchain_ledger_data_credits_entry_v1:serialize(Entry),
+              cache_put(Ledger, EntriesCF, Address, BEntry)
+      end,
+      maps:from_list(DCAccounts)),
+    ok.
+
+snapshot_security_accounts(Ledger) ->
+    lists:sort(maps:to_list(securities(Ledger))).
+
+load_security_accounts(SecAccounts, Ledger) ->
+    EntriesCF = securities_cf(Ledger),
+    maps:map(
+      fun(Address, Entry) ->
+              BEntry = blockchain_ledger_security_entry_v1:serialize(Entry),
+              cache_put(Ledger, EntriesCF, Address, BEntry)
+      end,
+      maps:from_list(SecAccounts)),
+    ok.
+
+snapshot_htlcs(Ledger) ->
+    lists:sort(maps:to_list(htlcs(Ledger))).
+
+load_htlcs(HTLCs, Ledger) ->
+    HTLCsCF = htlcs_cf(Ledger),
+    maps:map(
+      fun(Address, Entry) ->
+              BEntry = blockchain_ledger_htlc_v1:serialize(Entry),
+              cache_put(Ledger, HTLCsCF, Address, BEntry)
+      end,
+      maps:from_list(HTLCs)),
+    ok.
+
+snapshot_ouis(Ledger) ->
+    RoutingCF = routing_cf(Ledger),
+    lists:sort(
+      maps:to_list(
+        cache_fold(
+          Ledger, RoutingCF,
+          fun({OUI0, BValue}, Acc) ->
+                  <<OUI:32/little-unsigned-integer>> = OUI0,
+                  Value = blockchain_ledger_routing_v1:serialize(BValue),
+                  maps:put(OUI, Value, Acc)
+          end, #{},
+          []))).
+
+load_ouis(OUIs, Ledger) ->
+    RoutingCF = routing_cf(Ledger),
+    maps:map(
+      fun(OUI, Routing) ->
+              BRouting = blockchain_ledger_routing_v1:serialize(Routing),
+              cache_put(Ledger, RoutingCF, <<OUI:32/little-unsigned-integer>>, BRouting)
+      end,
+      maps:from_list(OUIs)),
+    ok.
+
+snapshot_subnets(Ledger) ->
+    SubnetsCF = subnets_cf(Ledger),
+    lists:sort(
+      maps:to_list(
+        cache_fold(
+          Ledger, SubnetsCF,
+          fun({Subnet, OUI0}, Acc) ->
+                  <<OUI:32/little-unsigned-integer>> = OUI0,
+                  maps:put(Subnet, OUI, Acc)
+          end, #{},
+          []))).
+
+load_subnets(Subnets, Ledger) ->
+    SubnetsCF = routing_cf(Ledger),
+    maps:map(
+      fun(Subnet, OUI) ->
+              cache_put(Ledger, SubnetsCF, Subnet, <<OUI:32/little-unsigned-integer>>)
+      end,
+      maps:from_list(Subnets)),
+    ok.
+
+snapshot_state_channels(Ledger) ->
+    SCsCF = state_channels_cf(Ledger),
+    lists:sort(
+      maps:to_list(
+        cache_fold(
+          Ledger, SCsCF,
+          fun({ID, V}, Acc) ->
+                  %% do we need to decompose the ID here into Key and Owner?
+                  maps:put(ID, blockchain_ledger_state_channel_v1:deserialize(V), Acc)
+          end, #{},
+          []))).
+
+load_state_channels(SCs, Ledger) ->
+    SCsCF = state_channels_cf(Ledger),
+    maps:map(
+      fun(ID, Channel) ->
+              BChannel = blockchain_ledger_state_channel_v1:serialize(Channel),
+              cache_put(Ledger, SCsCF, ID, BChannel)
+      end,
+      maps:from_list(SCs)),
+    ok.
+
+snapshot_hexes(Ledger) ->
+    case blockchain_ledger_v1:get_hexes(Ledger) of
+        {ok, HexMap} ->
+            lists:sort(
+              maps:to_list(
+                maps:fold(
+                  fun(HexAddr, _Ct, Acc) ->
+                          {ok, Hex} = get_hex(HexAddr, Ledger),
+                          Acc#{HexAddr => Hex}
+                  end,
+                  #{list => HexMap},
+                  HexMap)));
+        {error, not_found} ->
+            []
+    end.
+
+load_hexes(Hexes0, Ledger) ->
+    case maps:take(list, maps:from_list(Hexes0)) of
+        {HexMap, Hexes} ->
+            ok = set_hexes(HexMap, Ledger),
+            maps:map(
+              fun(HexAddr, Hex) ->
+                      set_hex(HexAddr, Hex, Ledger)
+              end,
+              Hexes),
+            ok;
+        error ->
+            ok
+    end.
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -217,9 +217,9 @@ is_valid(Txn, Chain) ->
                                                                     StartLA = erlang:monotonic_time(millisecond),
                                                                     {ok, OldLedger} = blockchain:ledger_at(blockchain_block:height(Block1), Chain),
                                                                     maybe_log_duration(ledger_at, StartLA),
+                                                                    Vars = vars(OldLedger),
                                                                     Path = case blockchain:config(?poc_version, OldLedger) of
                                                                                {ok, V} when V >= 8 ->
-                                                                                   Vars = blockchain_utils:vars_binary_keys_to_atoms(blockchain_ledger_v1:all_vars(OldLedger)),
                                                                                    %% Targeting phase
                                                                                    StartFT = erlang:monotonic_time(millisecond),
                                                                                    %% Find the original target
@@ -233,7 +233,6 @@ is_valid(Txn, Chain) ->
                                                                                    RetB;
 
                                                                                {ok, V} when V >= 7 ->
-                                                                                   Vars = blockchain_utils:vars_binary_keys_to_atoms(blockchain_ledger_v1:all_vars(OldLedger)),
                                                                                    StartFT = erlang:monotonic_time(millisecond),
                                                                                    %% If we make it to this point, we are bound to have a target.
                                                                                    {ok, Target} = blockchain_poc_target_v2:target_v2(Entropy, OldLedger, Vars),
@@ -247,7 +246,6 @@ is_valid(Txn, Chain) ->
                                                                                {ok, V} when V >= 4 ->
                                                                                    StartS = erlang:monotonic_time(millisecond),
                                                                                    GatewayScoreMap = blockchain_utils:score_gateways(OldLedger),
-                                                                                   Vars = blockchain_utils:vars_binary_keys_to_atoms(blockchain_ledger_v1:all_vars(OldLedger)),
                                                                                    maybe_log_duration(scored, StartS),
 
                                                                                    Time = blockchain_block:time(Block1),
@@ -871,6 +869,10 @@ hex_poc_id(Txn) ->
     #{secret := _OnionPrivKey, public := OnionPubKey} = libp2p_crypto:keys_from_bin(?MODULE:secret(Txn)),
     <<POCID:10/binary, _/binary>> = libp2p_crypto:pubkey_to_bin(OnionPubKey),
     blockchain_utils:bin_to_hex(POCID).
+
+vars(Ledger) ->
+    blockchain_utils:vars_binary_keys_to_atoms(
+      maps:from_list(blockchain_ledger_v1:snapshot_vars(Ledger))).
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_rewards_v1.erl
+++ b/src/transactions/v1/blockchain_txn_rewards_v1.erl
@@ -638,7 +638,7 @@ rewards_test() ->
 consensus_members_rewards_test() ->
     BaseDir = test_utils:tmp_dir("consensus_members_rewards_test"),
     Block = blockchain_block:new_genesis_block([]),
-    {ok, Chain} = blockchain:new(BaseDir, Block, undefined),
+    {ok, Chain} = blockchain:new(BaseDir, Block, undefined, undefined),
     Ledger = blockchain:ledger(Chain),
     Vars = #{
         epoch_reward => 1000,
@@ -662,7 +662,7 @@ consensus_members_rewards_test() ->
 securities_rewards_test() ->
     BaseDir = test_utils:tmp_dir("securities_rewards_test"),
     Block = blockchain_block:new_genesis_block([]),
-    {ok, Chain} = blockchain:new(BaseDir, Block, undefined),
+    {ok, Chain} = blockchain:new(BaseDir, Block, undefined, undefined),
     Ledger = blockchain:ledger(Chain),
     Vars = #{
         epoch_reward => 1000,

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -52,6 +52,12 @@
 
 -endif.
 
+-ifdef(TEST).
+-define(min_snap_interval, 1).
+-else.
+-define(min_snap_interval, 720).
+-endif.
+
 -type txn_vars() :: #blockchain_txn_vars_v1_pb{}.
 -export_type([txn_vars/0]).
 
@@ -781,6 +787,23 @@ validate_var(?sc_grace_blocks, Value) ->
     validate_int(Value, "sc_grace_blocks", 1, 100, false);
 validate_var(?dc_payload_size, Value) ->
     validate_int(Value, "dc_payload_size", 1, 32, false);
+
+%% txn snapshot vars
+validate_var(?snapshot_version, Value) ->
+    case Value of
+        N when is_integer(N), N == 1 ->
+            ok;
+        _ ->
+            throw({error, {invalid_snapshot_version, Value}})
+    end;
+%% this is a copy of the lines at the top for informational value
+%% -ifdef(TEST).
+%% -define(min_snap_interval, 1).
+%% -else.
+%% -define(min_snap_interval, 720).
+%% -endif.
+validate_var(?snapshot_interval, Value) -> % half day to two weeks
+    validate_int(Value, "snapshot_interval", ?min_snap_interval, 20160, false);
 
 validate_var(Var, Value) ->
     %% something we don't understand, crash

--- a/test/blockchain_fastforward_SUITE.erl
+++ b/test/blockchain_fastforward_SUITE.erl
@@ -103,12 +103,12 @@ basic(Version, Sup, {PrivKey, PubKey}, Config) ->
     Balance = 5000,
     BlocksN = 100,
     %% create a chain
-    {ok, _GenesisMembers, ConsensusMembers, _} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
+    {ok, _GenesisMembers, _GenesisBlock, ConsensusMembers, _} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
     Chain0 = blockchain_worker:blockchain(),
     {ok, Genesis} = blockchain:genesis_block(Chain0),
 
     %% create a second chain
-    {ok, Chain} = blockchain:new(SimDir, Genesis, undefined),
+    {ok, Chain} = blockchain:new(SimDir, Genesis, undefined, undefined),
 
     % Add some blocks to the first chain
     Blocks = lists:reverse(lists:foldl(

--- a/test/blockchain_payment_v2_SUITE.erl
+++ b/test/blockchain_payment_v2_SUITE.erl
@@ -44,7 +44,8 @@ init_per_testcase(TestCase, Config) ->
 
     ExtraVars = #{?max_payments => ?MAX_PAYMENTS, ?allow_zero_amount => false},
 
-    {ok, GenesisMembers, ConsensusMembers, Keys} = test_utils:init_chain(Balance, {PrivKey, PubKey}, true, ExtraVars),
+    {ok, GenesisMembers, _GenesisBlock, ConsensusMembers, Keys} =
+        test_utils:init_chain(Balance, {PrivKey, PubKey}, true, ExtraVars),
 
     Chain = blockchain_worker:blockchain(),
     Swarm = blockchain_swarm:swarm(),

--- a/test/blockchain_snapshot_SUITE.erl
+++ b/test/blockchain_snapshot_SUITE.erl
@@ -1,0 +1,112 @@
+-module(blockchain_snapshot_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include("blockchain_vars.hrl").
+
+-export([all/0, init_per_testcase/2, end_per_testcase/2]).
+
+-define(TEST_LOCATION, 631210968840687103).
+
+-export([
+    basic_test/1
+]).
+
+-import(blockchain_utils, [normalize_float/1]).
+
+%%--------------------------------------------------------------------
+%% COMMON TEST CALLBACK FUNCTIONS
+%%--------------------------------------------------------------------
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%%   Running tests for this suite
+%% @end
+%%--------------------------------------------------------------------
+all() ->
+    [
+        basic_test
+    ].
+
+%%--------------------------------------------------------------------
+%% TEST CASE SETUP
+%%--------------------------------------------------------------------
+
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% TEST CASE TEARDOWN
+%%--------------------------------------------------------------------
+end_per_testcase(_, _Config) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% TEST CASES
+%%--------------------------------------------------------------------
+basic_test(Config) ->
+    GenesisBlock = ?config(genesis_block, Config),
+
+    Ledger = ledger(),
+    {ok, Snapshot} = blockchain_ledger_snapshot_v1:snapshot(Ledger, []),
+
+    %% make a dir for the loaded snapshot
+    {ok, Dir} = file:get_cwd(),
+    PrivDir = filename:join([Dir, "priv"]),
+    NewDir = PrivDir ++ "/ledger2/",
+    ok = filelib:ensure_dir(NewDir),
+
+    Size = byte_size(element(2, blockchain_ledger_snapshot_v1:serialize(Snapshot))),
+    SHA = blockchain_ledger_snapshot_v1:hash(Snapshot),
+    ct:pal("size ~p", [Size]),
+
+    {ok, Chain} = blockchain:new(NewDir, GenesisBlock, blessed_snapshot, undefined),
+
+    {ok, Ledger1} = blockchain_ledger_snapshot_v1:import(Chain, SHA, Snapshot),
+    {ok, Snapshot1} = blockchain_ledger_snapshot_v1:snapshot(Ledger1, []),
+
+    ?assertEqual([], blockchain_ledger_snapshot_v1:diff(Snapshot, Snapshot1)),
+    ok.
+
+
+%% utils
+
+ledger() ->
+    %% Ledger at height: 194196
+    %% ActiveGateway Count: 3023
+    {ok, Dir} = file:get_cwd(),
+    %% Ensure priv dir exists
+    PrivDir = filename:join([Dir, "priv"]),
+    ok = filelib:ensure_dir(PrivDir ++ "/"),
+    %% Path to static ledger tar
+    LedgerTar = filename:join([PrivDir, "ledger.tar.gz"]),
+    %% Extract ledger tar if required
+    ok = extract_ledger_tar(PrivDir, LedgerTar),
+    %% Get the ledger
+    Ledger = blockchain_ledger_v1:new(PrivDir),
+    Ledger1 = blockchain_ledger_v1:new_context(Ledger),
+    %% If the hexes aren't on the ledger add them
+    blockchain:bootstrap_hexes(Ledger1),
+    blockchain_ledger_v1:commit_context(Ledger1),
+    Ledger.
+
+extract_ledger_tar(PrivDir, LedgerTar) ->
+    case filelib:is_file(LedgerTar) of
+        true ->
+            %% if we have already unpacked it, no need to do it again
+            LedgerDB = filename:join([PrivDir, "ledger.db"]),
+            case filelib:is_dir(LedgerDB) of
+                true ->
+                    ok;
+                false ->
+                    %% ledger tar file present, extract
+                    erl_tar:extract(LedgerTar, [compressed, {cwd, PrivDir}])
+            end;
+        false ->
+            %% ledger tar file not found, download & extract
+            ok = ssl:start(),
+            {ok, {{_, 200, "OK"}, _, Body}} = httpc:request("https://blockchain-core.s3-us-west-1.amazonaws.com/ledger.tar.gz"),
+            ok = file:write_file(filename:join([PrivDir, "ledger.tar.gz"]), Body),
+            erl_tar:extract(LedgerTar, [compressed, {cwd, PrivDir}])
+    end.

--- a/test/blockchain_sync_SUITE.erl
+++ b/test/blockchain_sync_SUITE.erl
@@ -80,12 +80,12 @@ basic(Config) ->
     Balance = 5000,
     BlocksN = 100,
     {ok, Sup, {PrivKey, PubKey}, _Opts} = test_utils:init(BaseDir),
-    {ok, _GenesisMembers, ConsensusMembers, _} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
+    {ok, _GenesisMembers, _GenesisBlock, ConsensusMembers, _} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
     Chain0 = blockchain_worker:blockchain(),
     {ok, Genesis} = blockchain:genesis_block(Chain0),
 
     % Simulate other chain with sync handler only
-    _Chain = blockchain:new(SimDir, Genesis, undefined),
+    _Chain = blockchain:new(SimDir, Genesis, undefined, undefined),
 
     % Add some blocks
     Blocks = lists:reverse(lists:foldl(

--- a/test/plausible_block_SUITE.erl
+++ b/test/plausible_block_SUITE.erl
@@ -35,7 +35,7 @@ basic(Config) ->
     Balance = 5000,
     BlocksN = 80,
     {ok, _Sup, {PrivKey, PubKey}, _Opts} = test_utils:init(BaseDir),
-    {ok, _GenesisMembers, ConsensusMembers, _} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
+    {ok, _GenesisMembers, _GenesisBlock, ConsensusMembers, _} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
     Chain0 = blockchain_worker:blockchain(),
     {ok, Genesis} = blockchain:genesis_block(Chain0),
 
@@ -51,7 +51,7 @@ basic(Config) ->
     )),
     LastBlock = lists:last(Blocks),
 
-    {ok, Chain} = blockchain:new(SimDir, Genesis, undefined),
+    {ok, Chain} = blockchain:new(SimDir, Genesis, undefined, undefined),
 
     plausible = blockchain:can_add_block(LastBlock, Chain),
     %% check we return the plausible message to the caller
@@ -94,7 +94,7 @@ definitely_invalid(Config) ->
     Balance = 5000,
     BlocksN = 80,
     {ok, _Sup, {PrivKey, PubKey}, _Opts} = test_utils:init(BaseDir),
-    {ok, _GenesisMembers, ConsensusMembers, _} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
+    {ok, _GenesisMembers, _GenesisBlock, ConsensusMembers, _} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
     Chain0 = blockchain_worker:blockchain(),
     {ok, Genesis} = blockchain:genesis_block(Chain0),
 
@@ -114,7 +114,7 @@ definitely_invalid(Config) ->
 
     %% boot an entirely disjoint chain
     {ok, _Sup1, {PrivKey1, PubKey1}, _Opts1} = test_utils:init(BaseDir++"extra"),
-    {ok, _GenesisMembers1, _ConsensusMembers1, _} = test_utils:init_chain(Balance, {PrivKey1, PubKey1}),
+    {ok, _GenesisMembers1, _GenesisBlock2, _ConsensusMembers1, _} = test_utils:init_chain(Balance, {PrivKey1, PubKey1}),
     Chain1 = blockchain_worker:blockchain(),
 
     % Add some blocks
@@ -129,7 +129,7 @@ definitely_invalid(Config) ->
     )),
     LastBlock = lists:last(Blocks1),
 
-    {ok, Chain} = blockchain:new(SimDir, Genesis, undefined),
+    {ok, Chain} = blockchain:new(SimDir, Genesis, undefined, undefined),
 
     {error, disjoint_chain} = blockchain:can_add_block(LastBlock, Chain),
     {error, disjoint_chain} = blockchain:add_block(hd(Blocks1), Chain),
@@ -160,7 +160,7 @@ ultimately_invalid(Config) ->
     Balance = 5000,
     BlocksN = 80,
     {ok, _Sup, {PrivKey, PubKey}, _Opts} = test_utils:init(BaseDir),
-    {ok, GenesisMembers, ConsensusMembers, _} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
+    {ok, GenesisMembers, _GenesisBlock, ConsensusMembers, _} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
     Chain0 = blockchain_worker:blockchain(),
     {ok, Genesis} = blockchain:genesis_block(Chain0),
 
@@ -180,7 +180,7 @@ ultimately_invalid(Config) ->
 
     %% boot an entirely disjoint chain
     {ok, _Sup1, {PrivKey, PubKey}, _Opts1} = test_utils:init(BaseDir++"extra", {PrivKey, PubKey}),
-    {ok, _GenesisMembers, ConsensusMembers, _} = test_utils:init_chain(Balance, GenesisMembers, #{}),
+    {ok, _GenesisMembers, _GenesisBlock2, ConsensusMembers, _} = test_utils:init_chain(Balance, GenesisMembers, #{}),
     Chain1 = blockchain_worker:blockchain(),
 
     % Add some blocks
@@ -195,7 +195,7 @@ ultimately_invalid(Config) ->
     )),
     LastBlock = lists:last(Blocks1),
 
-    {ok, Chain} = blockchain:new(SimDir, Genesis, undefined),
+    {ok, Chain} = blockchain:new(SimDir, Genesis, undefined, undefined),
 
     plausible = blockchain:can_add_block(LastBlock, Chain),
     %% check we return the plausible message to the caller

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -99,7 +99,7 @@ init_chain(Balance, GenesisMembers, ExtraVars) when is_list(GenesisMembers), is_
     ?assertEqual({ok, blockchain_block:hash_block(GenesisBlock)}, blockchain:genesis_hash(Chain)),
     ?assertEqual({ok, GenesisBlock}, blockchain:genesis_block(Chain)),
     ?assertEqual({ok, 1}, blockchain:height(Chain)),
-    {ok, GenesisMembers, ConsensusMembers, Keys}.
+    {ok, GenesisMembers, GenesisBlock, ConsensusMembers, Keys}.
 
 generate_keys(N) ->
     generate_keys(N, ecc_compact).


### PR DESCRIPTION
Our current approach to following the chain is to download all blocks and then apply them to the ledger.  This takes approximately forever on the current v1 hardware.  snapshots are meant to provide a more concise starting point for hotspots so that they can come online more quickly.  for full nodes, the route of downloading and validating all of the blocks will still be available.