### PR TITLE
compress more things when putting them on the disk

### DIFF
--- a/src/ledger/v1/blockchain_ledger_data_credits_entry_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_data_credits_entry_v1.erl
@@ -76,7 +76,7 @@ balance(Balance, Entry) ->
 %%--------------------------------------------------------------------
 -spec serialize(data_credits_entry()) -> binary().
 serialize(Entry) ->
-    BinEntry = erlang:term_to_binary(Entry),
+    BinEntry = erlang:term_to_binary(Entry, [compressed]),
     <<1, BinEntry/binary>>.
 
 %%--------------------------------------------------------------------

--- a/src/ledger/v1/blockchain_ledger_entry_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_entry_v1.erl
@@ -76,7 +76,7 @@ balance(Balance, Entry) ->
 %%--------------------------------------------------------------------
 -spec serialize(entry()) -> binary().
 serialize(Entry) ->
-    BinEntry = erlang:term_to_binary(Entry),
+    BinEntry = erlang:term_to_binary(Entry, [compressed]),
     <<1, BinEntry/binary>>.
 
 %%--------------------------------------------------------------------

--- a/src/ledger/v1/blockchain_ledger_gateway_v2.erl
+++ b/src/ledger/v1/blockchain_ledger_gateway_v2.erl
@@ -432,7 +432,7 @@ oui(OUI, Gateway) ->
 serialize(Gw) ->
     Neighbors = neighbors(Gw),
     Gw1 = neighbors(lists:usort(Neighbors), Gw),
-    BinGw = erlang:term_to_binary(Gw1),
+    BinGw = erlang:term_to_binary(Gw1, [compressed]),
     <<2, BinGw/binary>>.
 
 %%--------------------------------------------------------------------

--- a/src/ledger/v1/blockchain_ledger_htlc_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_htlc_v1.erl
@@ -156,7 +156,7 @@ timelock(Timelock, HTLC) ->
 %%--------------------------------------------------------------------
 -spec serialize(htlc()) -> binary().
 serialize(HTLC) ->
-    BinHTLC = erlang:term_to_binary(HTLC),
+    BinHTLC = erlang:term_to_binary(HTLC, [compressed]),
     <<1, BinHTLC/binary>>.
 
 %%--------------------------------------------------------------------

--- a/src/ledger/v1/blockchain_ledger_poc_v2.erl
+++ b/src/ledger/v1/blockchain_ledger_poc_v2.erl
@@ -124,6 +124,8 @@ block_hash(Challenger, PoC) ->
 %%--------------------------------------------------------------------
 -spec serialize(poc()) -> binary().
 serialize(PoC) ->
+    %% intentionally don't compress here, we compress these in batches
+    %% in the ledger code, which should get better compression anyway
     BinPoC = erlang:term_to_binary(PoC),
     <<2, BinPoC/binary>>.
 

--- a/src/ledger/v1/blockchain_ledger_routing_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_routing_v1.erl
@@ -134,7 +134,7 @@ nonce(Nonce, Entry) ->
 %%--------------------------------------------------------------------
 -spec serialize(routing()) -> binary().
 serialize(Entry) ->
-    BinEntry = erlang:term_to_binary(Entry),
+    BinEntry = erlang:term_to_binary(Entry, [compressed]),
     <<1, BinEntry/binary>>.
 
 %%--------------------------------------------------------------------

--- a/src/ledger/v1/blockchain_ledger_security_entry_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_security_entry_v1.erl
@@ -76,7 +76,7 @@ balance(Balance, Entry) ->
 %%--------------------------------------------------------------------
 -spec serialize(security_entry()) -> binary().
 serialize(Entry) ->
-    BinEntry = erlang:term_to_binary(Entry),
+    BinEntry = erlang:term_to_binary(Entry, [compressed]),
     <<1, BinEntry/binary>>.
 
 %%--------------------------------------------------------------------

--- a/src/ledger/v1/blockchain_ledger_state_channel_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_state_channel_v1.erl
@@ -80,7 +80,7 @@ nonce(Nonce, SC) ->
 %%--------------------------------------------------------------------
 -spec serialize(state_channel()) -> binary().
 serialize(SC) ->
-    BinSC = erlang:term_to_binary(SC),
+    BinSC = erlang:term_to_binary(SC, [compressed]),
     <<1, BinSC/binary>>.
 
 %%--------------------------------------------------------------------

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -1170,7 +1170,7 @@ request_poc_(OnionKeyHash, SecretHash, Challenger, BlockHash, Ledger, Gw0, PoCs)
 
     PoC = blockchain_ledger_poc_v2:new(SecretHash, OnionKeyHash, Challenger, BlockHash),
     PoCBin = blockchain_ledger_poc_v2:serialize(PoC),
-    BinPoCs = erlang:term_to_binary([PoCBin|lists:map(fun blockchain_ledger_poc_v2:serialize/1, PoCs)]),
+    BinPoCs = erlang:term_to_binary([PoCBin|lists:map(fun blockchain_ledger_poc_v2:serialize/1, PoCs)], [compressed]),
     PoCsCF = pocs_cf(Ledger),
     cache_put(Ledger, PoCsCF, OnionKeyHash, BinPoCs).
 
@@ -1192,7 +1192,7 @@ delete_poc(OnionKeyHash, Challenger, Ledger) ->
                 [] ->
                     ?MODULE:delete_pocs(OnionKeyHash, Ledger);
                 _ ->
-                    BinPoCs = erlang:term_to_binary(lists:map(fun blockchain_ledger_poc_v2:serialize/1, FilteredPoCs)),
+                    BinPoCs = erlang:term_to_binary(lists:map(fun blockchain_ledger_poc_v2:serialize/1, FilteredPoCs), [compressed]),
                     PoCsCF = pocs_cf(Ledger),
                     cache_put(Ledger, PoCsCF, OnionKeyHash, BinPoCs)
             end
@@ -1261,7 +1261,7 @@ maybe_gc_pocs(Chain) ->
                  ({KeyHash, NewPoCs}) ->
                       BinPoCs = erlang:term_to_binary(
                                   lists:map(fun blockchain_ledger_poc_v2:serialize/1,
-                                            NewPoCs)),
+                                            NewPoCs), [compressed]),
                       cache_put(Ledger, PoCsCF, KeyHash, BinPoCs)
               end,
               Alters),


### PR DESCRIPTION
Right now we don't compress many things when we write them to the disk.  The disk on spots is really slow and bandwidth constrained and acts as a lock around the forward progress of the consensus algorithm.  Writing less should also extend the life of the SD cards used in the spots.
