### PR TITLE
speed up starting

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -473,7 +473,7 @@ fold_blocks(Chain0, DelayedHeight, DelayedLedger, Height) ->
         lists:foldl(
           fun(_, Acc) when is_tuple(Acc) ->
                   Acc;
-             (H, none) when H == DelayedHeight ->
+             (H, none) when H == (DelayedHeight+1) ->
                   {DelayedHeight, DelayedLedger};
              (H, none) ->
                   case blockchain_ledger_v1:has_snapshot(Height, DelayedLedger) of

--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -1597,6 +1597,13 @@ load(Dir, Mode) ->
                 ledger=Ledger
             },
             compact(Blockchain),
+            %% pre-calculate the missing snapshots
+            case height(Blockchain) of
+                {ok, ChainHeight} when ChainHeight > 2 ->
+                    ledger_at(ChainHeight - 1, Blockchain);
+                _ ->
+                    ok
+            end,
             {Blockchain, ?MODULE:genesis_block(Blockchain)}
     end.
 

--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -468,6 +468,23 @@ ledger_at(Height, Chain0, ForceRecalc) ->
     end.
 
 fold_blocks(Chain0, DelayedHeight, DelayedLedger, Height) ->
+    %% to minimize work, check backwards for snapshots
+    {HighestSnapHeight, HighestLedger} =
+        lists:foldl(
+          fun(_, Acc) when is_tuple(Acc) ->
+                  Acc;
+             (H, none) when H == DelayedHeight ->
+                  {DelayedHeight, DelayedLedger};
+             (H, none) ->
+                  case blockchain_ledger_v1:has_snapshot(Height, DelayedLedger) of
+                      {ok, Snap} ->
+                          {H, Snap};
+                      _ ->
+                          none
+                  end
+          end,
+          none,
+          lists:seq(Height, DelayedHeight+1, -1)),
     lists:foldl(
       fun(H, {ok, ChainAcc}) ->
               case ?MODULE:get_block(H, Chain0) of
@@ -479,6 +496,13 @@ fold_blocks(Chain0, DelayedHeight, DelayedLedger, Height) ->
                               ok = blockchain_ledger_v1:maybe_gc_pocs(Chain1, Ledger0),
                               ok = blockchain_ledger_v1:maybe_gc_scs(Ledger0),
                               ok = blockchain_ledger_v1:refresh_gateway_witnesses(Hash, Ledger0),
+
+                              %% take an intermediate snapshot here to
+                              %% make things faster in the future
+                              Ledger1 = ?MODULE:ledger(Chain1),
+                              Ctxt = blockchain_ledger_v1:get_context(Ledger1),
+                              blockchain_ledger_v1:context_snapshot(Ctxt, Ledger1),
+
                               {ok, Chain1};
                           {error, Reason} ->
                               {error, {block_absorb_failed, H, Reason}}
@@ -490,8 +514,8 @@ fold_blocks(Chain0, DelayedHeight, DelayedLedger, Height) ->
             %% keep returning the error
             Error
       end,
-      {ok, ?MODULE:ledger(blockchain_ledger_v1:new_context(DelayedLedger), Chain0)},
-      lists:seq(DelayedHeight+1, Height)
+      {ok, ?MODULE:ledger(blockchain_ledger_v1:new_context(HighestLedger), Chain0)},
+      lists:seq(HighestSnapHeight+1, Height)
      ).
 
 %%--------------------------------------------------------------------

--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -474,9 +474,9 @@ fold_blocks(Chain0, DelayedHeight, DelayedLedger, Height) ->
           fun(_, Acc) when is_tuple(Acc) ->
                   Acc;
              (H, none) when H == (DelayedHeight+1) ->
-                  {DelayedHeight, DelayedLedger};
+                  {DelayedHeight, blockchain_ledger_v1:new_context(DelayedLedger)};
              (H, none) ->
-                  case blockchain_ledger_v1:has_snapshot(Height, DelayedLedger) of
+                  case blockchain_ledger_v1:has_snapshot(H, DelayedLedger) of
                       {ok, Snap} ->
                           {H, Snap};
                       _ ->
@@ -514,7 +514,7 @@ fold_blocks(Chain0, DelayedHeight, DelayedLedger, Height) ->
             %% keep returning the error
             Error
       end,
-      {ok, ?MODULE:ledger(blockchain_ledger_v1:new_context(HighestLedger), Chain0)},
+      {ok, ?MODULE:ledger(HighestLedger, Chain0)},
       lists:seq(HighestSnapHeight+1, Height)
      ).
 


### PR DESCRIPTION
currently ledger_at only adds a snapshot when we ask for a particular height.  This can lead to certain ledger states being computed over and over and over again, since there is no snapshot at that specific height.  It also means that parallel validations can't share very much work.

this PR changes the behavior to snapshot at every visited height, and to seek backwards first, so that if we have some intermediate state computed, we can do the least work possible.