### PR TITLE
Optimistically re-gossip blocks if they look plausible

### DIFF
--- a/test/blockchain_dist_SUITE.erl
+++ b/test/blockchain_dist_SUITE.erl
@@ -114,7 +114,10 @@ gossip_test(Config) ->
     N = length(Nodes),
     ct:pal("N: ~p", [N]),
 
-    _ = ct_rpc:call(FirstNode, blockchain_gossip_handler, add_block, [Swarm, Block, Chain, self()]),
+    GossipGroup = ct_rpc:call(FirstNode, libp2p_swarm, gossip_group, [Swarm]),
+    GossipData = ct_rpc:call(FirstNode, blockchain_gossip_handler, gossip_data, [Swarm, Block]),
+
+    ct_rpc:call(FirstNode, libp2p_group_gossip, send, [GossipGroup, ?GOSSIP_PROTOCOL, GossipData]),
 
     ok = lists:foreach(fun(Node) ->
         ok = blockchain_ct_utils:wait_until(fun() ->

--- a/test/blockchain_keys_SUITE.erl
+++ b/test/blockchain_keys_SUITE.erl
@@ -86,7 +86,6 @@ keys_test(Config) ->
     ok = blockchain_worker:integrate_genesis_block(GenesisBlock),
 
     Chain = blockchain_worker:blockchain(),
-    Swarm = blockchain_swarm:swarm(),
 
     ok = test_utils:wait_until(fun() -> {ok, 1} =:= blockchain:height(Chain) end),
 
@@ -96,7 +95,7 @@ keys_test(Config) ->
     Tx = blockchain_txn_payment_v1:new(Payer, Recipient, 2500, 0, 1),
     SignedTx = blockchain_txn_payment_v1:sign(Tx, PayerSigFun),
     Block = test_utils:create_block(ConsensusMembers, [SignedTx]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block, Chain, self()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block}, blockchain:head_block(Chain)),

--- a/test/blockchain_payment_v2_SUITE.erl
+++ b/test/blockchain_payment_v2_SUITE.erl
@@ -99,7 +99,6 @@ single_payee_test(Config) ->
     Balance = ?config(balance, Config),
     BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
 
     %% Test a payment transaction, add a block and check balances
     [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
@@ -116,7 +115,7 @@ single_payee_test(Config) ->
     ct:pal("~s", [blockchain_txn:print(SignedTx)]),
 
     Block = test_utils:create_block(ConsensusMembers, [SignedTx]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block, Chain, self()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block}, blockchain:head_block(Chain)),
@@ -165,7 +164,6 @@ different_payees_test(Config) ->
     Balance = ?config(balance, Config),
     BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
 
     %% Test a payment transaction, add a block and check balances
     [_, {Payer, {_, PayerPrivKey, _}}, {Recipient2, _} |_] = ConsensusMembers,
@@ -186,7 +184,7 @@ different_payees_test(Config) ->
     ct:pal("~s", [blockchain_txn:print(SignedTx)]),
 
     Block = test_utils:create_block(ConsensusMembers, [SignedTx]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block, Chain, self()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block}, blockchain:head_block(Chain)),

--- a/test/blockchain_simple_SUITE.erl
+++ b/test/blockchain_simple_SUITE.erl
@@ -163,7 +163,6 @@ basic_test(Config) ->
     Balance = ?config(balance, Config),
     BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
 
     % Test a payment transaction, add a block and check balances
     [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
@@ -172,7 +171,7 @@ basic_test(Config) ->
     SigFun = libp2p_crypto:mk_sig_fun(PayerPrivKey),
     SignedTx = blockchain_txn_payment_v1:sign(Tx, SigFun),
     Block = test_utils:create_block(ConsensusMembers, [SignedTx]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block, Chain, self()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block}, blockchain:head_block(Chain)),
@@ -201,14 +200,13 @@ reload_test(Config) ->
     Sup = ?config(sup, Config),
     Opts = ?config(opts, Config),
     Chain0 = ?config(chain, Config),
-    Swarm0 = ?config(swarm, Config),
     N0 = ?config(n, Config),
 
     % Add some blocks
     lists:foreach(
         fun(_) ->
             Block = test_utils:create_block(ConsensusMembers, []),
-            _ = blockchain_gossip_handler:add_block(Swarm0, Block, Chain0, self())
+            _ = blockchain_gossip_handler:add_block(Block, Chain0, self())
         end,
         lists:seq(1, 10)
     ),
@@ -252,14 +250,13 @@ restart_test(Config) ->
     Sup = ?config(sup, Config),
     Opts = ?config(opts, Config),
     Chain0 = ?config(chain, Config),
