### PR TITLE
re-enable APIs for creating new txns which support fee args

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -45,6 +45,7 @@
 
     init_assumed_valid/2,
 
+    add_gateway_txn/4, assert_loc_txn/6,   %% tmp apis
     add_gateway_txn/2, assert_loc_txn/4,
 
     add_snapshot/2, get_snapshot/2, find_last_snapshot/1,
@@ -1639,6 +1640,15 @@ load_genesis(Dir) ->
 
 %% @doc Creates a signed add_gatewaytransaction with this blockchain's
 %% keys as the gateway, and the given owner and payer
+
+%% add_gateway_txn/4 is maintained here until clients are updated to submit txns without fee args
+-spec add_gateway_txn(OwnerB58::string(),
+                      PayerB58::string() | undefined,
+                      Fee::pos_integer(),
+                      StakingFee::non_neg_integer()) -> {ok, binary()}.
+add_gateway_txn(OwnerB58, PayerB58, _Fee, _StakingFee) ->
+    add_gateway_txn(OwnerB58, PayerB58).
+
 -spec add_gateway_txn(OwnerB58::string(),
                       PayerB58::string() | undefined) -> {ok, binary()}.
 add_gateway_txn(OwnerB58, PayerB58) ->
@@ -1658,6 +1668,17 @@ add_gateway_txn(OwnerB58, PayerB58) ->
 %% @doc Creates a signed assert_location transaction using the keys of
 %% this blockchain as the gateway to be asserted for the given
 %% location, owner and payer.
