### PR TITLE
don't crash on ancient blocks being missing

### DIFF
--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -379,7 +379,7 @@ handle_call({install_snapshot, Hash, Snapshot}, _From,
                 true -> ok;
                 false ->
                     %% we likely retain some old blocks, and we should absorb them
-                    blockchain:replay_blocks(Chain1, false, LedgerHeight, ChainHeight)
+                    set_resyncing(ChainHeight, LedgerHeight, Chain1)
             end,
             blockchain_lock:release(),
             {reply, ok, maybe_sync(State#state{mode = normal, sync_paused = false,

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -1286,9 +1286,17 @@ maybe_gc_pocs(Chain, Ledger) ->
                                                 %% pre-upgrade pocs are ancient
                                                 false;
                                             _ ->
-                                                {ok, B} = blockchain:get_block(H, Chain),
-                                                BH = blockchain_block:height(B),
-                                                (Height - BH) < PoCInterval * 2
+                                                case blockchain:get_block(H, Chain) of
+                                                    {ok, B} ->
+                                                        BH = blockchain_block:height(B),
+                                                        (Height - BH) < PoCInterval * 2;
+                                                    {error, not_found} ->
+                                                        %% we assume that if we can't find the
+                                                        %% origin block in a snapshotted build, we
+                                                        %% can just get rid of it, it's guaranteed
+                                                        %% to be too old.
+                                                        false
+                                                end
                                         end
                                 end, PoCs),
                           case FPoCs == PoCs of


### PR DESCRIPTION
sometimes when trying to figure out if it can remove a potentially stale poc on snapshotted nodes, we don't have enough blocks to process them all.  we can assume that any block we do not have is too old to matter, and its associated PoCs can be discarded.