### PR TITLE
add a cache for deserialized gateways

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -252,9 +252,7 @@ upgrade_gateways_oui_(Ledger) ->
     %% find all neighbors for everyone
     maps:map(
       fun(A, G) ->
-              %% since we're here
-              G1 = blockchain_ledger_gateway_v2:neighbors([], G),
-              blockchain_ledger_v1:update_gateway(G1, A, Ledger)
+              blockchain_ledger_v1:update_gateway(G, A, Ledger)
       end, Gateways),
     ok.
 

--- a/src/blockchain_gateway_cache.erl
+++ b/src/blockchain_gateway_cache.erl
@@ -1,0 +1,323 @@
+-module(blockchain_gateway_cache).
+
+-behaviour(gen_server).
+
+%% API
+-export([
+         start_link/0,
+         get/2, get/3,
+         %% invalidate/2,
+         bulk_put/2,
+         stats/0
+        ]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-define(SERVER, ?MODULE).
+
+-record(state, {
+                height = 1 :: pos_integer(),
+                cache :: undefined | ets:tid()
+               }).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+-spec get(GwAddr :: libp2p_crypto:pubkey_bin(),
+          Ledger :: blockchain_ledger_v1:ledger()) ->
+                 ok | {error, _}.
+get(Addr, Ledger) ->
+    get(Addr, Ledger, true).
+
+-spec get(GwAddr :: libp2p_crypto:pubkey_bin(),
+          Ledger :: blockchain_ledger_v1:ledger(),
+          CacheRead :: boolean()) ->
+                 ok | {error, _}.
+get(Addr, Ledger, false) ->
+    ets:update_counter(?MODULE, total, 1, {total, 0}),
+    blockchain_ledger_v1:find_gateway_info(Addr, Ledger);
+get(Addr, Ledger, true) ->
+    ets:update_counter(?MODULE, total, 1, {total, 0}),
+    try
+        {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
+        %% first try the context cache
+        case blockchain_ledger_v1:gateway_cache_get(Addr, Ledger) of
+            {ok, Gw} ->
+                %% lager:info("new cache hit ~p ~p", [Addr, Height]),
+                ets:update_counter(?MODULE, hit, 1, {hit, 0}),
+                {ok, Gw};
+            _ ->
+                %% then try our cache
+                case cache_get(Addr, Ledger) of
+                    {ok, _} = Result ->
+                        ets:update_counter(?MODULE, hit, 1, {hit, 0}),
+                        lager:debug("get ~p at ~p hit", [Addr, Height]),
+                        Result;
+                    _ ->
+                        %% then back off finally to the disk
+                        case blockchain_ledger_v1:find_gateway_info(Addr, Ledger) of
+                            {ok, DiskGw} = Result2 ->
+                                %% lager:info("get ~p at ~p miss writeback", [Addr, Height]),
+                                cache_put(Addr, DiskGw, Ledger),
+                                Result2;
+                            Else ->
+                                lager:debug("get ~p at ~p miss err", [Addr, Height]),
+                                Else
+                        end
+                end
+        end
+    catch _:_ ->
+            ets:update_counter(?MODULE, error, 1, {error, 0}),
+            blockchain_ledger_v1:find_gateway_info(Addr, Ledger)
+    end.
+
+%% -spec invalidate(GwAddr :: libp2p_crypto:pubkey_bin(),
+%%                  Ledger :: blockchain_ledger_v1:ledger()) ->
+%%                         ok | {error, _}.
+%% invalidate(Addr, Ledger) ->
+%%     {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
+%%     case ets:lookup(?MODULE, curr_height) of
+%%         [{_, CurrHeight}] ->
+%%             case Height == CurrHeight of
+%%                 true ->
+%%                     ets:delete(?MODULE, {Addr, Height}),
+%%                     remove_height(Addr, Height ),
+%%                     lager:info("invalidate ~p ~p", [Addr, Height]);
+%%                 _ ->
+%%                     ok
+%%             end;
+%%         _ ->
+%%             ok
+%%     end.
+
+stats() ->
+    case ets:lookup(?MODULE, total) of
+        [] -> 0;
+        [{_, Tot}] ->
+            HitRate =
+                case ets:lookup(?MODULE, hit) of
+                    [] -> no_hits;
+                    [{_, Hits}] ->
+                        Hits / Tot
+                end,
+            Err = case ets:lookup(?MODULE, error) of
+                      [] -> 0;
+                      [{_, E}] -> E
+                  end,
+            {Tot, HitRate, Err}
+    end.
+
+bulk_put(Height, List) ->
+    gen_server:call(?MODULE, {bulk_put, Height, List}).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init([]) ->
+    %% register for blocks here
+    %% start the cache
+    Cache = ets:new(?MODULE,
+                    [named_table,
+                     public,
+                     {read_concurrency, true}]),
+    case application:get_env(blockchain, disable_gateway_cache, false) of
+        false ->
+            try blockchain_worker:blockchain() of
+                undefined ->
+                    erlang:send_after(500, self(), chain_init),
+                    {ok, #state{cache = Cache}};
+                Chain ->
+                    ok = blockchain_event:add_handler(self()),
+                    {ok, Height} = blockchain_ledger_v1:current_height(blockchain:ledger(Chain)),
+                    ets:insert(?MODULE, {start_height, Height}),
+                    {ok, #state{height = Height, cache = Cache}}
+            catch _:_ ->
+                      erlang:send_after(500, self(), chain_init),
+                      {ok, #state{cache = Cache}}
+            end;
+        _ ->
+            {ok, #state{cache=Cache}}
+    end.
+
+handle_call({bulk_put, Height, List}, _From, State) ->
+    lists:foreach(
+      fun({Addr, Gw}) ->
+              lager:debug("bulk ~p", [Addr]),
+              add_height(Addr, Height),
+              ets:insert(?MODULE, {{Addr, Height}, Gw})
+      end, List),
+    ets:insert(?MODULE, {curr_height, Height}),
+    lager:debug("bulk_add at ~p ~p", [Height, length(List)]),
+    {reply, ok, State};
+handle_call(_Request, _From, State) ->
+    lager:warning("unexpected call ~p from ~p", [_Request, _From]),
+    Reply = ok,
+    {reply, Reply, State}.
+
+handle_cast(_Msg, State) ->
+    lager:warning("unexpected cast ~p", [_Msg]),
+    {noreply, State}.
+
+handle_info({blockchain_event, {add_block, _Hash, _Sync, Ledger}}, State) ->
+    %% sweep here
+    case blockchain_ledger_v1:current_height(Ledger) of
+        {ok, Height} ->
+            lager:debug("sweeping at ~p", [Height]),
+            %% sweep later so we get some use out of the tail on
+            %% rarely updated spots
+            ets:select_delete(?MODULE, [{{{'_','$1'},'_'},[{'<','$1', Height - 76}],[true]}]),
+            {noreply, State#state{height = Height}};
+        {error, _Err} ->
+            {noreply, State}
+    end;
+handle_info({blockchain_event, {new_chain, NC}}, State) ->
+    ets:delete_all_objects(?MODULE),
+    {ok, Height} = blockchain_ledger_v1:current_height(blockchain:ledger(NC)),
+    {noreply, State#state{height = Height}};
+handle_info(chain_init, State) ->
+    try blockchain_worker:blockchain() of
+        undefined ->
+            erlang:send_after(500, self(), chain_init),
+            {noreply, State};
+        Chain ->
+            ok = blockchain_event:add_handler(self()),
+            {ok, Height} = blockchain_ledger_v1:current_height(blockchain:ledger(Chain)),
+            ets:insert(?MODULE, {start_height, Height}),
+            {noreply, State#state{height = Height}}
+    catch _:_ ->
+              erlang:send_after(500, self(), chain_init),
+              {noreply, State}
+    end;
+handle_info(_Info, State) ->
+    lager:warning("unexpected message ~p", [_Info]),
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+cache_get(Addr, Ledger) ->
+    {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
+    [{_, StartHeight}] = ets:lookup(?MODULE, start_height),
+    case ets:lookup(?MODULE, curr_height) of
+        [{_, CurrHeight}] ->
+            case ets:lookup(?MODULE, Addr) of
+                [] -> {error, not_found};
+                [{_, Updates}] ->
+                    case get_update(Height, CurrHeight, StartHeight, Updates) of
+                        none -> {error, not_found};
+                        Update ->
+                            case ets:lookup(?MODULE, {Addr, Update}) of
+                                [] ->
+                                    {error, not_found};
+                                [{_, Res}] ->
+                                    lager:debug("lastupdate ~p ~p ~p", [Addr, Update, Height]),
+                                    {ok, Res}
+                            end
+                    end
+            end;
+        _ -> {error, not_found}
+    end.
+
+cache_put(Addr, Gw, Ledger) ->
+    {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
+    case ets:lookup(?MODULE, curr_height) of
+        [{_, CurrHeight}] ->
+            case Height == CurrHeight of
+                %% because of speculative absorbs, we cannot accept these, as
+                %% they may be affected by transactions that will
+                %% never land. They should mostly be covered by the
+                %% context cache
+                true ->
+                    lager:debug("get ~p at ~p miss *no* writeback", [Addr, Height]),
+                    ok;
+                false ->
+                    case ets:lookup(?MODULE, Addr) of
+                        [] ->
+                            add_height(Addr, Height);
+                        [{_, LastUpdate}] ->
+                            case Height > LastUpdate of
+                                true ->
+                                    add_height(Addr, Height);
+                                false ->
+                                    ok
+                            end
+                    end,
+                        lager:debug("get ~p at ~p miss writeback", [Addr, Height]),
+                    ets:insert(?MODULE, {{Addr, Height}, Gw}),
+                    ok
+            end;
+        [] ->
+            %% not sure that it's safe to do anything here
+            ok
+    end.
+
+add_height(Addr, Height) ->
+    case ets:lookup(?MODULE, Addr) of
+        [] ->
+            New = {Addr, [Height]},
+            case ets:insert_new(?MODULE, New) of
+                true ->
+                    ok;
+                _ ->
+                    add_height(Addr, Height)
+            end;
+        [{_, Heights} = Old] ->
+            New = {Addr, add_in_order(Height, Heights)},
+            case ets:select_replace(?MODULE, [{Old, [], [{const, New}]}]) of
+                1 ->
+                    ok;
+                _ ->
+                    add_height(Addr, Height)
+            end
+    end.
+
+%% remove_height(Addr, Height) ->
+%%     case ets:lookup(?MODULE, Addr) of
+%%         [] ->
+%%             ok;
+%%         [{_, Heights} = Old] ->
+%%             New = {Addr, lists:delete(Height, Heights)},
+%%             case ets:select_replace(?MODULE, [{Old, [], [{const, New}]}]) of
+%%                 1 ->
+%%                     ok;
+%%                 _ ->
+%%                     remove_height(Addr, Height)
+%%             end
+%%     end.
+
+add_in_order(New, Heights) ->
+    Heights1 =
+        %% high to low
+        lists:reverse(
+          %% no dups
+          lists:usort([New | Heights])),
+    Top = hd(Heights1),
+    lists:filter(fun(X) -> X > Top - 76 end, Heights1).
+
+get_update(_Height, _CurrHeight, _StartHeight, []) ->
+    none;
+get_update(Height, CurrHeight, StartHeight, [H | T]) ->
+    case Height >= H of
+        true when H > (StartHeight + 1) ->
+            H;
+        %% it's not safe to use anything earlier than the starting
+        %% height, because the index may be incomplete.
+        true ->
+            none;
+        false ->
+            get_update(Height, CurrHeight, StartHeight, T)
+    end.

--- a/src/blockchain_sup.erl
+++ b/src/blockchain_sup.erl
@@ -114,6 +114,7 @@ init(Args) ->
         ?WORKER(blockchain_lock, []),
         ?WORKER(blockchain_swarm, [SwarmWorkerOpts]),
         ?WORKER(?EVT_MGR, blockchain_event, [BEventOpts]),
+        ?WORKER(blockchain_gateway_cache, []),
         ?WORKER(blockchain_score_cache, []),
         ?WORKER(blockchain_worker, [BWorkerOpts]),
         ?WORKER(blockchain_txn_mgr, [BTxnManagerOpts]),

--- a/src/poc/blockchain_poc_path.erl
+++ b/src/poc/blockchain_poc_path.erl
@@ -1073,7 +1073,7 @@ build_fake_ledger(TestDir, LatLongs, DefaultScore, ExclusionRingDist, MaxGridDis
 
     lists:foreach(fun({{Owner, Gw}, {Coordinate, _, _}}) ->
                           ok = blockchain_ledger_v1:add_gateway(Owner, Gw, h3:from_geo(Coordinate, Res), DefaultScore, Ledger1),
-                          {ok, _} = blockchain_ledger_v1:find_gateway_info(Gw, Ledger1)
+                          {ok, _} = blockchain_gateway_cache:get(Gw, Ledger1)
                   end, lists:zip(OwnerAndGateways, LatLongs)),
     ok = blockchain_ledger_v1:commit_context(Ledger1),
     Ledger.

--- a/src/poc/blockchain_poc_path_v3.erl
+++ b/src/poc/blockchain_poc_path_v3.erl
@@ -407,8 +407,8 @@ challenge_age(Vars) ->
 %% we assume that everything that has made it into build has already
 %% been asserted, and thus the lookup will never fail. This function
 %% in no way exists simply because
-%% blockchain_ledger_v1:find_gateway_info is too much to type a bunch
+%% blockchain_gateway_cache:get is too much to type a bunch
 %% of times.
 find(Addr, Ledger) ->
-    {ok, Gw} = blockchain_ledger_v1:find_gateway_info(Addr, Ledger),
+    {ok, Gw} = blockchain_gateway_cache:get(Addr, Ledger),
     Gw.

--- a/src/poc/blockchain_poc_path_v4.erl
+++ b/src/poc/blockchain_poc_path_v4.erl
@@ -481,11 +481,11 @@ poc_max_hop_cells(Vars) ->
 %% we assume that everything that has made it into build has already
 %% been asserted, and thus the lookup will never fail. This function
 %% in no way exists simply because
-%% blockchain_ledger_v1:find_gateway_info is too much to type a bunch
+%% blockchain_gateway_cache:get is too much to type a bunch
 %% of times.
 -spec find(libp2p_crypto:pubkey_bin(), blockchain_ledger_v1:ledger()) -> blockchain_ledger_gateway_v2:gateway().
 find(Addr, Ledger) ->
-    {ok, Gw} = blockchain_ledger_v1:find_gateway_info(Addr, Ledger),
+    {ok, Gw} = blockchain_gateway_cache:get(Addr, Ledger),
     Gw.
 
 -spec split_hist(Hist :: blockchain_ledger_gateway_v2:histogram(),

--- a/src/poc/blockchain_poc_target_v2.erl
+++ b/src/poc/blockchain_poc_target_v2.erl
@@ -62,7 +62,7 @@ target_v2(Hash, Ledger, Vars) ->
     GatewayMap =
         lists:foldl(
           fun(Addr, Acc) ->
-                  {ok, Gw} = blockchain_ledger_v1:find_gateway_info(Addr, Ledger),
+                  {ok, Gw} = blockchain_gateway_cache:get(Addr, Ledger),
                   Score =
                       case prob_score_wt(Vars) of
                           0.0 ->

--- a/src/state_channel/blockchain_state_channels_server.erl
+++ b/src/state_channel/blockchain_state_channels_server.erl
@@ -126,7 +126,7 @@ handle_cast({packet, SCPacket},
     %% Get the client (i.e. the hotspot who received this packet)
     ClientPubkeyBin = blockchain_state_channel_packet_v1:hotspot(SCPacket),
 
-    case blockchain_ledger_v1:find_gateway_info(ClientPubkeyBin, Ledger) of
+    case blockchain_gateway_cache:get(ClientPubkeyBin, Ledger) of
         {error, _} ->
             %% This client does not exist on chain, ignore
             {noreply, State};

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -328,10 +328,10 @@ absorb_and_commit(Block, Chain0, BeforeCommit, Rescue) ->
                 {ok, Chain2} ->
                     Ledger2 = blockchain:ledger(Chain2),
                     case BeforeCommit() of
-                         ok ->
+                        ok ->
                             ok = blockchain_ledger_v1:commit_context(Ledger2),
                             absorb_delayed(Block, Chain0);
-                       Any ->
+                        Any ->
                             Any
                     end;
                 Error ->

--- a/src/transactions/v1/blockchain_txn_assert_location_v1.erl
+++ b/src/transactions/v1/blockchain_txn_assert_location_v1.erl
@@ -316,7 +316,7 @@ is_valid(Txn, Chain) ->
                             Error;
                         ok ->
                             Gateway = ?MODULE:gateway(Txn),
-                            case blockchain_ledger_v1:find_gateway_info(Gateway, Ledger) of
+                            case blockchain_gateway_cache:get(Gateway, Ledger) of
                                 {error, _} ->
                                     {error, {unknown_gateway, Gateway, Ledger}};
                                 {ok, GwInfo} ->
@@ -364,7 +364,7 @@ absorb(Txn, Chain) ->
         false -> Payer
     end,
 
-    {ok, OldGw} = blockchain_ledger_v1:find_gateway_info(Gateway, Ledger),
+    {ok, OldGw} = blockchain_gateway_cache:get(Gateway, Ledger, false),
 
     case blockchain_ledger_v1:debit_fee(ActualPayer, Fee + StakingFee, Ledger) of
         {error, _Reason}=Error ->
@@ -405,7 +405,7 @@ absorb(Txn, Chain) ->
             %% TODO gc this nonsense in some deterministic way
             Gateways = blockchain_ledger_v1:active_gateways(Ledger),
             Neighbors = blockchain_poc_path:neighbors(Gateway, Gateways, Ledger),
-            {ok, Gw} = blockchain_ledger_v1:find_gateway_info(Gateway, Ledger),
+            {ok, Gw} = blockchain_gateway_cache:get(Gateway, Ledger, false),
             ok = blockchain_ledger_v1:fixup_neighbors(Gateway, Gateways, Neighbors, Ledger),
             Gw1 = blockchain_ledger_gateway_v2:neighbors(Neighbors, Gw),
             ok = blockchain_ledger_v1:update_gateway(Gw1, Gateway, Ledger)

--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -165,7 +165,7 @@ is_valid(Txn, Chain) ->
                                 {error, _} ->
                                     {error, poc_not_found};
                                 {ok, PoC} ->
-                                    case blockchain_ledger_v1:find_gateway_info(Challenger, Ledger) of
+                                    case blockchain_gateway_cache:get(Challenger, Ledger) of
                                         {error, Reason}=Error ->
                                             lager:warning([{poc_id, HexPOCID}],
                                                           "poc_receipts error find_gateway_info, challenger: ~p, reason: ~p",
@@ -173,6 +173,7 @@ is_valid(Txn, Chain) ->
                                             Error;
                                         {ok, GwInfo} ->
                                             LastChallenge = blockchain_ledger_gateway_v2:last_poc_challenge(GwInfo),
+                                            %% lager:info("gw last ~p ~p ~p", [LastChallenge, HexPOCID, GwInfo]),
                                             case blockchain:get_block(LastChallenge, Chain) of
                                                 {error, Reason}=Error ->
                                                     lager:warning([{poc_id, HexPOCID}],
@@ -183,6 +184,7 @@ is_valid(Txn, Chain) ->
                                                     PoCInterval = blockchain_utils:challenge_interval(Ledger),
                                                     case LastChallenge + PoCInterval >= Height of
                                                         false ->
+                                                            lager:info("challenge too old ~p ~p", [Challenger, GwInfo]),
                                                             {error, challenge_too_old};
                                                         true ->
                                                             Condition = case blockchain:config(?poc_version, Ledger) of
@@ -506,14 +508,14 @@ good_quality_witnesses(Element, Ledger) ->
     {ok, ParentRes} = blockchain_ledger_v1:config(?poc_v4_parent_res, Ledger),
     {ok, ExclusionCells} = blockchain_ledger_v1:config(?poc_v4_exclusion_cells, Ledger),
 
-    {ok, ChallengeeGw} = blockchain_ledger_v1:find_gateway_info(Challengee, Ledger),
+    {ok, ChallengeeGw} = blockchain_gateway_cache:get(Challengee, Ledger),
     ChallengeeLoc = blockchain_ledger_gateway_v2:location(ChallengeeGw),
     ChallengeeParentIndex = h3:parent(ChallengeeLoc, ParentRes),
 
     %% Good quality witnesses
     lists:filter(fun(Witness) ->
                                  WitnessPubkeyBin = blockchain_poc_witness_v1:gateway(Witness),
-                                 {ok, WitnessGw} = blockchain_ledger_v1:find_gateway_info(WitnessPubkeyBin, Ledger),
+                                 {ok, WitnessGw} = blockchain_gateway_cache:get(WitnessPubkeyBin, Ledger),
                                  WitnessGwLoc = blockchain_ledger_gateway_v2:location(WitnessGw),
                                  WitnessParentIndex = h3:parent(WitnessGwLoc, ParentRes),
                                  WitnessRSSI = blockchain_poc_witness_v1:signal(Witness),
@@ -550,11 +552,12 @@ absorb(Txn, Chain) ->
         %% get these to make sure we're not replaying.
         {ok, PoCs} = blockchain_ledger_v1:find_poc(LastOnionKeyHash, Ledger),
         {ok, _PoC} = blockchain_ledger_poc_v2:find_valid(PoCs, Challenger, Secret),
-        {ok, GwInfo} = blockchain_ledger_v1:find_gateway_info(Challenger, Ledger),
+        {ok, GwInfo} = blockchain_gateway_cache:get(Challenger, Ledger, false),
         LastChallenge = blockchain_ledger_gateway_v2:last_poc_challenge(GwInfo),
         PoCInterval = blockchain_utils:challenge_interval(Ledger),
         case LastChallenge + PoCInterval >= Height of
             false ->
+                lager:info("challenge too old ~p ~p", [Challenger, GwInfo]),
                 {error, challenge_too_old};
             true ->
                 case blockchain:config(?poc_version, Ledger) of
@@ -595,8 +598,8 @@ absorb(Txn, Chain) ->
                 end
         end
     catch What:Why:Stacktrace ->
-              lager:warning([{poc_id, HexPOCID}], "poc receipt calculation failed: ~p ~p ~p", [What, Why, Stacktrace]),
-              {error, state_missing}
+            lager:warning([{poc_id, HexPOCID}], "poc receipt calculation failed: ~p ~p ~p", [What, Why, Stacktrace]),
+            {error, state_missing}
     end.
 
 -spec get_lower_and_upper_bounds(Secret :: binary(),
@@ -614,7 +617,7 @@ get_lower_and_upper_bounds(Secret, OnionKeyHash, Challenger, Ledger, Chain) ->
                 {error, _}=Error1 ->
                     Error1;
                 {ok, _PoC} ->
-                    case blockchain_ledger_v1:find_gateway_info(Challenger, Ledger) of
+                    case blockchain_gateway_cache:get(Challenger, Ledger) of
                         {error, Reason}=Error2 ->
                             lager:warning("poc_receipts error find_gateway_info, challenger: ~p, reason: ~p", [Challenger, Reason]),
                             Error2;
@@ -862,7 +865,7 @@ check_witness_layerhash(Witnesses, Gateway, LayerHash, OldLedger) ->
                   %% the witnesses should have an asserted location
                   %% at the point when the request was mined!
                   WitnessGateway = blockchain_poc_witness_v1:gateway(Witness),
-                  case blockchain_ledger_v1:find_gateway_info(WitnessGateway, OldLedger) of
+                  case blockchain_gateway_cache:get(WitnessGateway, OldLedger) of
                       {error, _} ->
                           false;
                       {ok, _} when Gateway == WitnessGateway ->

--- a/src/transactions/v1/blockchain_txn_poc_request_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_request_v1.erl
@@ -155,12 +155,13 @@ is_valid(Txn, Chain) ->
                 false ->
                     {error, bad_signature};
                 true ->
-                    case blockchain_ledger_v1:find_gateway_info(Challenger, Ledger) of
+                    case blockchain_gateway_cache:get(Challenger, Ledger) of
                         {error, _Reason}=Error ->
                             Error;
                         {ok, Info} ->
                             case blockchain_ledger_gateway_v2:location(Info) of
                                 undefined ->
+                                    lager:info("no loc for challenger: ~p ~p", [Challenger, Info]),
                                     {error, no_gateway_location};
                                 _Location ->
                                     {ok, Height} = blockchain_ledger_v1:current_height(Ledger),

--- a/src/transactions/v1/blockchain_txn_rewards_v1.erl
+++ b/src/transactions/v1/blockchain_txn_rewards_v1.erl
@@ -619,7 +619,7 @@ poc_witnesses_rewards(Transactions,
 -spec get_gateway_owner(libp2p_crypto:pubkey_bin(), blockchain_ledger_v1:ledger())-> {ok, libp2p_crypto:pubkey_bin()}
                                                                                      | {error, any()}.
 get_gateway_owner(Address, Ledger) ->
-    case blockchain_ledger_v1:find_gateway_info(Address, Ledger) of
+    case blockchain_gateway_cache:get(Address, Ledger) of
         {error, _Reason}=Error ->
             lager:error("failed to get gateway owner for ~p: ~p", [Address, _Reason]),
             Error;


### PR DESCRIPTION
occasionally we see some ledger drift around witnesses.  a transient error here would explain them, but will be a bear to test.