+
+%% assert_loc_txn/6 is maintained here until clients are updated to submit txns without fee args
+-spec assert_loc_txn(H3String::string(),
+                     OwnerB58::string(),
+                     PayerB58::string() | undefined,
+                     Nonce::non_neg_integer(),
+                     StakingFee::pos_integer(),
+                     Fee::pos_integer()) -> {ok, binary()}.
+assert_loc_txn(H3String, OwnerB58, PayerB58, Nonce, _StakingFee, _Fee) ->
+    assert_loc_txn(H3String, OwnerB58, PayerB58, Nonce).
+
 -spec assert_loc_txn(H3String::string(),
                      OwnerB58::string(),
                      PayerB58::string() | undefined,

--- a/src/cli/blockchain_cli_txn.erl
+++ b/src/cli/blockchain_cli_txn.erl
@@ -120,9 +120,10 @@ txn_add_gateway_cmd() ->
 
 txn_add_gateway_usage() ->
     [["txn", "add_gateway"],
-     ["txn add_gateway owner=<owner> [--payer <payer>] \n\n",
+     ["txn add_gateway owner=<owner> [--payer <payer>] [--fee <fee>] [--amount <amount>]\n\n",
       "  Creates a signed add gateway transaction required to add a new Gateway to the Helium network.\n"
-      "  Requires an owner address & optionally takes a payer address if the payer of the cost is not the same\n"
+      "  Requires an owner address, a txn fee (amount in Data Credits), and a staking fee (amount in Data Credits)\n"
+      "  Optionally takes a payer address if the payer of the cost and fee is not the same\n"
       "  as the owner.\n\n"
       "  Returns a Base64 encoded transaction to be used as an input to either the\n"
       "  Helium mobile application or the wallet CLI for signing by the owner, and payer if provided, and \n"
@@ -130,6 +131,10 @@ txn_add_gateway_usage() ->
       "Required:\n\n"
       "  <owner>\n"
       "    The b58 address of the owner of the gateway to be added.\n\n"
+      "  --fee <fee>\n"
+      "    The transaction fee for the miners, in data credits. (default 1)\n"
+      "  --amount <amount>\n"
+      "    The staking fee cost for adding the gateway, in data credits. (default 1)\n"
       "Options:\n\n"
       "  --payer <address>\n",
       "    The b58 address of the payer of the fees. Defaults to the provided owner address\n"
@@ -144,7 +149,10 @@ txn_add_gateway(_CmdBase, Keys, Flags) ->
         Owner = proplists:get_value(owner, Keys),
         %% Get options
         Payer = proplists:get_value(payer, Flags, undefined),
-        {ok, TxnBin} = blockchain:add_gateway_txn(Owner, Payer),
+        Amount = proplists:get_value(amount, Flags, 1),
+        Fee = proplists:get_value(fee, Flags, 1),
+
+        {ok, TxnBin} = blockchain:add_gateway_txn(Owner, Payer, Fee, Amount),
         TxnB64 = base64:encode_to_string(TxnBin),
         print_txn_result(TxnB64)
     catch
@@ -183,7 +191,9 @@ txn_assert_location_usage() ->
     [["txn", "assert_location"],
      ["txn assert_location owner=<owner> location=<location> [--fee <fee>] [--payer <payer>] [--nonce <nonce] [--amount <amount]\n\n",
       "  Creates a signed location assertion required to declare the location of a n Gateway on the Helium network.\n"
-      "  Requires a location (in lat/lon or h3 form), an owner address and a nonce to use. \n"
+      "  Requires a location (in lat/lon or h3 form), an owner address, a txn fee (amount in Data Credits),\n"
+      "  a staking fee (amount in Data Credits), and a nonce to use \n"
+      "  Optionally takes a payer address if the payer of the cost and fee is not the same as the owner.\n\n"
       "  Optionally takes a payer address if the payer of the cost is not the same as the owner.\n\n"
       "  Returns a Base64 encoded transaction to be used as an input to either the\n"
       "  Helium mobile application or the wallet CLI for signing by the owner, and payer if provided, and \n"
@@ -196,6 +206,9 @@ txn_assert_location_usage() ->
       "Options:\n\n"
       "  --payer <address>\n"
       "    The b58 address of the payer of the fees. Defaults to the provided owner address\n"
+      "  --amount <amount>\n"
+      "    The staking fee cost for asserting the gateway, in data credits. (default 1)\n"
+      "  --fee <fee>\n"
       "    The transaction fee for the miners, in data credits. (default 1)\n"
       "  --nonce <nonce>\n"
       "    The assert_location nonce use for the transaction. (default 1)\n"
@@ -211,9 +224,11 @@ txn_assert_location(_CmdBase, Keys, Flags) ->
         H3String = proplists:get_value(location, Keys),
         %% Get options
         Payer = proplists:get_value(payer, Flags, undefined),
+        Amount = proplists:get_value(amount, Flags, 1),
+        Fee = proplists:get_value(fee, Flags, 1),
         Nonce = proplists:get_value(nonce, Flags, 1),
         %% Construct txn and encode as b64
-        {ok, TxnBin} = blockchain:assert_loc_txn(H3String, Owner, Payer, Nonce),
+        {ok, TxnBin} = blockchain:assert_loc_txn(H3String, Owner, Payer, Nonce, Amount, Fee),
         TxnB64 = base64:encode_to_string(TxnBin),
         print_txn_result(TxnB64)
     catch

--- a/src/transactions/v1/blockchain_txn_add_gateway_v1.erl
+++ b/src/transactions/v1/blockchain_txn_add_gateway_v1.erl
@@ -15,6 +15,7 @@
 
 -export([
     new/2, new/3,
+    new/4, new/5,  %% tmp api
     hash/1,
     owner/1,
     gateway/1,
@@ -49,6 +50,17 @@
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+%% new/4 & new/5 are maintained here until clients are updated to submit txns without fee args
+-spec new(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(),
+          non_neg_integer(), non_neg_integer()) -> txn_add_gateway().
+new(OwnerAddress, GatewayAddress, _StakingFee, _Fee) ->
+    new(OwnerAddress, GatewayAddress).
+
+-spec new(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(),
+          non_neg_integer(), non_neg_integer()) -> txn_add_gateway().
+new(OwnerAddress, GatewayAddress, Payer, _StakingFee, _Fee) ->
+    new(OwnerAddress, GatewayAddress, Payer).
+
 -spec new(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin()) -> txn_add_gateway().
 new(OwnerAddress, GatewayAddress) ->
     #blockchain_txn_add_gateway_v1_pb{

--- a/src/transactions/v1/blockchain_txn_add_gateway_v1.erl
+++ b/src/transactions/v1/blockchain_txn_add_gateway_v1.erl
@@ -14,8 +14,7 @@
 -include_lib("helium_proto/include/blockchain_txn_add_gateway_v1_pb.hrl").
 
 -export([
-    new/2, new/3,
-    new/4, new/5,  %% tmp api
+    new/2, new/3, new/4, new/5,
     hash/1,
     owner/1,
     gateway/1,
@@ -50,16 +49,32 @@
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
-%% new/4 & new/5 are maintained here until clients are updated to submit txns without fee args
+
+%% NOTE: For add gateway, we need to maintain new/6 & new/7 in which the StakingFee and Fee can be supplied
+%% this is to continue to allow miner to create, sign and submit add gateway txns
+%% on behalf of mobile clients.  We cannot assume these clients will have the chain present
+%% the supplied fee value will have been calculated by the client
+%% the supplied staking fee will have been derived from the API ( which will have the chain vars )
 -spec new(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(),
           non_neg_integer(), non_neg_integer()) -> txn_add_gateway().
-new(OwnerAddress, GatewayAddress, _StakingFee, _Fee) ->
-    new(OwnerAddress, GatewayAddress).
+new(OwnerAddress, GatewayAddress, StakingFee, Fee) ->
+    #blockchain_txn_add_gateway_v1_pb{
+        owner=OwnerAddress,
+        gateway=GatewayAddress,
+        fee=Fee,
+        staking_fee=StakingFee
+    }.
 
 -spec new(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(),
           non_neg_integer(), non_neg_integer()) -> txn_add_gateway().
-new(OwnerAddress, GatewayAddress, Payer, _StakingFee, _Fee) ->
-    new(OwnerAddress, GatewayAddress, Payer).
+new(OwnerAddress, GatewayAddress, Payer, StakingFee, Fee) ->
+    #blockchain_txn_add_gateway_v1_pb{
+        owner=OwnerAddress,
+        gateway=GatewayAddress,
+        payer=Payer,
+        fee=Fee,
+        staking_fee=StakingFee
+    }.
 
 -spec new(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin()) -> txn_add_gateway().
 new(OwnerAddress, GatewayAddress) ->

--- a/src/transactions/v1/blockchain_txn_assert_location_v1.erl
+++ b/src/transactions/v1/blockchain_txn_assert_location_v1.erl
@@ -16,6 +16,7 @@
 
 -export([
     new/4, new/5,
+    new/6, new/7,   %% tmp api
     hash/1,
     gateway/1,
     owner/1,
@@ -53,6 +54,26 @@
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+%% new/4 & new/5 are maintained here until clients are updated to submit txns without fee args
+-spec new(Gateway :: libp2p_crypto:pubkey_bin(),
+          Owner :: libp2p_crypto:pubkey_bin(),
+          Location :: location(),
+          Nonce :: non_neg_integer(),
+          StakingFee :: pos_integer(),
+          Fee :: pos_integer()) -> txn_assert_location().
+new(Gateway, Owner, Location, Nonce, _StakingFee, _Fee) ->
+    new(Gateway, Owner, Location, Nonce).
+
+-spec new(Gateway :: libp2p_crypto:pubkey_bin(),
+          Owner :: libp2p_crypto:pubkey_bin(),
+          Payer :: libp2p_crypto:pubkey_bin(),
+          Location :: location(),
+          Nonce :: non_neg_integer(),
+          StakingFee :: pos_integer(),
+          Fee :: pos_integer()) -> txn_assert_location().
+new(Gateway, Owner, Payer, Location, Nonce, _StakingFee, _Fee) ->
+    new(Gateway, Owner, Payer, Location, Nonce).
+
 -spec new(Gateway :: libp2p_crypto:pubkey_bin(),
           Owner :: libp2p_crypto:pubkey_bin(),
           Location :: location(),

--- a/src/transactions/v1/blockchain_txn_create_htlc_v1.erl
+++ b/src/transactions/v1/blockchain_txn_create_htlc_v1.erl
@@ -19,6 +19,7 @@
 
 -export([
     new/7,
+    new/8,   %% tmp api
     hash/1,
     payer/1,
     payee/1,
@@ -43,6 +44,12 @@
 
 -type txn_create_htlc() :: #blockchain_txn_create_htlc_v1_pb{}.
 -export_type([txn_create_htlc/0]).
+
+%% new/8 is maintained here until clients are updated to submit txns without fee args
+-spec new(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), binary(),
+          non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()) -> txn_create_htlc().
+new(Payer, Payee, Address, Hashlock, Timelock, Amount, _Fee, Nonce) ->
+    new(Payer, Payee, Address, Hashlock, Timelock, Amount, Nonce).
 
 -spec new(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), binary(),
           non_neg_integer(), non_neg_integer(), non_neg_integer()) -> txn_create_htlc().

--- a/src/transactions/v1/blockchain_txn_oui_v1.erl
+++ b/src/transactions/v1/blockchain_txn_oui_v1.erl
@@ -15,6 +15,7 @@
 
 -export([
     new/5, new/6,
+    new/7, new/8,  %% tmp api
     hash/1,
     owner/1,
     addresses/1,
@@ -48,6 +49,31 @@
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+
+%% new/7 & new/8 are maintained here until clients are updated to submit txns without fee args
+-spec new(
+        OUI :: pos_integer(),
+        Owner :: libp2p_crypto:pubkey_bin(),
+        Addresses :: [libp2p_crypto:pubkey_bin()],
+        Filter :: binary() | undefined,
+        RequestedSubnetSize :: pos_integer() | undefined,
+        StakingFee :: pos_integer(),
+        Fee :: non_neg_integer()) -> txn_oui().
+new(OUI, Owner, Addresses, Filter, RequestedSubnetSize, _StakingFee, _Fee) ->
+    new(OUI, Owner, Addresses, Filter, RequestedSubnetSize).
+
+-spec new(
+        OUI :: pos_integer(),
+        Owner :: libp2p_crypto:pubkey_bin(),
+        Addresses :: [libp2p_crypto:pubkey_bin()],
+        Filter :: binary() | undefined,
+        RequestedSubnetSize :: pos_integer() | undefined,
+        Payer :: libp2p_crypto:pubkey_bin(),
+        StakingFee :: pos_integer(),
+        Fee :: non_neg_integer()) -> txn_oui().
+new(OUI, Owner, Addresses, Filter, RequestedSubnetSize, Payer, _StakingFee, _Fee) ->
+    new(OUI, Owner, Addresses, Filter, RequestedSubnetSize, Payer).
+
 -spec new(
         OUI :: pos_integer(),
         Owner :: libp2p_crypto:pubkey_bin(),

--- a/src/transactions/v1/blockchain_txn_payment_v1.erl
+++ b/src/transactions/v1/blockchain_txn_payment_v1.erl
@@ -16,6 +16,7 @@
 
 -export([
     new/4,
+    new/5, %% tmp api
     hash/1,
     payer/1,
     payee/1,
@@ -37,6 +38,12 @@
 
 -type txn_payment() :: #blockchain_txn_payment_v1_pb{}.
 -export_type([txn_payment/0]).
+
+%% new/5 is maintained here until clients are updated to submit txns without fee args
+-spec new(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), pos_integer(),
+          non_neg_integer(), non_neg_integer()) -> txn_payment().
+new(Payer, Recipient, Amount, _Fee, Nonce) ->
+    new(Payer, Recipient, Amount, Nonce).
 
 -spec new(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), pos_integer(),
           non_neg_integer()) -> txn_payment().

--- a/src/transactions/v1/blockchain_txn_redeem_htlc_v1.erl
+++ b/src/transactions/v1/blockchain_txn_redeem_htlc_v1.erl
@@ -14,6 +14,7 @@
 -include_lib("helium_proto/include/blockchain_txn_redeem_htlc_v1_pb.hrl").
 
 -export([
+    new/4,  %% tmp api
     new/3,
     hash/1,
     payee/1,
@@ -35,6 +36,11 @@
 
 -type txn_redeem_htlc() :: #blockchain_txn_redeem_htlc_v1_pb{}.
 -export_type([txn_redeem_htlc/0]).
+
+%% new/4 is maintained here until clients are updated to submit txns without fee args
+-spec new(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), binary(), non_neg_integer()) -> txn_redeem_htlc().
+new(Payee, Address, PreImage, _Fee) ->
+    new(Payee, Address, PreImage).
 
 -spec new(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), binary()) -> txn_redeem_htlc().
 new(Payee, Address, PreImage) ->

--- a/src/transactions/v1/blockchain_txn_routing_v1.erl
+++ b/src/transactions/v1/blockchain_txn_routing_v1.erl
@@ -15,6 +15,11 @@
 -include_lib("helium_proto/include/blockchain_txn_routing_v1_pb.hrl").
 
 -export([
+    update_router_addresses/5,  %% tmp api
+    new_xor/5,  %% tmp api
+    update_xor/6,  %% tmp api
+    request_subnet/5,  %% tmp api
+
     update_router_addresses/4,
     new_xor/4,
     update_xor/5,
@@ -47,6 +52,12 @@
 
 -export_type([txn_routing/0, action/0]).
 
+
+%% update_router_addresses/5 is maintained here until clients are updated to submit txns without fee args
+-spec update_router_addresses(non_neg_integer(), libp2p_crypto:pubkey_bin(), [binary()], non_neg_integer(), non_neg_integer()) -> txn_routing().
+update_router_addresses(OUI, Owner, Addresses, _Fee, Nonce) ->
+    update_router_addresses(OUI, Owner, Addresses, Nonce).
+
 -spec update_router_addresses(non_neg_integer(), libp2p_crypto:pubkey_bin(), [binary()], non_neg_integer()) -> txn_routing().
 update_router_addresses(OUI, Owner, Addresses, Nonce) ->
     #blockchain_txn_routing_v1_pb{
@@ -58,6 +69,11 @@ update_router_addresses(OUI, Owner, Addresses, Nonce) ->
        nonce=Nonce,
        signature= <<>>
       }.
+
+%% new_xor/5 is maintained here until clients are updated to submit txns without fee args
+-spec new_xor(non_neg_integer(), libp2p_crypto:pubkey_bin(), binary(), non_neg_integer(), non_neg_integer()) -> txn_routing().
+new_xor(OUI, Owner, Xor, _Fee, Nonce) ->
+    new_xor(OUI, Owner, Xor, Nonce).
 
 -spec new_xor(non_neg_integer(), libp2p_crypto:pubkey_bin(), binary(), non_neg_integer()) -> txn_routing().
 new_xor(OUI, Owner, Xor, Nonce) ->
@@ -71,6 +87,11 @@ new_xor(OUI, Owner, Xor, Nonce) ->
        signature= <<>>
       }.
 
+%% update_xor/6 is maintained here until clients are updated to submit txns without fee args
+-spec update_xor(non_neg_integer(), libp2p_crypto:pubkey_bin(), non_neg_integer(), binary(), non_neg_integer(), non_neg_integer()) -> txn_routing().
+update_xor(OUI, Owner, Index, Xor, _Fee, Nonce) ->
+    update_xor(OUI, Owner, Index, Xor, Nonce).
+
 -spec update_xor(non_neg_integer(), libp2p_crypto:pubkey_bin(), non_neg_integer(), binary(), non_neg_integer()) -> txn_routing().
 update_xor(OUI, Owner, Index, Xor, Nonce) ->
     #blockchain_txn_routing_v1_pb{
@@ -82,6 +103,11 @@ update_xor(OUI, Owner, Index, Xor, Nonce) ->
        nonce=Nonce,
        signature= <<>>
       }.
+
+%% request_subnet/5 is maintained here until clients are updated to submit txns without fee args
+-spec request_subnet(non_neg_integer(), libp2p_crypto:pubkey_bin(), pos_integer(), non_neg_integer(), non_neg_integer()) -> txn_routing().
+request_subnet(OUI, Owner, SubnetSize, Fee, Nonce) ->
+    request_subnet(OUI, Owner, SubnetSize, Fee, Nonce).
 
 -spec request_subnet(non_neg_integer(), libp2p_crypto:pubkey_bin(), pos_integer(), non_neg_integer()) -> txn_routing().
 request_subnet(OUI, Owner, SubnetSize, Nonce) ->

--- a/src/transactions/v1/blockchain_txn_security_exchange_v1.erl
+++ b/src/transactions/v1/blockchain_txn_security_exchange_v1.erl
@@ -14,6 +14,7 @@
 -include_lib("helium_proto/include/blockchain_txn_security_exchange_v1_pb.hrl").
 
 -export([
+    new/5,  %% tmp api
     new/4,
     hash/1,
     payer/1,
@@ -41,6 +42,12 @@
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+%% new/5 is maintained here until clients are updated to submit txns without fee args
+-spec new(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), pos_integer(),
+          non_neg_integer(), non_neg_integer()) -> txn_security_exchange().
+new(Payer, Recipient, Amount, _Fee, Nonce) ->
+    new(Payer, Recipient, Amount, Nonce).
+
 -spec new(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), pos_integer(),
           non_neg_integer()) -> txn_security_exchange().
 new(Payer, Recipient, Amount, Nonce) ->

--- a/src/transactions/v1/blockchain_txn_update_gateway_oui_v1.erl
+++ b/src/transactions/v1/blockchain_txn_update_gateway_oui_v1.erl
@@ -14,6 +14,7 @@
 
 -export([
     new/3,
+    new/4,  %% tmp api
     hash/1,
     gateway/1,
     oui/1,
@@ -41,6 +42,14 @@
 
 -type txn_update_gateway_oui() :: #blockchain_txn_update_gateway_oui_v1_pb{}.
 -export_type([txn_update_gateway_oui/0]).
+
+%% new/4 is maintained here until clients are updated to submit txns without fee args
+-spec new(Gateway :: libp2p_crypto:pubkey_bin(),
+          OUI :: pos_integer(),
+          Nonce :: non_neg_integer(),
+          Fee :: non_neg_integer()) -> txn_update_gateway_oui().
+new(Gateway, OUI, Nonce, _Fee) ->
+    new(Gateway, OUI, Nonce).
 
 -spec new(Gateway :: libp2p_crypto:pubkey_bin(),
           OUI :: pos_integer(),

--- a/src/transactions/v2/blockchain_txn_payment_v2.erl
+++ b/src/transactions/v2/blockchain_txn_payment_v2.erl
@@ -18,6 +18,7 @@
 -include_lib("helium_proto/include/blockchain_txn_payment_v2_pb.hrl").
 
 -export([
+         new/4,  %% tmp api
          new/3,
          hash/1,
          payer/1,
@@ -43,6 +44,14 @@
 -type txn_payment_v2() :: #blockchain_txn_payment_v2_pb{}.
 
 -export_type([txn_payment_v2/0]).
+
+%% new/4 is maintained here until clients are updated to submit txns without fee args
+-spec new(Payer :: libp2p_crypto:pubkey_bin(),
+          Payments :: blockchain_payment_v2:payments(),
+          Nonce :: non_neg_integer(),
+          Fee :: non_neg_integer()) -> txn_payment_v2().
+new(Payer, Payments, Nonce, _Fee) ->
+    new(Payer, Payments, Nonce).
 
 -spec new(Payer :: libp2p_crypto:pubkey_bin(),
           Payments :: blockchain_payment_v2:payments(),


### PR DESCRIPTION
Re added support for the txn 'new' apis which accept txn and staking fees ( which applicable ).  This is a temp measure until all apps and client which rely on blockchain core are updated to have the fee args removed