-    Swarm0 = ?config(swarm, Config),
     {ok, GenBlock} = blockchain:head_block(Chain0),
 
     % Add some blocks
     [LastBlock| _Blocks] = lists:foldl(
         fun(_, Acc) ->
             Block = test_utils:create_block(ConsensusMembers, []),
-            _ = blockchain_gossip_handler:add_block(Swarm0, Block, Chain0, self()),
+            _ = blockchain_gossip_handler:add_block(Block, Chain0, self()),
             timer:sleep(100),
             [Block|Acc]
         end,
@@ -315,7 +312,6 @@ htlc_payee_redeem_test(Config) ->
     PubKey = ?config(pubkey, Config),
     PrivKey = ?config(privkey, Config),
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
 
     % Create a Payer
     Payer = libp2p_crypto:pubkey_to_bin(PubKey),
@@ -340,7 +336,7 @@ htlc_payee_redeem_test(Config) ->
 
     %% these transactions depend on each other, but they should be able to exist in the same block
     Block = test_utils:create_block(ConsensusMembers, [SignedCreateTx, SignedTx]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block, Chain, self()),
 
     {ok, HeadHash} = blockchain:head_hash(Chain),
     ?assertEqual(blockchain_block:hash_block(Block), HeadHash),
@@ -363,7 +359,7 @@ htlc_payee_redeem_test(Config) ->
     RedeemTx = blockchain_txn_redeem_htlc_v1:new(Payee, HTLCAddress, <<"sharkfed">>, 0),
     SignedRedeemTx = blockchain_txn_redeem_htlc_v1:sign(RedeemTx, RedeemSigFun),
     Block2 = test_utils:create_block(ConsensusMembers, [SignedRedeemTx]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block2, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block2, Chain, self()),
     timer:sleep(500), %% add block is a cast, need some time for this to happen
 
     % Check that the second block with the Redeem TX was mined properly
@@ -390,7 +386,6 @@ htlc_payer_redeem_test(Config) ->
     PubKey = ?config(pubkey, Config),
     PrivKey = ?config(privkey, Config),
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
 
     % Create a Payer
     Payer = libp2p_crypto:pubkey_to_bin(PubKey),
@@ -406,7 +401,7 @@ htlc_payer_redeem_test(Config) ->
     ?assertEqual(ok, blockchain_txn_create_htlc_v1:is_valid(SignedCreateTx, Chain)),
 
     Block = test_utils:create_block(ConsensusMembers, [SignedCreateTx]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block, Chain, self()),
 
     {ok, HeadHash} = blockchain:head_hash(Chain),
     ?assertEqual(blockchain_block:hash_block(Block), HeadHash),
@@ -426,9 +421,9 @@ htlc_payer_redeem_test(Config) ->
 
     % Mine another couple of blocks
     Block2 = test_utils:create_block(ConsensusMembers, []),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block2, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block2, Chain, self()),
     Block3 = test_utils:create_block(ConsensusMembers, []),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block3, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block3, Chain, self()),
     timer:sleep(500), %% add block is a cast, need some time for this to happen
 
     % Check we are at height 4
@@ -444,7 +439,7 @@ htlc_payer_redeem_test(Config) ->
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     SignedRedeemTx = blockchain_txn_redeem_htlc_v1:sign(RedeemTx, SigFun),
     Block4 = test_utils:create_block(ConsensusMembers, [SignedRedeemTx]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block4, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block4, Chain, self()),
 
     % Check that the Payer now owns 5000 again
     {ok, NewEntry1} = blockchain_ledger_v1:find_entry(Payer, blockchain:ledger(Chain)),
@@ -462,7 +457,6 @@ poc_request_test(Config) ->
     PrivKey = ?config(privkey, Config),
     Owner = libp2p_crypto:pubkey_to_bin(PubKey),
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
     Balance = ?config(balance, Config),
 
     Ledger = blockchain:ledger(Chain),
@@ -473,7 +467,7 @@ poc_request_test(Config) ->
     Proof = blockchain_txn_vars_v1:create_proof(Priv, VarTxn),
     VarTxn1 = blockchain_txn_vars_v1:proof(VarTxn, Proof),
     Block2 = test_utils:create_block(ConsensusMembers, [VarTxn1]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block2, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block2, Chain, self()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block2)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block2}, blockchain:head_block(Chain)),
@@ -482,7 +476,7 @@ poc_request_test(Config) ->
     lists:foreach(
         fun(_) ->
                 Block = test_utils:create_block(ConsensusMembers, []),
-                _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self())
+                _ = blockchain_gossip_handler:add_block(Block, Chain, self())
         end,
         lists:seq(1, 20)
     ),
@@ -493,7 +487,7 @@ poc_request_test(Config) ->
     BurnTx0 = blockchain_txn_token_burn_v1:new(Owner, 10, 1),
     SignedBurnTx0 = blockchain_txn_token_burn_v1:sign(BurnTx0, OwnerSigFun),
     Block23 = test_utils:create_block(ConsensusMembers, [SignedBurnTx0]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block23, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block23, Chain, self()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block23)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block23}, blockchain:head_block(Chain)),
@@ -515,7 +509,7 @@ poc_request_test(Config) ->
     SignedOwnerAddGatewayTx = blockchain_txn_add_gateway_v1:sign(AddGatewayTx, OwnerSigFun),
     SignedGatewayAddGatewayTx = blockchain_txn_add_gateway_v1:sign_request(SignedOwnerAddGatewayTx, GatewaySigFun),
     Block24 = test_utils:create_block(ConsensusMembers, [SignedGatewayAddGatewayTx]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block24, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block24, Chain, self()),
 
     {ok, HeadHash} = blockchain:head_hash(Chain),
     ?assertEqual(blockchain_block:hash_block(Block24), HeadHash),
