### PR TITLE
Return fast if we already have the gossipped block

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -1738,8 +1738,8 @@ is_block_plausible(Block, Chain) ->
     Ledger = ledger(Chain),
     BlockHeight = blockchain_block:height(Block),
     {ok, ChainHeight} = blockchain:height(Chain),
-    %% check the block is higher than our chain height
-    case BlockHeight > ChainHeight of
+    %% check the block is higher than our chain height but not unreasonably so
+    case BlockHeight > ChainHeight andalso BlockHeight < ChainHeight + 90 of
         true ->
             case blockchain_ledger_v1:consensus_members(Ledger) of
                 {error, _Reason} ->

--- a/src/handlers/blockchain_gossip_handler.erl
+++ b/src/handlers/blockchain_gossip_handler.erl
@@ -43,7 +43,7 @@ handle_gossip_data(_StreamPid, Data, [Swarm, Blockchain]) ->
                     true ->
                         %% already got this block, just return
                         ok;
-                    false ->
+                    _ ->
                         case blockchain:is_block_plausible(Block, Blockchain) of
                             true ->
                                 lager:debug("Got block: ~p from: ~p", [Block, From]),
@@ -69,6 +69,8 @@ handle_gossip_data(_StreamPid, Data, [Swarm, Blockchain]) ->
 
 add_block(Block, Chain, Sender) ->
     lager:debug("Sender: ~p, MyAddress: ~p", [Sender, blockchain_swarm:pubkey_bin()]),
+    %% try to acquire the lock with a timeout, will crash this process if we can't get the lock
+    ok = blockchain_lock:acquire(5000),
     case blockchain:add_block(Block, Chain) of
         ok ->
             lager:info("got gossipped block ~p", [blockchain_block:height(Block)]),

--- a/test/plausible_block_SUITE.erl
+++ b/test/plausible_block_SUITE.erl
@@ -33,7 +33,7 @@ basic(Config) ->
     SimDir = ?config(sim_dir, Config),
 
     Balance = 5000,
-    BlocksN = 100,
+    BlocksN = 80,
     {ok, _Sup, {PrivKey, PubKey}, _Opts} = test_utils:init(BaseDir),
     {ok, _GenesisMembers, ConsensusMembers, _} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
     Chain0 = blockchain_worker:blockchain(),
@@ -69,8 +69,8 @@ basic(Config) ->
     %% add all the rest of the blocks (emulate a sync)
     ok = blockchain:add_blocks(Blocks -- [LastBlock], Chain),
     %% check the plausible block is now the head of the chain
-    ?assertEqual({ok, 101}, blockchain:height(Chain)),
-    ?assertEqual({ok, 101}, blockchain:sync_height(Chain)),
+    ?assertEqual({ok, 81}, blockchain:height(Chain)),
+    ?assertEqual({ok, 81}, blockchain:sync_height(Chain)),
     ?assertEqual(blockchain:head_hash(Chain), {ok, blockchain_block:hash_block(LastBlock)}),
     %% make sure the plausible blocks got removed
     [] = blockchain:get_plausible_blocks(Chain),
@@ -78,8 +78,8 @@ basic(Config) ->
     FinalBlock = test_utils:create_block(ConsensusMembers, []),
     blockchain:add_block(FinalBlock, Chain0),
     ok = blockchain:add_block(FinalBlock, Chain),
-    ?assertEqual({ok, 102}, blockchain:height(Chain)),
-    ?assertEqual({ok, 102}, blockchain:sync_height(Chain)),
+    ?assertEqual({ok, 82}, blockchain:height(Chain)),
+    ?assertEqual({ok, 82}, blockchain:sync_height(Chain)),
     ?assertEqual(blockchain:head_hash(Chain), {ok, blockchain_block:hash_block(FinalBlock)}),
     [] = blockchain:get_plausible_blocks(Chain),
     %% try adding the previously plausible block again, it should not work
@@ -92,7 +92,7 @@ definitely_invalid(Config) ->
     SimDir = ?config(sim_dir, Config),
 
     Balance = 5000,
-    BlocksN = 100,
+    BlocksN = 80,
     {ok, _Sup, {PrivKey, PubKey}, _Opts} = test_utils:init(BaseDir),
     {ok, _GenesisMembers, ConsensusMembers, _} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
     Chain0 = blockchain_worker:blockchain(),
@@ -144,8 +144,8 @@ definitely_invalid(Config) ->
     %% add all the rest of the blocks (emulate a sync)
     ok = blockchain:add_blocks(Blocks, Chain),
     %% check the plausible block is not the head of the chain
-    ?assertEqual({ok, 101}, blockchain:height(Chain)),
-    ?assertEqual({ok, 101}, blockchain:sync_height(Chain)),
+    ?assertEqual({ok, 81}, blockchain:height(Chain)),
+    ?assertEqual({ok, 81}, blockchain:sync_height(Chain)),
     ?assertEqual(blockchain:head_hash(Chain), {ok, blockchain_block:hash_block(lists:last(Blocks))}),
     %% make sure the plausible block is not in the chain at all
     {error, not_found} = blockchain:get_block(blockchain_block:hash_block(LastBlock), Chain),
@@ -158,7 +158,7 @@ ultimately_invalid(Config) ->
     SimDir = ?config(sim_dir, Config),
 
     Balance = 5000,
-    BlocksN = 100,
+    BlocksN = 80,
     {ok, _Sup, {PrivKey, PubKey}, _Opts} = test_utils:init(BaseDir),
     {ok, GenesisMembers, ConsensusMembers, _} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
     Chain0 = blockchain_worker:blockchain(),
@@ -215,8 +215,8 @@ ultimately_invalid(Config) ->
     %% add all the rest of the blocks (emulate a sync)
     ok = blockchain:add_blocks(Blocks, Chain),
     %% check the plausible block is not the head of the chain
-    ?assertEqual({ok, 101}, blockchain:height(Chain)),
-    ?assertEqual({ok, 101}, blockchain:sync_height(Chain)),
+    ?assertEqual({ok, 81}, blockchain:height(Chain)),
+    ?assertEqual({ok, 81}, blockchain:sync_height(Chain)),
     ?assertEqual(blockchain:head_hash(Chain), {ok, blockchain_block:hash_block(lists:last(Blocks))}),
     %% make sure the plausible block is not in the chain at all
     {error, not_found} = blockchain:get_block(blockchain_block:hash_block(LastBlock), Chain),


### PR DESCRIPTION
Instead of acquiring the blockchain lock and doing other expensive
thinga, and potentially regossiping a block several time, short circuit
out of the block gossip handler if we already have the block stored in
the blockchain.