### PR TITLE
remove idle time bump, not working as expected

### DIFF
--- a/src/handlers/blockchain_snapshot_handler.erl
+++ b/src/handlers/blockchain_snapshot_handler.erl
@@ -46,18 +46,16 @@ server(Connection, Path, _TID, Args) ->
 %% ------------------------------------------------------------------
 %% libp2p_framed_stream Function Definitions
 %% ------------------------------------------------------------------
-init(client, Conn, [Hash, Height, Chain]) ->
+init(client, _Conn, [Hash, Height, Chain]) ->
     case blockchain_worker:sync_paused() of
         true ->
             {stop, normal};
         false ->
-            ok = libp2p_connection:set_idle_timeout(Conn, timer:minutes(15)),
             Msg = #blockchain_snapshot_req_pb{height = Height, hash = Hash},
             {ok, #state{chain = Chain, hash = Hash},
              blockchain_snapshot_handler_pb:encode_msg(Msg)}
     end;
-init(server, Conn, [_Path, _, Chain]) ->
-    ok = libp2p_connection:set_idle_timeout(Conn, timer:minutes(15)),
+init(server, _Conn, [_Path, _, Chain]) ->
     {ok, #state{chain = Chain}}.
 
 handle_data(client, Data, #state{chain = Chain, hash = Hash} = State) ->


### PR DESCRIPTION
This isn't altering the correct timeout, and lets zombie processes hang around too long.