@@ -532,7 +526,7 @@ poc_request_test(Config) ->
     SignedAssertLocationTx = blockchain_txn_assert_location_v1:sign(PartialAssertLocationTxn, OwnerSigFun),
 
     Block25 = test_utils:create_block(ConsensusMembers, [SignedAssertLocationTx]),
-    ok = blockchain_gossip_handler:add_block(Swarm, Block25, Chain, self()),
+    ok = blockchain_gossip_handler:add_block(Block25, Chain, self()),
     timer:sleep(500),
 
     {ok, HeadHash2} = blockchain:head_hash(Chain),
@@ -549,7 +543,7 @@ poc_request_test(Config) ->
     PoCReqTxn0 = blockchain_txn_poc_request_v1:new(Gateway, SecretHash0, OnionKeyHash0, blockchain_block:hash_block(Block2), 1),
     SignedPoCReqTxn0 = blockchain_txn_poc_request_v1:sign(PoCReqTxn0, GatewaySigFun),
     Block26 = test_utils:create_block(ConsensusMembers, [SignedPoCReqTxn0]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block26, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block26, Chain, self()),
     ok = blockchain_ct_utils:wait_until(fun() -> {ok, 26} =:= blockchain:height(Chain) end),
 
     Ledger = blockchain:ledger(Chain),
@@ -573,13 +567,13 @@ poc_request_test(Config) ->
     PoCReceiptsTxn = blockchain_txn_poc_receipts_v1:new(Gateway, Secret0, OnionKeyHash0, []),
     SignedPoCReceiptsTxn = blockchain_txn_poc_receipts_v1:sign(PoCReceiptsTxn, GatewaySigFun),
     Block27 = test_utils:create_block(ConsensusMembers, [SignedPoCReceiptsTxn]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block27, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block27, Chain, self()),
     ok = blockchain_ct_utils:wait_until(fun() -> {ok, 27} =:= blockchain:height(Chain) end),
 
     Block62 = lists:foldl(
         fun(_, _) ->
             B = test_utils:create_block(ConsensusMembers, []),
-            _ = blockchain_gossip_handler:add_block(Swarm, B, Chain, self()),
+            _ = blockchain_gossip_handler:add_block(B, Chain, self()),
             timer:sleep(10),
             B
         end,
@@ -598,7 +592,7 @@ poc_request_test(Config) ->
     PoCReqTxn1 = blockchain_txn_poc_request_v1:new(Gateway, SecretHash1, OnionKeyHash1, blockchain_block:hash_block(Block62), 1),
     SignedPoCReqTxn1 = blockchain_txn_poc_request_v1:sign(PoCReqTxn1, GatewaySigFun),
     Block63 = test_utils:create_block(ConsensusMembers, [SignedPoCReqTxn1]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block63, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block63, Chain, self()),
 
     ok = blockchain_ct_utils:wait_until(fun() -> {ok, 63} =:= blockchain:height(Chain) end),
 
@@ -617,14 +611,13 @@ bogus_coinbase_test(Config) ->
     Balance = ?config(balance, Config),
     [{FirstMemberAddr, _} | _] = ConsensusMembers,
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
 
     ?assertEqual({ok, 1}, blockchain:height(Chain)),
 
     %% Lets give the first member a bunch of coinbase tokens
     BogusCoinbaseTxn = blockchain_txn_coinbase_v1:new(FirstMemberAddr, 999999),
     Block2 = test_utils:create_block(ConsensusMembers, [BogusCoinbaseTxn]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block2, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block2, Chain, self()),
     timer:sleep(500),
 
     %% None of the balances should have changed
@@ -642,7 +635,6 @@ bogus_coinbase_with_good_payment_test(Config) ->
     ConsensusMembers = ?config(consensus_members, Config),
     [{FirstMemberAddr, _} | _] = ConsensusMembers,
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
 
     %% Lets give the first member a bunch of coinbase tokens
     BogusCoinbaseTxn = blockchain_txn_coinbase_v1:new(FirstMemberAddr, 999999),
@@ -655,7 +647,7 @@ bogus_coinbase_with_good_payment_test(Config) ->
     SignedGoodPaymentTxn = blockchain_txn_payment_v1:sign(Tx, SigFun),
 
     Block2 = test_utils:create_block(ConsensusMembers, [BogusCoinbaseTxn, SignedGoodPaymentTxn]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block2, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block2, Chain, self()),
     timer:sleep(500),
 
     %% Check that the chain didnt' grow
@@ -676,7 +668,6 @@ export_test(Config) ->
     Fee = 0,
     N = length(ConsensusMembers),
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
     N = ?config(n, Config),
 
     Ledger = blockchain:ledger(Chain),
@@ -687,7 +678,7 @@ export_test(Config) ->
     Proof = blockchain_txn_vars_v1:create_proof(Priv, VarTxn),
     VarTxn1 = blockchain_txn_vars_v1:proof(VarTxn, Proof),
     Block2 = test_utils:create_block(ConsensusMembers, [VarTxn1]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block2, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block2, Chain, self()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block2)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block2}, blockchain:head_block(Chain)),
