### PR TITLE
strickter witness application

### DIFF
--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -1135,8 +1135,10 @@ add_gateway_witnesses(GatewayAddress, WitnessInfo, Ledger) ->
                                       case ?MODULE:find_gateway_info(WitnessAddress, Ledger) of
                                           {ok, Witness} ->
                                               blockchain_ledger_gateway_v2:add_witness(WitnessAddress, Witness, RSSI, TS, GW);
-                                          {error, _} ->
-                                              GW
+                                          {error, Reason} ->
+                                              lager:warning("exiting trying to add witness",
+                                                            [Reason]),
+                                              erlang:error({add_gateway_error, Reason})
                                       end
                               end, GW0, WitnessInfo),
             AGwsCF = active_gateways_cf(Ledger),


### PR DESCRIPTION
make it an error to have an error while applying witnesses, and also add the resync validation option for easier testing.