### PR TITLE
Fix zero amount bug in transations

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -253,3 +253,5 @@
 -define(max_payments, max_payments).
 %% Var to switch off legacy payment txn
 -define(deprecate_payment_v1, deprecate_payment_v1).
+%% Var to allow zero amount pyament_v2 txns, set to false
+-define(allow_zero_amount, allow_zero_amount).

--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -253,5 +253,5 @@
 -define(max_payments, max_payments).
 %% Var to switch off legacy payment txn
 -define(deprecate_payment_v1, deprecate_payment_v1).
-%% Var to allow zero amount pyament_v2 txns, set to false
+%% Set this var to false to disable zero amount txns (payment_v1, payment_v2, htlc_create)
 -define(allow_zero_amount, allow_zero_amount).

--- a/src/transactions/v1/blockchain_txn_payment_v1.erl
+++ b/src/transactions/v1/blockchain_txn_payment_v1.erl
@@ -149,7 +149,17 @@ is_valid(Txn, Chain) ->
                                         {error, _}=Error0 ->
                                             Error0;
                                         {ok, MinerFee} ->
-                                            case (Amount >= 0) andalso (Fee >= MinerFee) of
+
+                                            AmountCheck = case blockchain:config(?allow_zero_amount, Ledger) of
+                                                              {ok, false} ->
+                                                                  %% check that amount is greater than 0
+                                                                  (Amount > 0) andalso (Fee >= MinerFee);
+                                                              _ ->
+                                                                  %% if undefined or true, use the old check
+                                                                  (Amount >= 0) andalso (Fee >= MinerFee)
+                                                          end,
+
+                                            case AmountCheck of
                                                 false ->
                                                     {error, invalid_transaction};
                                                 true ->

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -750,6 +750,13 @@ validate_var(?deprecate_payment_v1, Value) ->
         _ -> throw({error, {invalid_deprecate_payment_v1, Value}})
     end;
 
+validate_var(?allow_zero_amount, Value) ->
+    case Value of
+        true -> ok;
+        false -> ok;
+        _ -> throw({error, {invalid_allow_zero_amount, Value}})
+    end;
+
 validate_var(Var, Value) ->
     %% something we don't understand, crash
     invalid_var(Var, Value).

--- a/src/transactions/v2/blockchain_payment_v2.erl
+++ b/src/transactions/v2/blockchain_payment_v2.erl
@@ -25,7 +25,7 @@
 
 -spec new(Payee :: libp2p_crypto:pubkey_bin(),
           Amount :: non_neg_integer()) -> payment().
-new(Payee, Amount) when Amount > 0 ->
+new(Payee, Amount) ->
     #payment_pb{
        payee=Payee,
        amount=Amount

--- a/test/blockchain_ct_utils.erl
+++ b/test/blockchain_ct_utils.erl
@@ -315,7 +315,8 @@ raw_vars(Vars) ->
                 ?h3_max_grid_distance => 13,
                 ?h3_neighbor_res => 12,
                 ?min_score => 0.15,
-                ?reward_version => 1
+                ?reward_version => 1,
+                ?allow_zero_amount => false
                },
 
     maps:merge(DefVars, Vars).


### PR DESCRIPTION
- Adds var, `allow_zero_amount`, must be set to false to trigger new checks.
- Update tests for the same