@@ -696,7 +687,7 @@ export_test(Config) ->
     lists:foreach(
         fun(_) ->
                 Block = test_utils:create_block(ConsensusMembers, []),
-                _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self())
+                _ = blockchain_gossip_handler:add_block(Block, Chain, self())
         end,
         lists:seq(1, 20)
     ),
@@ -709,7 +700,7 @@ export_test(Config) ->
     BurnTx0 = blockchain_txn_token_burn_v1:new(Owner, 10, 1),
     SignedBurnTx0 = blockchain_txn_token_burn_v1:sign(BurnTx0, OwnerSigFun),
     Block23 = test_utils:create_block(ConsensusMembers, [SignedBurnTx0]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block23, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block23, Chain, self()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block23)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block23}, blockchain:head_block(Chain)),
@@ -742,7 +733,7 @@ export_test(Config) ->
     Txns0 = [SignedAssertLocationTx, PaymentTxn2, SignedGatewayAddGatewayTx, PaymentTxn1, PaymentTxn3],
     Txns1 = lists:sort(fun blockchain_txn:sort/2, Txns0),
     Block24 = test_utils:create_block(ConsensusMembers, Txns1),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block24, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block24, Chain, self()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block24)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block24}, blockchain:head_block(Chain)),
@@ -825,7 +816,6 @@ delayed_ledger_test(Config) ->
     ConsensusMembers = ?config(consensus_members, Config),
     BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
     Balance = ?config(balance, Config),
 
     Ledger = blockchain:ledger(Chain),
@@ -844,7 +834,7 @@ delayed_ledger_test(Config) ->
             Tx = blockchain_txn_payment_v1:new(Payer, Payee, 1, 0, X),
             SignedTx = blockchain_txn_payment_v1:sign(Tx, SigFun),
             B = test_utils:create_block(ConsensusMembers, [SignedTx]),
-            _ = blockchain_gossip_handler:add_block(Swarm, B, Chain, self())
+            _ = blockchain_gossip_handler:add_block(B, Chain, self())
         end,
         lists:seq(1, 100)
     ),
@@ -912,7 +902,6 @@ fees_since_test(Config) ->
     ConsensusMembers = ?config(consensus_members, Config),
     BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
 
     [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
     Payee = blockchain_swarm:pubkey_bin(),
@@ -928,7 +917,7 @@ fees_since_test(Config) ->
             Tx = blockchain_txn_payment_v1:new(Payer, Payee, 1, 1, X),
             SignedTx = blockchain_txn_payment_v1:sign(Tx, SigFun),
             B = test_utils:create_block(ConsensusMembers, [SignedTx]),
-            _ = blockchain_gossip_handler:add_block(Swarm, B, Chain, self())
+            _ = blockchain_gossip_handler:add_block(B, Chain, self())
         end,
         lists:seq(1, 100)
     ),
@@ -951,7 +940,6 @@ security_token_test(Config) ->
     Balance = ?config(balance, Config),
     BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
 
     % Test a payment transaction, add a block and check balances
     [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
@@ -960,7 +948,7 @@ security_token_test(Config) ->
     SigFun = libp2p_crypto:mk_sig_fun(PayerPrivKey),
     SignedTx = blockchain_txn_security_exchange_v1:sign(Tx, SigFun),
     Block = test_utils:create_block(ConsensusMembers, [SignedTx]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block, Chain, self()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block}, blockchain:head_block(Chain)),
@@ -1004,7 +992,7 @@ routing_test(Config) ->
     ?assertEqual({error, not_found}, blockchain_ledger_v1:find_routing(OUI1, Ledger)),
 
     Block0 = test_utils:create_block(ConsensusMembers, [SignedOUITxn0]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block0, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block0, Chain, self()),
 
     ok = test_utils:wait_until(fun() -> {ok, 2} == blockchain:height(Chain) end),
 
@@ -1015,7 +1003,7 @@ routing_test(Config) ->
     OUITxn2 = blockchain_txn_routing_v1:new(OUI1, Payer, Addresses1, 0, 1),
     SignedOUITxn2 = blockchain_txn_routing_v1:sign(OUITxn2, SigFun),
     Block1 = test_utils:create_block(ConsensusMembers, [SignedOUITxn2]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block1, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block1, Chain, self()),
 
     ok = test_utils:wait_until(fun() -> {ok, 3} == blockchain:height(Chain) end),
 
@@ -1030,7 +1018,7 @@ routing_test(Config) ->
     ?assertEqual({error, not_found}, blockchain_ledger_v1:find_routing(OUI2, Ledger)),
 
     Block2 = test_utils:create_block(ConsensusMembers, [SignedOUITxn3]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block2, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block2, Chain, self()),
 
     ok = test_utils:wait_until(fun() -> {ok, 4} == blockchain:height(Chain) end),
 
