### PR TITLE
Don't crash if we don't have a genesis block on startup

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -123,11 +123,9 @@ new(Dir, undefined, QuickSyncMode, QuickSyncData) ->
             lager:error("DB corrupted cleaning up ~p", [_Corrupted]),
             ok = clean(Blockchain),
             new(Dir, undefined, QuickSyncMode, QuickSyncData);
-        {Blockchain, {error, _Reason}} when QuickSyncMode /= blessed_snapshot ->
+        {Blockchain, {error, _Reason}} ->
             lager:info("no genesis block found: ~p", [_Reason]),
             {no_genesis, init_quick_sync(QuickSyncMode, Blockchain, QuickSyncData)};
-        {Blockchain, {error, _Reason}} ->
-            {ok, init_quick_sync(QuickSyncMode, Blockchain, QuickSyncData)};
         {Blockchain, {ok, _GenBlock}} ->
             Ledger = blockchain:ledger(Blockchain),
             Upgrades = lists:zip(?BC_UPGRADE_NAMES, ?BC_UPGRADE_FUNS),

--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -315,8 +315,8 @@ init(Args) ->
                      [ libp2p_swarm:listen(SwarmTID, "/ip4/0.0.0.0/tcp/" ++ integer_to_list(Port)) || Port <- Ports ]),
     QuickSyncMode = application:get_env(blockchain, quick_sync_mode, assumed_valid),
     {Mode, Info} =
-        case application:get_env(blockchain, sync_mode, quick) of
-            quick ->
+        case application:get_env(blockchain, honor_quick_sync, false) of
+            true ->
                 case QuickSyncMode of
                     assumed_valid -> {normal, undefined};
                     blessed_snapshot ->
@@ -336,7 +336,7 @@ init(Args) ->
                                 end
                         end
                 end;
-            full ->
+            false ->
                 %% full sync only ever syncs blocks, so just sync blocks
                 {normal, undefined}
         end,

--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -325,6 +325,8 @@ init(Args) ->
                         case Blockchain of
                             undefined ->
                                 {snapshot, {Hash, Height}};
+                            {no_genesis, _} ->
+                                {snapshot, {Hash, Height}};
                             _Chain ->
                                 {ok, CurrHeight} = blockchain:height(Blockchain),
                                 case CurrHeight >= Height of


### PR DESCRIPTION
Just small fixes.

I think there's a bug where we go onto the snapshot path even if honor_quick_sync is false, as well.