### PR TITLE
enable standalone test runs of FF and Sync

### DIFF
--- a/test/blockchain_ct_utils.erl
+++ b/test/blockchain_ct_utils.erl
@@ -17,6 +17,7 @@
          get_config/2,
          random_n/2,
          init_per_testcase/2,
+         init_per_suite/1,
          end_per_testcase/2,
          create_vars/0, create_vars/1,
          raw_vars/1,
@@ -156,6 +157,14 @@ random_n(N, List) ->
 
 shuffle(List) ->
     [x || {_,x} <- lists:sort([{rand:uniform(), N} || N <- List])].
+
+init_per_suite(Config) ->
+    application:ensure_all_started(ranch),
+    application:set_env(lager, error_logger_flush_queue, false),
+    application:ensure_all_started(lager),
+    lager:set_loglevel(lager_console_backend, debug),
+    application:ensure_all_started(throttle),
+    Config.
 
 init_per_testcase(TestCase, Config) ->
 

--- a/test/blockchain_fastforward_SUITE.erl
+++ b/test/blockchain_fastforward_SUITE.erl
@@ -6,7 +6,11 @@
 -include("blockchain.hrl").
 
 -export([
-    all/0, init_per_testcase/2, end_per_testcase/2
+    all/0,
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_testcase/2,
+    end_per_testcase/2
 ]).
 
 -export([
@@ -26,6 +30,18 @@
 %%--------------------------------------------------------------------
 all() ->
     [basic].
+
+%%--------------------------------------------------------------------
+%% TEST SUITE SETUP
+%%--------------------------------------------------------------------
+init_per_suite(Config) ->
+    blockchain_ct_utils:init_per_suite(Config).
+
+%%--------------------------------------------------------------------
+%% TEST SUITE TEARDOWN
+%%--------------------------------------------------------------------
+end_per_suite(Config) ->
+    Config.
 
 %%--------------------------------------------------------------------
 %% TEST CASE SETUP

--- a/test/blockchain_sync_SUITE.erl
+++ b/test/blockchain_sync_SUITE.erl
@@ -6,7 +6,11 @@
 -include("blockchain.hrl").
 
 -export([
-    all/0, init_per_testcase/2, end_per_testcase/2
+    all/0,
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_testcase/2,
+    end_per_testcase/2
 ]).
 
 -export([
@@ -25,6 +29,19 @@
 %%--------------------------------------------------------------------
 all() ->
     [basic].
+
+%%--------------------------------------------------------------------
+%% TEST SUITE SETUP
+%%--------------------------------------------------------------------
+init_per_suite(Config) ->
+    blockchain_ct_utils:init_per_suite(Config).
+
+%%--------------------------------------------------------------------
+%% TEST SUITE TEARDOWN
+%%--------------------------------------------------------------------
+end_per_suite(Config) ->
+    Config.
+
 
 %%--------------------------------------------------------------------
 %% TEST CASE SETUP


### PR DESCRIPTION
The FF and Sync common tests would not setup successfully if attempted to run standalone.  This was due to throttle and ranch apps not being started.  They would run when the full suite of tests were run as these apps were previously started by another test run and we had contagion carrying forward.