@@ -1055,7 +1043,6 @@ block_save_failed_test(Config) ->
     Balance = ?config(balance, Config),
     BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
 
      % Test a payment transaction, add a block and check balances
     [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
@@ -1068,10 +1055,10 @@ block_save_failed_test(Config) ->
     meck:new(blockchain, [passthrough]),
     meck:expect(blockchain, save_block, fun(_, _) -> erlang:error(boom) end),
     {ok, OldHeight} = blockchain:height(Chain),
-    blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+    blockchain_gossip_handler:add_block(Block, Chain, self()),
     meck:unload(blockchain),
     blockchain_lock:release(),
-    ok = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+    ok = blockchain_gossip_handler:add_block(Block, Chain, self()),
     {ok, NewHeight} = blockchain:height(Chain),
     ?assert(NewHeight == OldHeight + 1),
 
@@ -1100,7 +1087,6 @@ absorb_failed_test(Config) ->
     Balance = ?config(balance, Config),
     BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
 
     % Test a payment transaction, add a block and check balances
     [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
@@ -1115,7 +1101,7 @@ absorb_failed_test(Config) ->
         ct:pal("BOOM"),
         erlang:error(boom)
     end),
-    blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+    blockchain_gossip_handler:add_block(Block, Chain, self()),
     meck:unload(blockchain),
     Ledger = blockchain:ledger(Chain),
 
@@ -1126,13 +1112,13 @@ absorb_failed_test(Config) ->
     ?assertEqual({ok, Block}, blockchain:get_block(2, Chain)),
 
     ct:pal("Try to re-add block 1 will cause the mismatch"),
-    ok = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+    ok = blockchain_gossip_handler:add_block(Block, Chain, self()),
 
     ok = test_utils:wait_until(fun() -> {ok, 2} =:= blockchain:height(Chain) end),
     ok = test_utils:wait_until(fun() -> {ok, 2} =:= blockchain_ledger_v1:current_height(Ledger) end),
 
     ct:pal("Try to re-add block 2"),
-    ok = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+    ok = blockchain_gossip_handler:add_block(Block, Chain, self()),
 
     ok = test_utils:wait_until(fun() -> {ok, 2} =:= blockchain:height(Chain) end),
     ok = test_utils:wait_until(fun() -> {ok, 2} =:= blockchain_ledger_v1:current_height(Ledger) end),
@@ -1155,7 +1141,6 @@ missing_last_block_test(Config) ->
     Balance = ?config(balance, Config),
     BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
 
     % Test a payment transaction, add a block and check balances
     [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
@@ -1169,7 +1154,7 @@ missing_last_block_test(Config) ->
             %% just don't save it
             ok
     end),
-    blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+    blockchain_gossip_handler:add_block(Block, Chain, self()),
     meck:unload(blockchain),
     Ledger = blockchain:ledger(Chain),
     {ok, GenesisBlock} = blockchain:genesis_block(Chain),
@@ -1181,13 +1166,13 @@ missing_last_block_test(Config) ->
     ?assertEqual({error, not_found}, blockchain:get_block(2, Chain)),
 
     ct:pal("Try to re-add block 1 will cause the mismatch"),
-    ok = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+    ok = blockchain_gossip_handler:add_block(Block, Chain, self()),
 
     ok = test_utils:wait_until(fun() -> {ok, 2} =:= blockchain:height(Chain) end),
     ok = test_utils:wait_until(fun() -> {ok, 2} =:= blockchain_ledger_v1:current_height(Ledger) end),
 
     ct:pal("Try to re-add block 2"),
-    ok = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+    ok = blockchain_gossip_handler:add_block(Block, Chain, self()),
 
     ok = test_utils:wait_until(fun() -> {ok, 2} =:= blockchain:height(Chain) end),
     ok = test_utils:wait_until(fun() -> {ok, 2} =:= blockchain_ledger_v1:current_height(Ledger) end),
@@ -1215,7 +1200,6 @@ epoch_reward_test(Config) ->
     ConsensusMembers = ?config(consensus_members, Config),
     BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
 
     [_, {PubKeyBin, {_, _PrivKey, _}}|_] = ConsensusMembers,
 
@@ -1244,7 +1228,7 @@ epoch_reward_test(Config) ->
                     [POCReceiptTxn]
             end,
             B = test_utils:create_block(ConsensusMembers, Txns),
-            _ = blockchain_gossip_handler:add_block(Swarm, B, Chain, self()),
+            _ = blockchain_gossip_handler:add_block(B, Chain, self()),
             [B|Acc]
         end,
         [],
@@ -1254,7 +1238,7 @@ epoch_reward_test(Config) ->
     ct:pal("rewards ~p", [Rewards]),
     Tx = blockchain_txn_rewards_v1:new(Start, End, Rewards),
     B = test_utils:create_block(ConsensusMembers, [Tx]),
-    _ = blockchain_gossip_handler:add_block(Swarm, B, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(B, Chain, self()),
 
     Ledger = blockchain:ledger(Chain),
     {ok, Entry} = blockchain_ledger_v1:find_entry(PubKeyBin, Ledger),
@@ -1344,7 +1328,6 @@ election_v3_test(Config) ->
     BaseDir = ?config(base_dir, Config),
     %% Chain = ?config(chain, Config),
     Chain = blockchain_worker:blockchain(),
-    Swarm = ?config(swarm, Config),
     N = 7,
 
     %% make sure our generated alpha & beta values are the same each time
@@ -1402,7 +1385,7 @@ election_v3_test(Config) ->
       fun(_) ->
               Block = test_utils:create_block(ConsensusMembers, [], #{seen_votes => Seen,
                                                                       bba_completion => BBA}),
-              _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self())
+              _ = blockchain_gossip_handler:add_block(Block, Chain, self())
       end,
       lists:seq(1, BlockCt)
     ),
