### PR TITLE
Only gossip a block if it's really new to us

### DIFF
--- a/src/handlers/blockchain_gossip_handler.erl
+++ b/src/handlers/blockchain_gossip_handler.erl
@@ -17,7 +17,7 @@
 -export([
          init_gossip_data/1,
          handle_gossip_data/3,
-         add_block/3,
+         add_block/4,
          gossip_data/2
         ]).
 
@@ -48,13 +48,8 @@ handle_gossip_data(_StreamPid, Data, [Swarm, Blockchain]) ->
                             true ->
                                 lager:debug("Got block: ~p from: ~p", [Block, From]),
                                 %% don't block the gossip server
-                                spawn(fun() -> add_block(Block, Blockchain, From) end),
-                                %% pass it along
-                                libp2p_group_gossip:send(
-                                  libp2p_swarm:gossip_group(Swarm),
-                                  ?GOSSIP_PROTOCOL,
-                                  blockchain_gossip_handler:gossip_data(Swarm, Block)
-                                 );
+                                spawn(fun() -> add_block(Block, Blockchain, From, Swarm) end),
+                                ok;
                             false ->
                                 blockchain_worker:maybe_sync(),
                                 ok
@@ -67,17 +62,23 @@ handle_gossip_data(_StreamPid, Data, [Swarm, Blockchain]) ->
     end,
     noreply.
 
-add_block(Block, Chain, Sender) ->
+add_block(Block, Chain, Sender, Swarm) ->
     lager:debug("Sender: ~p, MyAddress: ~p", [Sender, blockchain_swarm:pubkey_bin()]),
     %% try to acquire the lock with a timeout, will crash this process if we can't get the lock
     ok = blockchain_lock:acquire(5000),
     case blockchain:add_block(Block, Chain) of
         ok ->
             lager:info("got gossipped block ~p", [blockchain_block:height(Block)]),
+            %% pass it along
+            regossip_block(Block, Swarm),
             ok;
         plausible ->
             lager:warning("plausuble gossipped block doesn't fit with our chain, will start sync if not already active"),
             blockchain_worker:maybe_sync(),
+            %% pass it along
+            regossip_block(Block, Swarm),
+            ok;
+        exists ->
             ok;
         {error, disjoint_chain} ->
             lager:warning("gossipped block ~p doesn't fit with our chain,"
@@ -101,3 +102,10 @@ gossip_data(Swarm, Block) ->
     BinBlock = blockchain_block:serialize(Block),
     Msg= #blockchain_gossip_block_pb{from=PubKeyBin, block=BinBlock},
     blockchain_gossip_handler_pb:encode_msg(Msg).
+
+regossip_block(Block, Swarm) ->
+    libp2p_group_gossip:send(
+      libp2p_swarm:gossip_group(Swarm),
+      ?GOSSIP_PROTOCOL,
+      blockchain_gossip_handler:gossip_data(Swarm, Block)
+     ).

--- a/test/blockchain_keys_SUITE.erl
+++ b/test/blockchain_keys_SUITE.erl
@@ -95,7 +95,7 @@ keys_test(Config) ->
     Tx = blockchain_txn_payment_v1:new(Payer, Recipient, 2500, 0, 1),
     SignedTx = blockchain_txn_payment_v1:sign(Tx, PayerSigFun),
     Block = test_utils:create_block(ConsensusMembers, [SignedTx]),
-    _ = blockchain_gossip_handler:add_block(Block, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block, Chain, self(), blockchain_swarm:swarm()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block}, blockchain:head_block(Chain)),

--- a/test/blockchain_payment_v2_SUITE.erl
+++ b/test/blockchain_payment_v2_SUITE.erl
@@ -115,7 +115,7 @@ single_payee_test(Config) ->
     ct:pal("~s", [blockchain_txn:print(SignedTx)]),
 
     Block = test_utils:create_block(ConsensusMembers, [SignedTx]),
-    _ = blockchain_gossip_handler:add_block(Block, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block, Chain, self(), blockchain_swarm:swarm()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block}, blockchain:head_block(Chain)),
@@ -184,7 +184,7 @@ different_payees_test(Config) ->
     ct:pal("~s", [blockchain_txn:print(SignedTx)]),
 
     Block = test_utils:create_block(ConsensusMembers, [SignedTx]),
-    _ = blockchain_gossip_handler:add_block(Block, Chain, self()),
+    _ = blockchain_gossip_handler:add_block(Block, Chain, self(), blockchain_swarm:swarm()),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block}, blockchain:head_block(Chain)),

--- a/test/blockchain_sync_SUITE.erl
+++ b/test/blockchain_sync_SUITE.erl
@@ -87,7 +87,7 @@ basic(Config) ->
     Blocks = lists:reverse(lists:foldl(
         fun(_, Acc) ->
             Block = test_utils:create_block(ConsensusMembers, []),
-            _ = blockchain_gossip_handler:add_block(Block, Chain0,  blockchain_swarm:pubkey_bin()),
+            _ = blockchain_gossip_handler:add_block(Block, Chain0,  blockchain_swarm:pubkey_bin(), blockchain_swarm:swarm()),
             [Block|Acc]
         end,
         [],
@@ -106,7 +106,7 @@ basic(Config) ->
     ok = test_utils:wait_until(fun() -> erlang:length(libp2p_peerbook:values(libp2p_swarm:peerbook(blockchain_swarm:swarm()))) > 1 end),
 
     % Simulate add block from other chain
-    _ = blockchain_gossip_handler:add_block(LastBlock, Chain0, libp2p_swarm:pubkey_bin(SimSwarm)),
+    _ = blockchain_gossip_handler:add_block(LastBlock, Chain0, libp2p_swarm:pubkey_bin(SimSwarm), blockchain_swarm:swarm()),
 
     ok = test_utils:wait_until(fun() ->{ok, BlocksN + 1} =:= blockchain:height(Chain0) end),
     ?assertEqual({ok, LastBlock}, blockchain:head_block(blockchain_worker:blockchain())),

--- a/test/plausible_block_SUITE.erl
+++ b/test/plausible_block_SUITE.erl
@@ -83,7 +83,7 @@ basic(Config) ->
     ?assertEqual(blockchain:head_hash(Chain), {ok, blockchain_block:hash_block(FinalBlock)}),
     [] = blockchain:get_plausible_blocks(Chain),
     %% try adding the previously plausible block again, it should not work
-    ok = blockchain:add_block(LastBlock, Chain),
+    exists = blockchain:add_block(LastBlock, Chain),
     [] = blockchain:get_plausible_blocks(Chain),
     ok.
 


### PR DESCRIPTION
blockchain:add_block didn't use to distinguish a block that it already
had from a block that was new, but validly stored. This add an `exists`
return to add_block so the gossip handler can distinguish between an
existing block and a new one, and only re-gossip the latter.