### PR TITLE
allow the parent app to override the metadata fun

### DIFF
--- a/src/blockchain_sup.erl
+++ b/src/blockchain_sup.erl
@@ -73,6 +73,10 @@ init(Args) ->
                 [{group_delete_predicate, Pred}]
         end,
     BaseDir = proplists:get_value(base_dir, Args, "data"),
+
+    %% allow the parent app to change this if it needs to.
+    MetadataFun = application:get_env(blockchain, metadata_fun,
+                                      fun blockchain_worker:signed_metadata_fun/0),
     SwarmWorkerOpts =
         [
          {key, proplists:get_value(key, Args)},
@@ -80,7 +84,7 @@ init(Args) ->
          {libp2p_proxy,
           [{limit, application:get_env(blockchain, relay_limit, 25)}]},
          {libp2p_peerbook,
-          [{signed_metadata_fun, fun blockchain_worker:signed_metadata_fun/0},
+          [{signed_metadata_fun, MetadataFun},
            {notify_time, application:get_env(blockchain, peerbook_update_interval, timer:minutes(5))},
            {allow_rfc1918, application:get_env(blockchain, peerbook_allow_rfc1918, false)}
           ]},


### PR DESCRIPTION
this is so the miner can add lora status to the blockchain-provided metadata.