@@ -1478,7 +1461,6 @@ election_v3_test(Config) ->
 chain_vars_test(Config) ->
     ConsensusMembers = ?config(consensus_members, Config),
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
     {Priv, _} = ?config(master_key, Config),
 
     Ledger = blockchain:ledger(Chain),
@@ -1492,7 +1474,7 @@ chain_vars_test(Config) ->
     VarTxn1 = blockchain_txn_vars_v1:proof(VarTxn, Proof),
 
     InitBlock = test_utils:create_block(ConsensusMembers, [VarTxn1]),
-    _ = blockchain_gossip_handler:add_block(Swarm, InitBlock, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(InitBlock, Chain, self()),
 
     {ok, Delay} = blockchain:config(?vars_commit_delay, Ledger),
     ct:pal("commit delay ~p", [Delay]),
@@ -1500,7 +1482,7 @@ chain_vars_test(Config) ->
     lists:foreach(
         fun(_) ->
                 Block = test_utils:create_block(ConsensusMembers, []),
-                _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+                _ = blockchain_gossip_handler:add_block(Block, Chain, self()),
                 {ok, Height} = blockchain:height(Chain),
                 case blockchain:config(poc_version, Ledger) of % ignore "?"
                     {error, not_found} when Height < (Delay + 1) ->
@@ -1519,7 +1501,6 @@ chain_vars_test(Config) ->
 chain_vars_set_unset_test(Config) ->
     ConsensusMembers = ?config(consensus_members, Config),
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
     {Priv, _} = ?config(master_key, Config),
 
     Ledger = blockchain:ledger(Chain),
@@ -1533,7 +1514,7 @@ chain_vars_set_unset_test(Config) ->
     VarTxn1 = blockchain_txn_vars_v1:proof(VarTxn, Proof),
 
     InitBlock = test_utils:create_block(ConsensusMembers, [VarTxn1]),
-    _ = blockchain_gossip_handler:add_block(Swarm, InitBlock, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(InitBlock, Chain, self()),
 
     {ok, Delay} = blockchain:config(?vars_commit_delay, Ledger),
     ct:pal("commit delay ~p", [Delay]),
@@ -1541,7 +1522,7 @@ chain_vars_set_unset_test(Config) ->
     lists:foreach(
         fun(_) ->
                 Block = test_utils:create_block(ConsensusMembers, []),
-                _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+                _ = blockchain_gossip_handler:add_block(Block, Chain, self()),
                 {ok, Height} = blockchain:height(Chain),
                 case blockchain:config(poc_version, Ledger) of % ignore "?"
                     {error, not_found} when Height < (Delay + 1) ->
@@ -1563,12 +1544,12 @@ chain_vars_set_unset_test(Config) ->
     UnsetVarTxn1 = blockchain_txn_vars_v1:proof(UnsetVarTxn, UnsetProof),
 
     NewBlock = test_utils:create_block(ConsensusMembers, [UnsetVarTxn1]),
-    _ = blockchain_gossip_handler:add_block(Swarm, NewBlock, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(NewBlock, Chain, self()),
     %% Add some blocks,
     lists:foreach(
         fun(_) ->
                 Block1 = test_utils:create_block(ConsensusMembers, []),
-                _ = blockchain_gossip_handler:add_block(Swarm, Block1, Chain, self()),
+                _ = blockchain_gossip_handler:add_block(Block1, Chain, self()),
                 {ok, Height1} = blockchain:height(Chain),
                 ct:pal("Height1 ~p", [Height1]),
                 case blockchain:config(poc_version, Ledger) of % ignore "?"
@@ -1597,7 +1578,6 @@ token_burn_test(Config) ->
     Balance = ?config(balance, Config),
     BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
 
     [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
     Recipient = blockchain_swarm:pubkey_bin(),
@@ -1608,7 +1588,7 @@ token_burn_test(Config) ->
     Tx0 = blockchain_txn_payment_v1:new(Payer, Recipient, 2500, 0, 1),
     SignedTx0 = blockchain_txn_payment_v1:sign(Tx0, SigFun),
     Block2 = test_utils:create_block(ConsensusMembers, [SignedTx0]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block2, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block2, Chain, self()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block2)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block2}, blockchain:head_block(Chain)),
@@ -1623,7 +1603,7 @@ token_burn_test(Config) ->
     BurnTx0 = blockchain_txn_token_burn_v1:new(Payer, 10, 2),
     SignedBurnTx0 = blockchain_txn_token_burn_v1:sign(BurnTx0, SigFun),
     FailedBlock = test_utils:create_block(ConsensusMembers, [SignedBurnTx0]),
-    _ = blockchain_gossip_handler:add_block(Swarm, FailedBlock, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(FailedBlock, Chain, self()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block2)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block2}, blockchain:head_block(Chain)),
@@ -1640,7 +1620,7 @@ token_burn_test(Config) ->
     Proof = blockchain_txn_vars_v1:create_proof(Priv, VarTxn),
     VarTxn1 = blockchain_txn_vars_v1:proof(VarTxn, Proof),
     Block3 = test_utils:create_block(ConsensusMembers, [VarTxn1]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block3, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block3, Chain, self()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block3)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block3}, blockchain:head_block(Chain)),
@@ -1649,7 +1629,7 @@ token_burn_test(Config) ->
     lists:foreach(
         fun(_) ->
                 Block = test_utils:create_block(ConsensusMembers, []),
-                _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self())
+                _ = blockchain_gossip_handler:add_block(Block, Chain, self())
         end,
         lists:seq(1, 20)
     ),
@@ -1657,7 +1637,7 @@ token_burn_test(Config) ->
 
     % Step 4: Retry token burn txn should pass now
     Block24 = test_utils:create_block(ConsensusMembers, [SignedBurnTx0]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block24, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block24, Chain, self()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block24)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block24}, blockchain:head_block(Chain)),
