### PR TITLE
Properly sequence dependent transactions in the transaction manager

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -1064,7 +1064,6 @@ reset_ledger(Height,
             %% new chain
             {ok, Ledger1} = blockchain_worker:new_ledger(Dir),
             Chain1 = ledger(Ledger1, Chain),
-            blockchain_worker:blockchain(Chain1),
 
             %% reapply the blocks
             Chain2 =
@@ -1100,6 +1099,8 @@ reset_ledger(Height,
               %% this will be a noop in the case where Height == TopHeight
               Chain1,
               lists:seq(1, Height)),
+
+            blockchain_worker:blockchain(Chain1),
 
             blockchain_lock:release(),
             {ok, Chain2}

--- a/src/transactions/v1/blockchain_txn_payment_v1.erl
+++ b/src/transactions/v1/blockchain_txn_payment_v1.erl
@@ -127,7 +127,6 @@ is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Payer = ?MODULE:payer(Txn),
     Payee = ?MODULE:payee(Txn),
-    Nonce = ?MODULE:nonce(Txn),
     Signature = ?MODULE:signature(Txn),
     PubKey = libp2p_crypto:bin_to_pubkey(Payer),
     BaseTxn = Txn#blockchain_txn_payment_v1_pb{signature = <<>>},
@@ -158,16 +157,7 @@ is_valid(Txn, Chain) ->
                                                         {error, _}=Error1 ->
                                                             Error1;
                                                         ok ->
-                                                            case blockchain_ledger_v1:check_balance(Payer, Amount, Ledger) of
-                                                                ok ->
-                                                                    {ok, Entry} = blockchain_ledger_v1:find_entry(Payer, Ledger),
-                                                                    case Nonce =:= blockchain_ledger_entry_v1:nonce(Entry) + 1 of
-                                                                        true -> ok;
-                                                                        false -> {error, {bad_nonce, {payment, Nonce, blockchain_ledger_entry_v1:nonce(Entry)}}}
-                                                                    end;
-                                                                Error2 ->
-                                                                    Error2
-                                                            end
+                                                            blockchain_ledger_v1:check_balance(Payer, Amount, Ledger)
                                                     end
                                             end
                                     end;

--- a/src/transactions/v2/blockchain_txn_payment_v2.erl
+++ b/src/transactions/v2/blockchain_txn_payment_v2.erl
@@ -163,7 +163,6 @@ do_is_valid_checks(Txn, Ledger, MaxPayments) ->
     Payer = ?MODULE:payer(Txn),
     Signature = ?MODULE:signature(Txn),
     Payments = ?MODULE:payments(Txn),
-    Nonce = ?MODULE:nonce(Txn),
     PubKey = libp2p_crypto:bin_to_pubkey(Payer),
     BaseTxn = Txn#blockchain_txn_payment_v2_pb{signature = <<>>},
     EncodedTxn = blockchain_txn_payment_v2_pb:encode_msg(BaseTxn),
@@ -204,15 +203,7 @@ do_is_valid_checks(Txn, Ledger, MaxPayments) ->
                                                                 {error, _}=Error1 ->
                                                                     Error1;
                                                                 ok ->
-                                                                    case blockchain_ledger_v1:check_balance(Payer, TotAmount, Ledger) of
-                                                                        ok ->
-                                                                            {ok, Entry} = blockchain_ledger_v1:find_entry(Payer, Ledger),
-                                                                            case Nonce =:= blockchain_ledger_entry_v1:nonce(Entry) + 1 of
-                                                                                true -> ok;
-                                                                                false -> {error, {bad_nonce, {payment, Nonce, blockchain_ledger_entry_v1:nonce(Entry)}}}
-                                                                            end;
-                                                                        Error2 -> Error2
-                                                                    end
+                                                                    blockchain_ledger_v1:check_balance(Payer, TotAmount, Ledger)
                                                             end
                                                     end
                                             end


### PR DESCRIPTION
When delivering a transaction to the consensus group, check if any other
transactions current in-progress are dependencies. If any are found,
submit the transaction only to members which have accepted all the
dependencies. This ensures that the dependent transactions appear in the
same buffer as their dependencies or they wait until all the
dependencies have cleared.