### PR TITLE
Track active transaction manager dialers more consistently

### DIFF
--- a/src/transactions/blockchain_txn_mgr_sup.erl
+++ b/src/transactions/blockchain_txn_mgr_sup.erl
@@ -43,6 +43,6 @@ start_dialer([Parent, Txn, ConsensusMember]) ->
 stop_dialer(Pid) ->
     supervisor:terminate_child(?MODULE, Pid).
 
-stop_dialers(Pids) ->
-    [catch supervisor:terminate_child(?MODULE, Pid) || Pid <- Pids],
+stop_dialers(Dialers) ->
+    [catch supervisor:terminate_child(?MODULE, Pid) || {Pid, _Member} <- Dialers],
     ok.


### PR DESCRIPTION
The transaction manager would often lose track of the active dialers for
a transaction if a dial failed or an election happened. This is
potentially problematic in that we'd lose responses from the other
active dialers possibly leading to an orphaned transaction.

This change tracks the dialer pids associated with the member they're
dialing. When a single dialer fails, only that dialer is removed. When
an election occurs, only the dialers for deposed members are removed and
when dialing new members, the members with active dialers are excluded
from being selected as a member to dial.