@@ -1673,7 +1653,7 @@ token_burn_test(Config) ->
     Tx1 = blockchain_txn_payment_v1:new(Payer, Recipient, 500, Fee, 3),
     SignedTx1 = blockchain_txn_payment_v1:sign(Tx1, SigFun),
     Block25 = test_utils:create_block(ConsensusMembers, [SignedTx1]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block25, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block25, Chain, self()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block25)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block25}, blockchain:head_block(Chain)),
@@ -1716,7 +1696,7 @@ payer_test(Config) ->
     Proof = blockchain_txn_vars_v1:create_proof(Priv, VarTxn),
     VarTxn1 = blockchain_txn_vars_v1:proof(VarTxn, Proof),
     Block2 = test_utils:create_block(ConsensusMembers, [VarTxn1]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block2, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block2, Chain, self()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block2)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block2}, blockchain:head_block(Chain)),
@@ -1725,7 +1705,7 @@ payer_test(Config) ->
     Blocks = lists:map(
                fun(_) ->
                        Block = test_utils:create_block(ConsensusMembers, []),
-                       _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self()),
+                       _ = blockchain_gossip_handler:add_block(Block, Chain, self()),
                        Block
                end,
                lists:seq(1, 20)),
@@ -1736,7 +1716,7 @@ payer_test(Config) ->
     BurnTx0 = blockchain_txn_token_burn_v1:new(Payer, 10, 1),
     SignedBurnTx0 = blockchain_txn_token_burn_v1:sign(BurnTx0, PayerSigFun),
     Block23 = test_utils:create_block(ConsensusMembers, [SignedBurnTx0]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block23, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block23, Chain, self()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block23)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block23}, blockchain:head_block(Chain)),
@@ -1769,7 +1749,7 @@ payer_test(Config) ->
     SignedAssertLocationTx2 = blockchain_txn_assert_location_v1:sign_payer(SignedAssertLocationTx1, PayerSigFun),
 
     Block24 = test_utils:create_block(ConsensusMembers, [SignedOUITxn1, SignedAddGatewayTx2, SignedAssertLocationTx2]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block24, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block24, Chain, self()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block24)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block24}, blockchain:head_block(Chain)),
@@ -1824,7 +1804,6 @@ poc_sync_interval_test(Config) ->
     PrivKey = ?config(privkey, Config),
     Owner = libp2p_crypto:pubkey_to_bin(PubKey),
     Chain = ?config(chain, Config),
-    Swarm = ?config(swarm, Config),
     Balance = ?config(balance, Config),
 
     Ledger = blockchain:ledger(Chain),
@@ -1832,14 +1811,14 @@ poc_sync_interval_test(Config) ->
     {Priv, _} = ?config(master_key, Config),
     VarTxn = fake_var_txn(Priv, 3, #{token_burn_exchange_rate => Rate}),
     Block2 = test_utils:create_block(ConsensusMembers, [VarTxn]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block2, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block2, Chain, self()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block2)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block2}, blockchain:head_block(Chain)),
     ?assertEqual({ok, 2}, blockchain:height(Chain)),
     ?assertEqual({ok, Block2}, blockchain:get_block(2, Chain)),
 
-    ok = dump_empty_blocks(Chain, ConsensusMembers, Swarm, 20),
+    ok = dump_empty_blocks(Chain, ConsensusMembers, 20),
 
     ?assertEqual({ok, Rate}, blockchain_ledger_v1:config(?token_burn_exchange_rate, Ledger)),
 
