### PR TITLE
optional decompression in fingerprints

### DIFF
--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -484,7 +484,9 @@ raw_fingerprint(#ledger_v1{mode = Mode} = Ledger, Extended) ->
         Filter = ?BC_UPGRADE_NAMES,
         DefaultVals = cache_fold(
                         Ledger, DefaultCF,
-                        %% these are nonsense, ignore them
+                        %% if any of these are in the CF, it's a
+                        %% result of an old, fixed bug, they're safe
+                        %% to ignore.
                         fun({<<"$block_", _/binary>>, _}, Acc) ->
                                 Acc;
                            ({K, _} = X, Acc) ->
@@ -495,32 +497,25 @@ raw_fingerprint(#ledger_v1{mode = Mode} = Ledger, Extended) ->
                         end, []),
         L0 = [GWsVals, EntriesVals, DCEntriesVals, HTLCs,
               PoCs, Securities, Routings, StateChannels, Subnets] =
-            case Extended of
-                decompress ->
-                    [cache_fold(Ledger, CF,
-                                fun({K, V}, Acc) when Mod == t2b ->
-                                        [{K, erlang:binary_to_term(V)} | Acc];
-                                   ({K, V}, Acc) when Mod /= undefined ->
-                                        [{K, Mod:deserialize(V)} | Acc];
-                                   (X, Acc) -> [X | Acc]
-                                end,
-                                [])
-                     || {CF, Mod} <-
-                            [{AGwsCF, blockchain_ledger_gateway_v2},
-                             {EntriesCF, blockchain_ledger_entry_v1},
-                             {DCEntriesCF, blockchain_ledger_data_credits_entry_v1},
-                             {HTLCsCF, blockchain_ledger_htlc_v1},
-                             {PoCsCF, t2b},
-                             {SecuritiesCF, blockchain_ledger_security_entry_v1},
-                             {RoutingCF, blockchain_ledger_routing_v1},
-                             {SCsCF, blockchain_ledger_state_channel_v1},
-                             {SubnetsCF, undefined}
-                            ]];
-                _ ->
-                    [cache_fold(Ledger, CF, fun(X, Acc) -> [X | Acc] end, [])
-                     || CF <- [AGwsCF, EntriesCF, DCEntriesCF, HTLCsCF,
-                               PoCsCF, SecuritiesCF, RoutingCF, SCsCF, SubnetsCF]]
-            end,
+            [cache_fold(Ledger, CF,
+                        fun({K, V}, Acc) when Mod == t2b ->
+                                [{K, erlang:binary_to_term(V)} | Acc];
+                           ({K, V}, Acc) when Mod /= undefined ->
+                                [{K, Mod:deserialize(V)} | Acc];
+                           (X, Acc) -> [X | Acc]
+                        end,
+                        [])
+             || {CF, Mod} <-
+                    [{AGwsCF, blockchain_ledger_gateway_v2},
+                     {EntriesCF, blockchain_ledger_entry_v1},
+                     {DCEntriesCF, blockchain_ledger_data_credits_entry_v1},
+                     {HTLCsCF, blockchain_ledger_htlc_v1},
+                     {PoCsCF, t2b},
+                     {SecuritiesCF, blockchain_ledger_security_entry_v1},
+                     {RoutingCF, blockchain_ledger_routing_v1},
+                     {SCsCF, blockchain_ledger_state_channel_v1},
+                     {SubnetsCF, undefined}
+                    ]],
         L = lists:append(L0, DefaultVals),
         case Extended of
             false ->

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -484,7 +484,10 @@ raw_fingerprint(#ledger_v1{mode = Mode} = Ledger, Extended) ->
         Filter = ?BC_UPGRADE_NAMES,
         DefaultVals = cache_fold(
                         Ledger, DefaultCF,
-                        fun({K, _} = X, Acc) ->
+                        %% these are nonsense, ignore them
+                        fun({<<"$block_", _/binary>>, _}, Acc) ->
+                                Acc;
+                           ({K, _} = X, Acc) ->
                                 case lists:member(K, Filter) of
                                     true -> Acc;
                                     _ -> [X | Acc]
@@ -495,10 +498,10 @@ raw_fingerprint(#ledger_v1{mode = Mode} = Ledger, Extended) ->
             case Extended of
                 decompress ->
                     [cache_fold(Ledger, CF,
-                                fun({K, V}, Acc) when Mod /= undefined ->
-                                        [{K, Mod:deserialize(V)} | Acc];
-                                   ({K, V}, Acc) when Mod == t2b ->
+                                fun({K, V}, Acc) when Mod == t2b ->
                                         [{K, erlang:binary_to_term(V)} | Acc];
+                                   ({K, V}, Acc) when Mod /= undefined ->
+                                        [{K, Mod:deserialize(V)} | Acc];
                                    (X, Acc) -> [X | Acc]
                                 end,
                                 [])

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -497,6 +497,8 @@ raw_fingerprint(#ledger_v1{mode = Mode} = Ledger, Extended) ->
                     [cache_fold(Ledger, CF,
                                 fun({K, V}, Acc) when Mod /= undefined ->
                                         [{K, Mod:deserialize(V)} | Acc];
+                                   ({K, V}, Acc) when Mod == t2b ->
+                                        [{K, erlang:binary_to_term(V)} | Acc];
                                    (X, Acc) -> [X | Acc]
                                 end,
                                 [])
@@ -505,7 +507,7 @@ raw_fingerprint(#ledger_v1{mode = Mode} = Ledger, Extended) ->
                              {EntriesCF, blockchain_ledger_entry_v1},
                              {DCEntriesCF, blockchain_ledger_data_credits_entry_v1},
                              {HTLCsCF, blockchain_ledger_htlc_v1},
-                             {PoCsCF, blockchain_ledger_poc_v2},
+                             {PoCsCF, t2b},
                              {SecuritiesCF, blockchain_ledger_security_entry_v1},
                              {RoutingCF, blockchain_ledger_routing_v1},
                              {SCsCF, blockchain_ledger_state_channel_v1},

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -491,15 +491,36 @@ raw_fingerprint(#ledger_v1{mode = Mode} = Ledger, Extended) ->
                                 end
                         end, []),
         L0 = [GWsVals, EntriesVals, DCEntriesVals, HTLCs,
-              PoCs, Securities, Routings, StateChannels, Subnets]
-        = [cache_fold(Ledger, CF, fun(X, Acc) -> [X | Acc] end, [])
-           || CF <- [AGwsCF, EntriesCF, DCEntriesCF, HTLCsCF,
-                     PoCsCF, SecuritiesCF, RoutingCF, SCsCF, SubnetsCF]],
+              PoCs, Securities, Routings, StateChannels, Subnets] =
+            case Extended of
+                decompress ->
+                    [cache_fold(Ledger, CF,
+                                fun({K, V}, Acc) when Mod /= undefined ->
+                                        [{K, Mod:deserialize(V)} | Acc];
+                                   (X, Acc) -> [X | Acc]
+                                end,
+                                [])
+                     || {CF, Mod} <-
+                            [{AGwsCF, blockchain_ledger_gateway_v2},
+                             {EntriesCF, blockchain_ledger_entry_v1},
+                             {DCEntriesCF, blockchain_ledger_data_credits_entry_v1},
+                             {HTLCsCF, blockchain_ledger_htlc_v1},
+                             {PoCsCF, blockchain_ledger_poc_v2},
+                             {SecuritiesCF, blockchain_ledger_security_entry_v1},
+                             {RoutingCF, blockchain_ledger_routing_v1},
+                             {SCsCF, blockchain_ledger_state_channel_v1},
+                             {SubnetsCF, undefined}
+                            ]];
+                _ ->
+                    [cache_fold(Ledger, CF, fun(X, Acc) -> [X | Acc] end, [])
+                     || CF <- [AGwsCF, EntriesCF, DCEntriesCF, HTLCsCF,
+                               PoCsCF, SecuritiesCF, RoutingCF, SCsCF, SubnetsCF]]
+            end,
         L = lists:append(L0, DefaultVals),
         case Extended of
             false ->
                 {ok, #{<<"ledger_fingerprint">> => fp(lists:flatten(L))}};
-            true ->
+            _ ->
                 {ok, #{<<"ledger_fingerprint">> => fp(lists:flatten(L)),
                        <<"gateways_fingerprint">> => fp(GWsVals),
                        <<"core_fingerprint">> => fp(DefaultVals),
@@ -513,8 +534,9 @@ raw_fingerprint(#ledger_v1{mode = Mode} = Ledger, Extended) ->
                        <<"subnets_fingerprint">> => fp(Subnets)
                       }}
         end
-    catch _:_ ->
-              {error, could_not_fingerprint}
+    catch C:E:S ->
+            lager:warning("fp error ~p:~p ~p", [C, E, S]),
+            {error, could_not_fingerprint}
     end.
 
 fp(L) ->


### PR DESCRIPTION
compression has done a number on the validity of fingerprints.  until snapshots are enabled and we can switch to that for ledger convergence information, we may need the stuff in here to diagnose what's going on when there is drift.