### PR TITLE
adjust gossip/sync strategy

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -624,7 +624,7 @@ add_block_(Block, Blockchain, Syncing) ->
                                     {error, disjoint_chain}
                             end;
                         {true, true} ->
-                            lager:info("prev hash matches the gossiped block"),
+                            lager:debug("prev hash matches the gossiped block"),
                             MyAddress = blockchain_swarm:pubkey_bin(),
                             case blockchain_ledger_v1:consensus_members(Ledger) of
                                 {error, _Reason}=Error ->

--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -570,7 +570,7 @@ maybe_sync(#state{blockchain = Chain} = State) ->
     erlang:cancel_timer(State#state.sync_timer),
     %% last block add time is relative to the system clock so as long as the local
     %% clock mostly increments this will eventually be true on a stuck node
-    SyncCooldownTime = application:get_env(blockchain, sync_cooldown_time, 75),
+    SyncCooldownTime = application:get_env(blockchain, sync_cooldown_time, 60),
     SkewedSyncCooldownTime = application:get_env(blockchain, skewed_sync_cooldown_time, 300),
     {ok, HeadBlock} = blockchain:head_block(Chain),
     Height = blockchain_block:height(HeadBlock),

--- a/src/handlers/blockchain_gossip_handler.erl
+++ b/src/handlers/blockchain_gossip_handler.erl
@@ -53,9 +53,11 @@ add_block(_Swarm, Block, Chain, Sender) ->
     lager:debug("Sender: ~p, MyAddress: ~p", [Sender, blockchain_swarm:pubkey_bin()]),
     case blockchain:add_block(Block, Chain) of
         ok ->
+            lager:info("got gossipped block ~p", [blockchain_block:height(Block)]),
             ok;
         {error, disjoint_chain} ->
-            lager:warning("gossipped block doesn't fit with our chain, will start sync if not already active"),
+            lager:warning("gossipped block ~p doesn't fit with our chain,"
+                          " will start sync if not already active", [blockchain_block:height(Block)]),
             blockchain_worker:maybe_sync(),
             ok;
         Error ->


### PR DESCRIPTION
we've been having some issues with hotpots falling out of sync due to some prior bugfixing.  there is a 5 minute cooldown on starting a new sync, added when we were having some clock skew issues that were causing spots to never manage to sync.  unfortunately, it means that if a spot misses timely gossip, which happens often, it can't sync up for five minutes after the last block.  often, when the spot does sync, it then misses gossip again and has to wait another five minutes to have another attempt to get back onto the gossip train.

this patch tries, when we're not obviously clock skewed, to use the block time rather than the last-added block time.  this should lead to quicker sync cycles and make it more likely that the spot gets back into sync and stays there.