@@ -1848,7 +1827,7 @@ poc_sync_interval_test(Config) ->
     BurnTx0 = blockchain_txn_token_burn_v1:new(Owner, 10, 1),
     SignedBurnTx0 = blockchain_txn_token_burn_v1:sign(BurnTx0, OwnerSigFun),
     Block23 = test_utils:create_block(ConsensusMembers, [SignedBurnTx0]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block23, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block23, Chain, self()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block23)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block23}, blockchain:head_block(Chain)),
@@ -1870,7 +1849,7 @@ poc_sync_interval_test(Config) ->
 
     %% Put the txns in a block
     Block24 = test_utils:create_block(ConsensusMembers, Txns),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block24, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block24, Chain, self()),
 
     %% Check chain moved ahead
     {ok, HeadHash} = blockchain:head_hash(Chain),
@@ -1897,13 +1876,13 @@ poc_sync_interval_test(Config) ->
 
     %% Forge a chain var block
     Block25 = test_utils:create_block(ConsensusMembers, [VarTxn2]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block25, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block25, Chain, self()),
 
     %% Wait for things to settle
     timer:sleep(500),
 
     %% Dump some more blocks
-    ok = dump_empty_blocks(Chain, ConsensusMembers, Swarm, 20),
+    ok = dump_empty_blocks(Chain, ConsensusMembers, 20),
 
     %% Chain vars should have kicked in by now
     ?assertEqual({ok, POCVersion},
@@ -1921,10 +1900,10 @@ poc_sync_interval_test(Config) ->
     {ok, BlockHash} = blockchain:head_hash(Chain),
     POCReqTxn = fake_poc_request(Gateway, GatewaySigFun, BlockHash),
     Block46 = test_utils:create_block(ConsensusMembers, [POCReqTxn]),
-    _ = blockchain_gossip_handler:add_block(Swarm, Block46, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block46, Chain, self()),
 
     %% Dump a couple more blocks
-    ok = dump_empty_blocks(Chain, ConsensusMembers, Swarm, 2),
+    ok = dump_empty_blocks(Chain, ConsensusMembers, 2),
 
     %% Check last_poc_challenge for added gateway is updated
     {ok, AddedGw2} = blockchain_ledger_v1:find_gateway_info(Gateway, Ledger),
@@ -1936,7 +1915,7 @@ poc_sync_interval_test(Config) ->
     ?assertEqual(true, blockchain_poc_path:check_sync(AddedGw3, Ledger)),
 
     %% Dump even more blocks to make it ineligible again
-    ok = dump_empty_blocks(Chain, ConsensusMembers, Swarm, 20),
+    ok = dump_empty_blocks(Chain, ConsensusMembers, 20),
     {ok, AddedGw4} = blockchain_ledger_v1:find_gateway_info(Gateway, Ledger),
     ?assertEqual(false, blockchain_poc_path:check_sync(AddedGw4, Ledger)),
 
@@ -2052,11 +2031,11 @@ fake_var_txn(Priv, Nonce, Vars) ->
     Proof = blockchain_txn_vars_v1:create_proof(Priv, VarTxn),
     blockchain_txn_vars_v1:proof(VarTxn, Proof).
 
-dump_empty_blocks(Chain, ConsensusMembers, Swarm, Count) ->
+dump_empty_blocks(Chain, ConsensusMembers, Count) ->
     lists:foreach(
         fun(_) ->
                 Block = test_utils:create_block(ConsensusMembers, []),
-                _ = blockchain_gossip_handler:add_block(Swarm, Block, Chain, self())
+                _ = blockchain_gossip_handler:add_block(Block, Chain, self())
         end,
         lists:seq(1, Count)
     ).

--- a/test/blockchain_sync_SUITE.erl
+++ b/test/blockchain_sync_SUITE.erl
@@ -70,7 +70,7 @@ basic(Config) ->
     Blocks = lists:reverse(lists:foldl(
         fun(_, Acc) ->
             Block = test_utils:create_block(ConsensusMembers, []),
-            _ = blockchain_gossip_handler:add_block(blockchain_swarm:swarm(), Block, Chain0,  blockchain_swarm:pubkey_bin()),
+            _ = blockchain_gossip_handler:add_block(Block, Chain0,  blockchain_swarm:pubkey_bin()),
             [Block|Acc]
         end,
         [],
@@ -89,7 +89,7 @@ basic(Config) ->
     ok = test_utils:wait_until(fun() -> erlang:length(libp2p_peerbook:values(libp2p_swarm:peerbook(blockchain_swarm:swarm()))) > 1 end),
 
     % Simulate add block from other chain
-    _ = blockchain_gossip_handler:add_block(SimSwarm, LastBlock, Chain0, libp2p_swarm:pubkey_bin(SimSwarm)),
+    _ = blockchain_gossip_handler:add_block(LastBlock, Chain0, libp2p_swarm:pubkey_bin(SimSwarm)),
 
     ok = test_utils:wait_until(fun() ->{ok, BlocksN + 1} =:= blockchain:height(Chain0) end),
     ?assertEqual({ok, LastBlock}, blockchain:head_block(blockchain_worker:blockchain())),


### PR DESCRIPTION
This tries to simplify the block re-gossip mechanism and doesn't put it
behind absorbing the block. If the block passes the is_plausible checks
(height and signatures), immediately re-gossip it.