### PR TITLE
return invalid reason to txn mgr and then out to callback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ cover:
 	$(REBAR) cover
 
 ci:
-	$(REBAR) dialyzer && $(REBAR) do eunit,ct
+	$(REBAR) dialyzer && $(REBAR) do eunit, ct
 	$(REBAR) do cover,covertool generate
 	codecov --required -f _build/test/covertool/blockchain.covertool.xml
 

--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -833,7 +833,9 @@ send_txn(Txn) ->
                                             case Res of
                                                 ok ->
                                                     lager:info("successfully submit txn: ~s", [blockchain_txn:print(Txn)]);
-                                                {error, Reason} ->
+                                                {error, rejected = Reason} ->
+                                                    lager:error("failed to submit txn: ~s error: ~p", [blockchain_txn:print(Txn), Reason]);
+                                                {error, {invalid, _InvalidReason} = Reason} ->
                                                     lager:error("failed to submit txn: ~s error: ~p", [blockchain_txn:print(Txn), Reason])
                                             end
                                     end)).

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -201,7 +201,7 @@ validate(Transactions, Chain) ->
     validate(Transactions, Chain, false).
 
 -spec validate(txns(), blockchain:blockchain(), boolean()) ->
-                      {blockchain_txn:txns(), blockchain_txn:txns()}.
+                      {blockchain_txn:txns(), [{txn(), atom()}]}.
 validate(Transactions, _Chain, true) ->
     {Transactions, []};
 validate(Transactions, Chain0, false) ->
@@ -245,18 +245,31 @@ validate([Txn | Tail] = Txns, Valid, Invalid, PType, PBuf, Chain) ->
                         ok ->
                             maybe_log_duration(type(Txn), Start),
                             validate(Tail, [Txn|Valid], Invalid, PType, PBuf, Chain);
-                        {error, _Reason} ->
-                            lager:warning("invalid txn while absorbing ~p : ~p / ~s", [Type, _Reason, print(Txn)]),
-                            validate(Tail, Valid, [Txn | Invalid], PType, PBuf, Chain)
+                        {error, {InvalidReason, _Details}} = Error ->
+                            lager:warning("invalid txn while absorbing ~p : ~p / ~s", [Type, Error, print(Txn)]),
+                            validate(Tail, Valid, [{Txn, InvalidReason} | Invalid], PType, PBuf, Chain);
+                        {error, InvalidReason} = Error->
+                            lager:warning("invalid txn while absorbing ~p : ~p / ~s", [Type, Error, print(Txn)]),
+                            validate(Tail, Valid, [{Txn, InvalidReason} | Invalid], PType, PBuf, Chain)
                     end;
                 {error, {bad_nonce, {_NonceType, Nonce, LedgerNonce}}} when Nonce > LedgerNonce + 1 ->
                     %% we don't have enough context to decide if this transaction is valid yet, keep it
                     %% but don't include it in the block (so it stays in the buffer)
                     validate(Tail, Valid, Invalid, PType, PBuf, Chain);
+                {error, {InvalidReason, _Details}} = Error ->
+                    lager:warning("invalid txn ~p : ~p / ~s", [Type, Error, print(Txn)]),
+                    %% any other error means we drop it
+                    validate(Tail, Valid, [{Txn, InvalidReason} | Invalid], PType, PBuf, Chain);
+                {error, InvalidReason}=Error when is_atom(InvalidReason) ->
+                    lager:warning("invalid txn ~p : ~p / ~s", [Type, Error, print(Txn)]),
+                    %% any other error means we drop it
+                    validate(Tail, Valid, [{Txn, InvalidReason} | Invalid], PType, PBuf, Chain);
                 Error ->
                     lager:warning("invalid txn ~p : ~p / ~s", [Type, Error, print(Txn)]),
                     %% any other error means we drop it
-                    validate(Tail, Valid, [Txn | Invalid], PType, PBuf, Chain)
+                    %% this error is unexpected and could be a crash report or some other weirdness
+                    %% we will use a generic error reason
+                    validate(Tail, Valid, [{Txn, validation_failed} | Invalid], PType, PBuf, Chain)
             end;
         _Else ->
             Res = blockchain_utils:pmap(
@@ -277,18 +290,25 @@ separate_res([{T, ok} | Rest], Chain, V, I) ->
     case ?MODULE:absorb(T, Chain) of
         ok ->
             separate_res(Rest, Chain, [T|V], I);
-        {error, _Reason} ->
-            lager:warning("invalid txn while absorbing ~p : ~p / ~s", [type(T), _Reason, print(T)]),
-            separate_res(Rest, Chain, V, [T | I])
+        {error, {Reason, _Details}} = Error ->
+            lager:warning("invalid txn while absorbing ~p : ~p / ~s", [type(T), Error, print(T)]),
+            separate_res(Rest, Chain, V, [{T, Reason} | I]);
+        {error, Reason} ->
+            lager:warning("invalid txn while absorbing ~p : ~p / ~s", [type(T), Reason, print(T)]),
+            separate_res(Rest, Chain, V, [{T, Reason} | I])
     end;
 separate_res([{T, Err} | Rest], Chain, V, I) ->
     case Err of
         {error, {bad_nonce, {_NonceType, Nonce, LedgerNonce}}} when Nonce > LedgerNonce + 1 ->
             separate_res(Rest, Chain, V, I);
-        Error ->
+        {error, {InvalidReason, _Details}} = Error ->
             lager:warning("invalid txn ~p : ~p / ~s", [type(T), Error, print(T)]),
             %% any other error means we drop it
-            separate_res(Rest, Chain, V, [T | I])
+            separate_res(Rest, Chain, V, [{T, InvalidReason} | I]);
+        {error, InvalidReason} = Error ->
+            lager:warning("invalid txn ~p : ~p / ~s", [type(T), Error, print(T)]),
+            %% any other error means we drop it
+            separate_res(Rest, Chain, V, [{T, InvalidReason} | I])
     end.
 
 maybe_log_duration(Type, Start) ->
@@ -300,7 +320,10 @@ maybe_log_duration(Type, Start) ->
     end.
 
 types(L) ->
-    L1 = lists:map(fun type/1, L),
+    L1 = lists:map(fun
+                       ({Txn, _}) -> type(Txn);
+                       (Txn)-> type(Txn)
+                   end, L),
     M = lists:foldl(
           fun(T, Acc) ->
                   maps:update_with(T, fun(X) -> X + 1 end, 1, Acc)
@@ -537,14 +560,14 @@ validate_fields([{{Name, Field}, {binary, Length}}|Tail]) when is_binary(Field) 
         true ->
             validate_fields(Tail);
         false ->
-            {error, {field_wrong_size, Name, Length, byte_size(Field)}}
+            {error, {field_wrong_size, {Name, Length, byte_size(Field)}}}
     end;
 validate_fields([{{Name, Field}, {binary, Min, Max}}|Tail]) when is_binary(Field) ->
     case byte_size(Field) =< Max andalso byte_size(Field) >= Min of
         true ->
             validate_fields(Tail);
         false ->
-            {error, {field_wrong_size, Name, {Min, Max}, byte_size(Field)}}
+            {error, {field_wrong_size, {Name, {Min, Max}, byte_size(Field)}}}
     end;
 validate_fields([{{Name, Field}, {address, libp2p}}|Tail]) when is_binary(Field) ->
     try libp2p_crypto:bin_to_pubkey(Field) of
@@ -560,16 +583,16 @@ validate_fields([{{Name, Field}, {member, List}}|Tail]) when is_list(List),
         true ->
             validate_fields(Tail);
         false ->
-            {error, {not_a_member, Name, Field, List}}
+            {error, {not_a_member, {Name, Field, List}}}
     end;
 validate_fields([{{_Name, Field}, {is_integer, Min}}|Tail]) when is_integer(Field)
                                                          andalso Field >= Min ->
     validate_fields(Tail);
 validate_fields([{{Name, Field}, {is_integer, Min}}|_Tail]) when is_integer(Field)
                                                          andalso Field < Min ->
-    {error, {integer_too_small, Name, Field, Min}};
+    {error, {integer_too_small, {Name, Field, Min}}};
 validate_fields([{{Name, Field}, {is_integer, _Min}}|_Tail]) ->
-    {error, {not_an_integer, Name, Field}};
+    {error, {not_an_integer, {Name, Field}}};
 validate_fields([{{Name, undefined}, _}|_Tail]) ->
     {error, {missing_field, Name}};
 validate_fields([{{Name, _Field}, _Validation}|_Tail]) ->

--- a/src/transactions/v1/blockchain_txn_add_gateway_v1.erl
+++ b/src/transactions/v1/blockchain_txn_add_gateway_v1.erl
@@ -294,7 +294,7 @@ is_valid_staking_key(#blockchain_txn_add_gateway_v1_pb{payer=Payer}=_Txn, Ledger
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec is_valid(txn_add_gateway(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec is_valid(txn_add_gateway(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     case {?MODULE:is_valid_owner(Txn),
@@ -318,9 +318,9 @@ is_valid(Txn, Chain) ->
             ExpectedTxnFee = ?MODULE:calculate_fee(Txn, Chain),
             case {(ExpectedTxnFee =< TxnFee orelse not AreFeesEnabled), ExpectedStakingFee == StakingFee} of
                 {false,_} ->
-                    {error, {wrong_txn_fee, ExpectedTxnFee, TxnFee}};
+                    {error, {wrong_txn_fee, {ExpectedTxnFee, TxnFee}}};
                 {_,false} ->
-                    {error, {wrong_staking_fee, ExpectedStakingFee, StakingFee}};
+                    {error, {wrong_staking_fee, {ExpectedStakingFee, StakingFee}}};
                 {true, true} ->
                     Payer = ?MODULE:payer(Txn),
                     Owner = ?MODULE:owner(Txn),
@@ -338,7 +338,7 @@ is_valid(Txn, Chain) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec absorb(txn_add_gateway(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec absorb(txn_add_gateway(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     AreFeesEnabled = blockchain_ledger_v1:txn_fees_active(Ledger),

--- a/src/transactions/v1/blockchain_txn_assert_location_v1.erl
+++ b/src/transactions/v1/blockchain_txn_assert_location_v1.erl
@@ -287,7 +287,7 @@ is_valid_payer(#blockchain_txn_assert_location_v1_pb{payer=PubKeyBin,
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec is_valid(txn_assert_location(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec is_valid(txn_assert_location(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     case {?MODULE:is_valid_owner(Txn),
@@ -314,9 +314,9 @@ is_valid(Txn, Chain) ->
             ExpectedTxnFee = calculate_fee(Txn, Chain),
             case {(ExpectedTxnFee =< TxnFee orelse not AreFeesEnabled), ExpectedStakingFee == StakingFee} of
                 {false,_} ->
-                    {error, {wrong_txn_fee, ExpectedTxnFee, TxnFee}};
+                    {error, {wrong_txn_fee, {ExpectedTxnFee, TxnFee}}};
                 {_,false} ->
-                    {error, {wrong_staking_fee, ExpectedStakingFee, StakingFee}};
+                    {error, {wrong_staking_fee, {ExpectedStakingFee, StakingFee}}};
                 {true, true} ->
                     case blockchain_ledger_v1:check_dc_or_hnt_balance(ActualPayer, TxnFee + StakingFee, Ledger, AreFeesEnabled) of
                         {error, _}=Error ->
@@ -325,7 +325,7 @@ is_valid(Txn, Chain) ->
                             Gateway = ?MODULE:gateway(Txn),
                             case blockchain_gateway_cache:get(Gateway, Ledger) of
                                 {error, _} ->
-                                    {error, {unknown_gateway, Gateway, Ledger}};
+                                    {error, {unknown_gateway, {Gateway, Ledger}}};
                                 {ok, GwInfo} ->
                                     GwOwner = blockchain_ledger_gateway_v2:owner_address(GwInfo),
                                     case Owner == GwOwner of
@@ -356,7 +356,7 @@ is_valid(Txn, Chain) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec absorb(txn_assert_location(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec absorb(txn_assert_location(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     AreFeesEnabled = blockchain_ledger_v1:txn_fees_active(Ledger),

--- a/src/transactions/v1/blockchain_txn_bundle_v1.erl
+++ b/src/transactions/v1/blockchain_txn_bundle_v1.erl
@@ -39,7 +39,7 @@ hash(#blockchain_txn_bundle_v1_pb{transactions=Txns}) ->
     TxnHashes = [blockchain_txn:hash(T) || T <- Txns],
     crypto:hash(sha256, TxnHashes).
 
--spec absorb(txn_bundle(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec absorb(txn_bundle(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(#blockchain_txn_bundle_v1_pb{transactions=Txns}=_Txn, Chain) ->
     lists:foreach(fun(T) -> blockchain_txn:absorb(T, Chain) end, Txns).
 
@@ -56,7 +56,7 @@ fee(_TxnBundle) ->
 txns(#blockchain_txn_bundle_v1_pb{transactions=Txns}) ->
     Txns.
 
--spec is_valid(txn_bundle(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec is_valid(txn_bundle(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(#blockchain_txn_bundle_v1_pb{transactions=Txns}=Txn, Chain) ->
     TxnBundleSize = length(Txns),
     MaxBundleSize = max_bundle_size(Chain),
@@ -69,7 +69,7 @@ is_valid(#blockchain_txn_bundle_v1_pb{transactions=Txns}=Txn, Chain) ->
             %% check that the bundle size doesn't exceed allowed max_bundle_size var
             case TxnBundleSize > MaxBundleSize of
                 true ->
-                    {error, {bundle_size_exceeded, TxnBundleSize, MaxBundleSize}};
+                    {error, {bundle_size_exceeded, {TxnBundleSize, MaxBundleSize}}};
                 false ->
                     %% check that there are no bundles in the bundle txn
                     case lists:any(fun(T) ->

--- a/src/transactions/v1/blockchain_txn_coinbase_v1.erl
+++ b/src/transactions/v1/blockchain_txn_coinbase_v1.erl
@@ -87,7 +87,7 @@ fee(_Txn) ->
 %% This transaction is only allowed in the genesis block
 %% @end
 %%--------------------------------------------------------------------
--spec is_valid(txn_coinbase(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec is_valid(txn_coinbase(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     case blockchain_ledger_v1:current_height(Ledger) of
@@ -107,7 +107,7 @@ is_valid(Txn, Chain) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec absorb(txn_coinbase(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec absorb(txn_coinbase(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Payee = ?MODULE:payee(Txn),

--- a/src/transactions/v1/blockchain_txn_create_htlc_v1.erl
+++ b/src/transactions/v1/blockchain_txn_create_htlc_v1.erl
@@ -142,7 +142,7 @@ sign(Txn, SigFun) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec is_valid(txn_create_htlc(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec is_valid(txn_create_htlc(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Payer = ?MODULE:payer(Txn),
@@ -201,7 +201,7 @@ is_valid(Txn, Chain) ->
                                                     ExpectedTxnFee = calculate_fee(Txn, Chain),
                                                     case (ExpectedTxnFee =< TxnFee orelse not AreFeesEnabled) of
                                                         false ->
-                                                            {error, {wrong_txn_fee, ExpectedTxnFee, TxnFee}};
+                                                            {error, {wrong_txn_fee, {ExpectedTxnFee, TxnFee}}};
                                                         true ->
                                                             blockchain_ledger_v1:check_dc_or_hnt_balance(Payer, TxnFee, Ledger, AreFeesEnabled)
                                                     end
@@ -218,7 +218,7 @@ is_valid(Txn, Chain) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec absorb(txn_create_htlc(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec absorb(txn_create_htlc(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Amount = ?MODULE:amount(Txn),

--- a/src/transactions/v1/blockchain_txn_dc_coinbase_v1.erl
+++ b/src/transactions/v1/blockchain_txn_dc_coinbase_v1.erl
@@ -89,7 +89,7 @@ fee(_Txn) ->
 %% This transaction is only allowed in the genesis block
 %% @end
 %%--------------------------------------------------------------------
--spec is_valid(txn_dc_coinbase(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec is_valid(txn_dc_coinbase(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     case blockchain_ledger_v1:current_height(Ledger) of
@@ -109,7 +109,7 @@ is_valid(Txn, Chain) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec absorb(txn_dc_coinbase(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec absorb(txn_dc_coinbase(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Payee = ?MODULE:payee(Txn),

--- a/src/transactions/v1/blockchain_txn_gen_gateway_v1.erl
+++ b/src/transactions/v1/blockchain_txn_gen_gateway_v1.erl
@@ -118,7 +118,7 @@ fee(_Txn) ->
 %% This transaction should only be absorbed when it's in the genesis block
 %% @end
 %%--------------------------------------------------------------------
--spec is_valid(txn_genesis_gateway(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec is_valid(txn_genesis_gateway(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(_Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     case blockchain_ledger_v1:current_height(Ledger) of
@@ -132,7 +132,7 @@ is_valid(_Txn, Chain) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec absorb(txn_genesis_gateway(), blockchain:blockchain()) -> ok | {error, not_in_genesis_block}.
+-spec absorb(txn_genesis_gateway(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Gateway = ?MODULE:gateway(Txn),

--- a/src/transactions/v1/blockchain_txn_gen_price_oracle_v1.erl
+++ b/src/transactions/v1/blockchain_txn_gen_price_oracle_v1.erl
@@ -82,7 +82,7 @@ fee(_Txn) ->
 %% This transaction should only be absorbed when it's in the genesis block
 %% @end
 %%--------------------------------------------------------------------
--spec is_valid(txn_genesis_price_oracle(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec is_valid(txn_genesis_price_oracle(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Price = price(Txn),

--- a/src/transactions/v1/blockchain_txn_payment_v1.erl
+++ b/src/transactions/v1/blockchain_txn_payment_v1.erl
@@ -112,7 +112,7 @@ calculate_fee(_Txn, _Ledger, _DCPayloadSize, _TxnFeeMultiplier, false) ->
 calculate_fee(Txn, Ledger, DCPayloadSize, TxnFeeMultiplier, true) ->
     ?calculate_fee(Txn#blockchain_txn_payment_v1_pb{fee=0, signature = <<0:512>>}, Ledger, DCPayloadSize, TxnFeeMultiplier).
 
--spec is_valid(txn_payment(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec is_valid(txn_payment(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Payer = ?MODULE:payer(Txn),
@@ -157,7 +157,7 @@ is_valid(Txn, Chain) ->
                                                 ExpectedTxnFee = ?MODULE:calculate_fee(Txn, Chain),
                                                 case ExpectedTxnFee =< TxnFee orelse not AreFeesEnabled of
                                                     false ->
-                                                        {error, {wrong_txn_fee, ExpectedTxnFee, TxnFee}};
+                                                        {error, {wrong_txn_fee, {ExpectedTxnFee, TxnFee}}};
                                                     true ->
                                                         blockchain_ledger_v1:check_dc_or_hnt_balance(Payer, TxnFee, Ledger, AreFeesEnabled)
                                                 end
@@ -171,7 +171,7 @@ is_valid(Txn, Chain) ->
             end
     end.
 
--spec absorb(txn_payment(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec absorb(txn_payment(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Amount = ?MODULE:amount(Txn),

--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -132,7 +132,7 @@ sign(Txn, SigFun) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec is_valid(txn_poc_receipts(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec is_valid(txn_poc_receipts(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Challenger = ?MODULE:challenger(Txn),
@@ -539,7 +539,7 @@ good_quality_witnesses(Element, Ledger) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
- -spec absorb(txn_poc_receipts(), blockchain:blockchain()) -> ok | {error, any()}.
+ -spec absorb(txn_poc_receipts(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(Txn, Chain) ->
     LastOnionKeyHash = ?MODULE:onion_key_hash(Txn),
     Challenger = ?MODULE:challenger(Txn),

--- a/src/transactions/v1/blockchain_txn_poc_request_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_request_v1.erl
@@ -138,7 +138,7 @@ sign(Txn0, SigFun) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec is_valid(txn_poc_request(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec is_valid(txn_poc_request(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Challenger = ?MODULE:challenger(Txn),
@@ -196,7 +196,7 @@ is_valid(Txn, Chain) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec absorb(txn_poc_request(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec absorb(txn_poc_request(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Challenger = ?MODULE:challenger(Txn),

--- a/src/transactions/v1/blockchain_txn_price_oracle_v1.erl
+++ b/src/transactions/v1/blockchain_txn_price_oracle_v1.erl
@@ -145,7 +145,7 @@ sign(Txn, SigFun) ->
 %% `price_oracle_height_delta' chain variable.
 %% @end
 %%--------------------------------------------------------------------
--spec is_valid(txn_price_oracle(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec is_valid(txn_price_oracle(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Price = ?MODULE:price(Txn),
@@ -185,7 +185,7 @@ is_valid(Txn, Chain) ->
 %% ledger
 %% @end
 %%--------------------------------------------------------------------
--spec absorb(txn_price_oracle(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec absorb(txn_price_oracle(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     {ok, LedgerHeight} = blockchain_ledger_v1:current_height(Ledger),

--- a/src/transactions/v1/blockchain_txn_redeem_htlc_v1.erl
+++ b/src/transactions/v1/blockchain_txn_redeem_htlc_v1.erl
@@ -109,7 +109,7 @@ calculate_fee(Txn, Ledger, DCPayloadSize, TxnFeeMultiplier, true) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec is_valid(txn_redeem_htlc(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec is_valid(txn_redeem_htlc(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Redeemer = ?MODULE:payee(Txn),
@@ -143,7 +143,7 @@ is_valid(Txn, Chain) ->
                             ExpectedTxnFee = ?MODULE:calculate_fee(Txn, Chain),
                             case ExpectedTxnFee =< TxnFee orelse not AreFeesEnabled of
                                 false ->
-                                    {error, {wrong_txn_fee, ExpectedTxnFee, TxnFee}};
+                                    {error, {wrong_txn_fee, {ExpectedTxnFee, TxnFee}}};
                                 true ->
                                     case blockchain_ledger_v1:check_dc_or_hnt_balance(Redeemer, TxnFee, Ledger, AreFeesEnabled) of
                                         {error, _Reason}=Error ->
@@ -191,7 +191,7 @@ is_valid(Txn, Chain) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec absorb(txn_redeem_htlc(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec absorb(txn_redeem_htlc(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Fee = ?MODULE:fee(Txn),

--- a/src/transactions/v1/blockchain_txn_reward_v1.erl
+++ b/src/transactions/v1/blockchain_txn_reward_v1.erl
@@ -97,6 +97,9 @@ type(Reward) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
+%% NOTE: this is_valid function is never called.
+%%       should it be brought into play in the future, it needs updating
+%%       to return ok | {error, Reason} rather than a boolean
 -spec is_valid(Reward :: reward()) -> boolean().
 is_valid(#blockchain_txn_reward_v1_pb{account=Account, gateway=Gateway,
                                       amount=Amount, type=Type}) ->

--- a/src/transactions/v1/blockchain_txn_rewards_v1.erl
+++ b/src/transactions/v1/blockchain_txn_rewards_v1.erl
@@ -105,7 +105,7 @@ fee(_Txn) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec is_valid(txn_rewards(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec is_valid(txn_rewards(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(Txn, Chain) ->
     Start = ?MODULE:start_epoch(Txn),
     End = ?MODULE:end_epoch(Txn),
@@ -126,7 +126,7 @@ is_valid(Txn, Chain) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec absorb(txn_rewards(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec absorb(txn_rewards(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Rewards = ?MODULE:rewards(Txn),

--- a/src/transactions/v1/blockchain_txn_security_coinbase_v1.erl
+++ b/src/transactions/v1/blockchain_txn_security_coinbase_v1.erl
@@ -87,7 +87,7 @@ fee(_Txn) ->
 %% This transaction is only allowed in the genesis block
 %% @end
 %%--------------------------------------------------------------------
--spec is_valid(txn_security_coinbase(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec is_valid(txn_security_coinbase(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     case blockchain_ledger_v1:current_height(Ledger) of
@@ -107,7 +107,7 @@ is_valid(Txn, Chain) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec absorb(txn_security_coinbase(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec absorb(txn_security_coinbase(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Payee = ?MODULE:payee(Txn),

--- a/src/transactions/v1/blockchain_txn_security_exchange_v1.erl
+++ b/src/transactions/v1/blockchain_txn_security_exchange_v1.erl
@@ -172,7 +172,7 @@ calculate_fee(Txn, Ledger, DCPayloadSize, TxnFeeMultiplier, true) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec is_valid(txn_security_exchange(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec is_valid(txn_security_exchange(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Payer = ?MODULE:payer(Txn),
@@ -197,7 +197,7 @@ is_valid(Txn, Chain) ->
                                     ExpectedTxnFee = ?MODULE:calculate_fee(Txn, Chain),
                                     case ExpectedTxnFee =< TxnFee orelse not AreFeesEnabled of
                                         false ->
-                                            {error, {wrong_txn_fee, ExpectedTxnFee, TxnFee}};
+                                            {error, {wrong_txn_fee, {ExpectedTxnFee, TxnFee}}};
                                         true ->
                                             blockchain_ledger_v1:check_dc_or_hnt_balance(Payer, TxnFee, Ledger, AreFeesEnabled)
                                     end;
@@ -215,7 +215,7 @@ is_valid(Txn, Chain) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec absorb(txn_security_exchange(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec absorb(txn_security_exchange(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Amount = ?MODULE:amount(Txn),

--- a/src/transactions/v1/blockchain_txn_state_channel_close_v1.erl
+++ b/src/transactions/v1/blockchain_txn_state_channel_close_v1.erl
@@ -122,7 +122,7 @@ calculate_fee(_Txn, _Ledger, _DCPayloadSize, _TxnFeeMultiplier, false) ->
 calculate_fee(_Txn, _Ledger, _DCPayloadSize, _TxnFeeMultiplier, true) ->
     0.  %% for now we are defaulting close fees to 0
 
--spec is_valid(txn_state_channel_close(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec is_valid(txn_state_channel_close(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     {ok, LedgerHeight} = blockchain_ledger_v1:current_height(Ledger),
@@ -311,7 +311,7 @@ is_causally_correct(OlderSC, CurrentSC, Ledger) ->
             true
     end.
 
--spec absorb(txn_state_channel_close(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec absorb(txn_state_channel_close(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     AreFeesEnabled = blockchain_ledger_v1:txn_fees_active(Ledger),

--- a/src/transactions/v1/blockchain_txn_state_channel_open_v1.erl
+++ b/src/transactions/v1/blockchain_txn_state_channel_open_v1.erl
@@ -124,7 +124,7 @@ calculate_fee(Txn, Ledger, DCPayloadSize, TxnFeeMultiplier, true) ->
     ?calculate_fee(Txn#blockchain_txn_state_channel_open_v1_pb{fee=0, signature = <<0:512>>}, Ledger, DCPayloadSize, TxnFeeMultiplier).
 
 -spec is_valid(Txn :: txn_state_channel_open(),
-               Chain :: blockchain:blockchain()) -> ok | {error, any()}.
+               Chain :: blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(Txn, Chain) ->
     Owner = ?MODULE:owner(Txn),
     Signature = ?MODULE:signature(Txn),
@@ -139,7 +139,7 @@ is_valid(Txn, Chain) ->
     end.
 
 -spec absorb(Txn :: txn_state_channel_open(),
-             Chain :: blockchain:blockchain()) -> ok | {error, any()}.
+             Chain :: blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     AreFeesEnabled = blockchain_ledger_v1:txn_fees_active(Ledger),
@@ -191,7 +191,7 @@ to_json(Txn, _Opts) ->
       amount => amount(Txn)
      }.
 
--spec do_is_valid_checks(txn_state_channel_open(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec do_is_valid_checks(txn_state_channel_open(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 do_is_valid_checks(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     ExpireWithin = ?MODULE:expire_within(Txn),
@@ -210,7 +210,7 @@ do_is_valid_checks(Txn, Chain) ->
                             case blockchain_ledger_v1:find_routing(OUI, Ledger) of
                                 {error, not_found} ->
                                     lager:error("oui: ~p not found for this router: ~p", [OUI, Owner]),
-                                    {error, {not_found, OUI, Owner}};
+                                    {error, {not_found, {OUI, Owner}}};
                                 {ok, Routing} ->
                                     KnownRouters = blockchain_ledger_routing_v1:addresses(Routing),
                                     case lists:member(Owner, KnownRouters) of
@@ -233,7 +233,7 @@ do_is_valid_checks(Txn, Chain) ->
                                                             ExpectedTxnFee = ?MODULE:calculate_fee(Txn, Chain),
                                                             case ExpectedTxnFee =< TxnFee orelse not AreFeesEnabled of
                                                                 false ->
-                                                                    {error, {wrong_txn_fee, ExpectedTxnFee, TxnFee}};
+                                                                    {error, {wrong_txn_fee, {ExpectedTxnFee, TxnFee}}};
                                                                 true ->
                                                                     case blockchain:config(?sc_open_validation_bugfix, Ledger) of
                                                                         {ok, 1} ->

--- a/src/transactions/v1/blockchain_txn_token_burn_exchange_rate_v1.erl
+++ b/src/transactions/v1/blockchain_txn_token_burn_exchange_rate_v1.erl
@@ -6,6 +6,10 @@
 %%%-------------------------------------------------------------------
 -module(blockchain_txn_token_burn_exchange_rate_v1).
 
+%%
+%% TODO: if this txn type has never been used we should remove this module and associated code
+%%
+
 -behavior(blockchain_txn).
 
 -behavior(blockchain_json).
@@ -78,7 +82,7 @@ fee(_Txn) ->
 %% This transaction is only allowed in the genesis block
 %% @end
 %%--------------------------------------------------------------------
--spec is_valid(txn_token_burn_exchange_rate(), blockchain:blockchain()) -> {error, any()}.
+-spec is_valid(txn_token_burn_exchange_rate(), blockchain:blockchain()) -> {error, atom()} | {error, {atom(), any()}}.
 is_valid(_Txn, _Chain) ->
     {error, not_implemented}.
     % Amount = ?MODULE:rate(Txn),
@@ -93,7 +97,7 @@ is_valid(_Txn, _Chain) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec absorb(txn_token_burn_exchange_rate(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec absorb(txn_token_burn_exchange_rate(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Rate = ?MODULE:rate(Txn),

--- a/src/transactions/v1/blockchain_txn_token_burn_v1.erl
+++ b/src/transactions/v1/blockchain_txn_token_burn_v1.erl
@@ -133,7 +133,7 @@ calculate_fee(Txn, Ledger, DCPayloadSize, TxnFeeMultiplier, true) ->
     ?calculate_fee(Txn#blockchain_txn_token_burn_v1_pb{fee=0, signature= <<0:512>>}, Ledger, DCPayloadSize, TxnFeeMultiplier).
 
 
--spec is_valid(txn_token_burn(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec is_valid(txn_token_burn(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Payer = ?MODULE:payer(Txn),
@@ -162,7 +162,7 @@ is_valid(Txn, Chain) ->
                                     ExpectedTxnFee = ?MODULE:calculate_fee(Txn, Chain),
                                     case ExpectedTxnFee =< TxnFee orelse not AreFeesEnabled of
                                         false ->
-                                            {error, {wrong_txn_fee, ExpectedTxnFee, TxnFee}};
+                                            {error, {wrong_txn_fee, {ExpectedTxnFee, TxnFee}}};
                                         true ->
                                             blockchain_ledger_v1:check_dc_or_hnt_balance(Payer, TxnFee, Ledger, AreFeesEnabled)
                                     end
@@ -173,7 +173,7 @@ is_valid(Txn, Chain) ->
             Error
     end.
 
--spec absorb(txn_token_burn(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec absorb(txn_token_burn(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     HNTAmount = ?MODULE:amount(Txn),

--- a/src/transactions/v1/blockchain_txn_update_gateway_oui_v1.erl
+++ b/src/transactions/v1/blockchain_txn_update_gateway_oui_v1.erl
@@ -142,7 +142,7 @@ calculate_fee(Txn, Ledger, DCPayloadSize, TxnFeeMultiplier, true) ->
     ?calculate_fee(Txn#blockchain_txn_update_gateway_oui_v1_pb{fee=0, gateway_owner_signature = <<0:512>>, oui_owner_signature = <<0:512>>}, Ledger, DCPayloadSize, TxnFeeMultiplier).
 
 
--spec is_valid(txn_update_gateway_oui(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec is_valid(txn_update_gateway_oui(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     case {validate_oui(Txn, Ledger),
@@ -164,14 +164,14 @@ is_valid(Txn, Chain) ->
                     ExpectedTxnFee = ?MODULE:calculate_fee(Txn, Chain),
                     case ExpectedTxnFee =< TxnFee orelse not AreFeesEnabled of
                         false ->
-                            {error, {wrong_txn_fee, ExpectedTxnFee, TxnFee}};
+                            {error, {wrong_txn_fee, {ExpectedTxnFee, TxnFee}}};
                         true ->
                             blockchain_ledger_v1:check_dc_or_hnt_balance(GatewayOwner, TxnFee, Ledger, AreFeesEnabled)
                     end
             end
     end.
 
--spec absorb(txn_update_gateway_oui(), blockchain:blockchain()) -> ok | {error, any()}.
+-spec absorb(txn_update_gateway_oui(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Gateway = ?MODULE:gateway(Txn),

--- a/src/transactions/v2/blockchain_txn_payment_v2.erl
+++ b/src/transactions/v2/blockchain_txn_payment_v2.erl
@@ -215,7 +215,7 @@ do_is_valid_checks(Txn, Chain, MaxPayments) ->
                     case LengthPayments > MaxPayments of
                         %% Check that we don't exceed max payments
                         true ->
-                            {error, {exceeded_max_payments, LengthPayments, MaxPayments}};
+                            {error, {exceeded_max_payments, {LengthPayments, MaxPayments}}};
                         false ->
                             case lists:member(Payer, ?MODULE:payees(Txn)) of
                                 false ->
@@ -242,7 +242,7 @@ do_is_valid_checks(Txn, Chain, MaxPayments) ->
                                                     ExpectedTxnFee = ?MODULE:calculate_fee(Txn, Chain),
                                                     case ExpectedTxnFee =< TxnFee orelse not AreFeesEnabled of
                                                         false ->
-                                                            {error, {wrong_txn_fee, ExpectedTxnFee, TxnFee}};
+                                                            {error, {wrong_txn_fee, {ExpectedTxnFee, TxnFee}}};
                                                         true ->
                                                             blockchain_ledger_v1:check_dc_or_hnt_balance(Payer, TxnFee, Ledger, AreFeesEnabled)
                                                     end

--- a/test/blockchain_payment_v2_SUITE.erl
+++ b/test/blockchain_payment_v2_SUITE.erl
@@ -269,7 +269,7 @@ max_payments_test(Config) ->
     SigFun = libp2p_crypto:mk_sig_fun(PayerPrivKey),
     SignedTx = blockchain_txn_payment_v2:sign(Tx, SigFun),
 
-    ?assertEqual({error, {exceeded_max_payments, length(Payments), ?MAX_PAYMENTS}},
+    ?assertEqual({error, {exceeded_max_payments, {length(Payments), ?MAX_PAYMENTS}}},
                  blockchain_txn_payment_v2:is_valid(SignedTx, Chain)),
 
     ok.
@@ -322,7 +322,7 @@ zero_amount_test(Config) ->
     %% Placeholder: update when we land a better version of add_block in test_utils
     %% which does validations, this will suffice for now
     %% NOTE: SignedTx being in the second pos implies it's invalid
-    {[], [SignedTx]} = blockchain_txn:validate([SignedTx], Chain),
+    {[], [{SignedTx, _InvalidReason}]} = blockchain_txn:validate([SignedTx], Chain),
     ok.
 
 negative_amount_test(Config) ->
@@ -346,5 +346,5 @@ negative_amount_test(Config) ->
     %% Placeholder: update when we land a better version of add_block in test_utils
     %% which does validations, this will suffice for now
     %% NOTE: SignedTx being in the second pos implies it's invalid
-    {[], [SignedTx]} = blockchain_txn:validate([SignedTx], Chain),
+    {[], [{SignedTx, _InvalidReason}]} = blockchain_txn:validate([SignedTx], Chain),
     ok.

--- a/test/blockchain_price_oracle_SUITE.erl
+++ b/test/blockchain_price_oracle_SUITE.erl
@@ -511,7 +511,7 @@ txn_fees_pay_with_dc(Config) ->
     SignedBurnTx2 = blockchain_txn_token_burn_v1:sign(BurnTx2, PayerSigFun),
 
     %% check is_valid behaves as expected and returns correct error msgs
-    ?assertMatch({error,{wrong_txn_fee,_,0}}, blockchain_txn_token_burn_v1:is_valid(SignedBurnTx0, Chain)),
+    ?assertMatch({error,{wrong_txn_fee,{_,0}}}, blockchain_txn_token_burn_v1:is_valid(SignedBurnTx0, Chain)),
     ?assertMatch(ok, blockchain_txn_token_burn_v1:is_valid(SignedBurnTx1, Chain)),
     ?assertMatch(ok, blockchain_txn_token_burn_v1:is_valid(SignedBurnTx2, Chain)),
     %% check create block on tx with invalid txn fee
@@ -568,9 +568,9 @@ txn_fees_pay_with_dc(Config) ->
     SignedOUITx4 = blockchain_txn_oui_v1:sign(OUITx4, PayerSigFun),
 
     %% check is_valid behaves as expected and returns correct error msgs
-    ?assertMatch({error,{wrong_txn_fee,_,0}}, blockchain_txn_oui_v1:is_valid(SignedOUITx0, Chain)),
-    ?assertMatch({error,{wrong_staking_fee,_,1}}, blockchain_txn_oui_v1:is_valid(SignedOUITx1, Chain)),
-    ?assertMatch({error,{wrong_staking_fee,_,_}}, blockchain_txn_oui_v1:is_valid(SignedOUITx4, Chain)),
+    ?assertMatch({error,{wrong_txn_fee,{_,0}}}, blockchain_txn_oui_v1:is_valid(SignedOUITx0, Chain)),
+    ?assertMatch({error,{wrong_staking_fee,{_,1}}}, blockchain_txn_oui_v1:is_valid(SignedOUITx1, Chain)),
+    ?assertMatch({error,{wrong_staking_fee,{_,_}}}, blockchain_txn_oui_v1:is_valid(SignedOUITx4, Chain)),
     ?assertMatch(ok, blockchain_txn_oui_v1:is_valid(SignedOUITx2, Chain)),
     ?assertMatch(ok, blockchain_txn_oui_v1:is_valid(SignedOUITx3, Chain)),
     %% check create block on tx with invalid txn fee and invalid staking fee
@@ -633,9 +633,9 @@ txn_fees_pay_with_dc(Config) ->
     SignedPayerAddGatewayTx4 = blockchain_txn_add_gateway_v1:sign_payer(SignedGatewayAddGatewayTx4, PayerSigFun),
 
     %% check is_valid behaves as expected and returns correct error msgs
-    ?assertMatch({error,{wrong_txn_fee,_,0}}, blockchain_txn_add_gateway_v1:is_valid(SignedPayerAddGatewayTx0, Chain)),
-    ?assertMatch({error,{wrong_staking_fee,_,1}}, blockchain_txn_add_gateway_v1:is_valid(SignedPayerAddGatewayTx1, Chain)),
-    ?assertMatch({error,{wrong_staking_fee,_,_}}, blockchain_txn_add_gateway_v1:is_valid(SignedPayerAddGatewayTx4, Chain)),
+    ?assertMatch({error,{wrong_txn_fee,{_,0}}}, blockchain_txn_add_gateway_v1:is_valid(SignedPayerAddGatewayTx0, Chain)),
+    ?assertMatch({error,{wrong_staking_fee,{_,1}}}, blockchain_txn_add_gateway_v1:is_valid(SignedPayerAddGatewayTx1, Chain)),
+    ?assertMatch({error,{wrong_staking_fee,{_,_}}}, blockchain_txn_add_gateway_v1:is_valid(SignedPayerAddGatewayTx4, Chain)),
     ?assertMatch(ok, blockchain_txn_add_gateway_v1:is_valid(SignedPayerAddGatewayTx2, Chain)),
     ?assertMatch(ok, blockchain_txn_add_gateway_v1:is_valid(SignedPayerAddGatewayTx3, Chain)),
     %% check create block on tx with invalid txn fee and invalid staking fee
@@ -693,9 +693,9 @@ txn_fees_pay_with_dc(Config) ->
     SignedPayerAssertLocationTx4 = blockchain_txn_assert_location_v1:sign_payer(SignedAssertLocationTx4, PayerSigFun),
 
     %% check is_valid behaves as expected and returns correct error msgs
-    ?assertMatch({error,{wrong_txn_fee,_,0}}, blockchain_txn_assert_location_v1:is_valid(SignedPayerAssertLocationTx0, Chain)),
-    ?assertMatch({error,{wrong_staking_fee,_,1}}, blockchain_txn_assert_location_v1:is_valid(SignedPayerAssertLocationTx1, Chain)),
-    ?assertMatch({error,{wrong_staking_fee,_,_}}, blockchain_txn_assert_location_v1:is_valid(SignedPayerAssertLocationTx4, Chain)),
+    ?assertMatch({error,{wrong_txn_fee,{_,0}}}, blockchain_txn_assert_location_v1:is_valid(SignedPayerAssertLocationTx0, Chain)),
+    ?assertMatch({error,{wrong_staking_fee,{_,1}}}, blockchain_txn_assert_location_v1:is_valid(SignedPayerAssertLocationTx1, Chain)),
+    ?assertMatch({error,{wrong_staking_fee,{_,_}}}, blockchain_txn_assert_location_v1:is_valid(SignedPayerAssertLocationTx4, Chain)),
     ?assertMatch(ok, blockchain_txn_assert_location_v1:is_valid(SignedPayerAssertLocationTx2, Chain)),
     ?assertMatch(ok, blockchain_txn_assert_location_v1:is_valid(SignedPayerAssertLocationTx3, Chain)),
     %% check create block on tx with invalid txn fee and invalid staking fee
@@ -743,7 +743,7 @@ txn_fees_pay_with_dc(Config) ->
     SignedCreateHTLCTx2 = blockchain_txn_create_htlc_v1:sign(CreateHTLCTx2, PayerSigFun),
 
     %% check is_valid behaves as expected and returns correct error msgs
-    ?assertMatch({error,{wrong_txn_fee,_,0}}, blockchain_txn_create_htlc_v1:is_valid(SignedCreateHTLCTx0, Chain)),
+    ?assertMatch({error,{wrong_txn_fee,{_,0}}}, blockchain_txn_create_htlc_v1:is_valid(SignedCreateHTLCTx0, Chain)),
     ?assertMatch(ok, blockchain_txn_create_htlc_v1:is_valid(SignedCreateHTLCTx1, Chain)),
     ?assertMatch(ok, blockchain_txn_create_htlc_v1:is_valid(SignedCreateHTLCTx2, Chain)),
     %% check create block on tx with invalid txn fee
@@ -792,7 +792,7 @@ txn_fees_pay_with_dc(Config) ->
     SignedRedeemTx2 = blockchain_txn_redeem_htlc_v1:sign(RedeemTx2, PayeeSigFun),
 
     %% check is_valid behaves as expected and returns correct error msgs
-    ?assertMatch({error,{wrong_txn_fee,_,0}}, blockchain_txn_redeem_htlc_v1:is_valid(SignedRedeemTx0, Chain)),
+    ?assertMatch({error,{wrong_txn_fee,{_,0}}}, blockchain_txn_redeem_htlc_v1:is_valid(SignedRedeemTx0, Chain)),
     ?assertMatch(ok, blockchain_txn_redeem_htlc_v1:is_valid(SignedRedeemTx1, Chain)),
     ?assertMatch(ok, blockchain_txn_redeem_htlc_v1:is_valid(SignedRedeemTx2, Chain)),
     %% check create block on tx with invalid txn fee
@@ -833,7 +833,7 @@ txn_fees_pay_with_dc(Config) ->
     SignedPaymentTx2 = blockchain_txn_payment_v1:sign(PaymentTx2, PayerSigFun),
 
     %% check is_valid behaves as expected and returns correct error msgs
-    ?assertMatch({error,{wrong_txn_fee,_,0}}, blockchain_txn_payment_v1:is_valid(SignedPaymentTx0, Chain)),
+    ?assertMatch({error,{wrong_txn_fee,{_,0}}}, blockchain_txn_payment_v1:is_valid(SignedPaymentTx0, Chain)),
     ?assertMatch(ok, blockchain_txn_payment_v1:is_valid(SignedPaymentTx1, Chain)),
     ?assertMatch(ok, blockchain_txn_payment_v1:is_valid(SignedPaymentTx2, Chain)),
     %% check create block on tx with invalid txn fee
@@ -877,7 +877,7 @@ txn_fees_pay_with_dc(Config) ->
     SignedRoutingTx2 = blockchain_txn_routing_v1:sign(RoutingTx2, PayerSigFun),
 
     %% check is_valid behaves as expected and returns correct error msgs
-    ?assertMatch({error,{wrong_txn_fee,_,0}}, blockchain_txn_routing_v1:is_valid(SignedRoutingTx0, Chain)),
+    ?assertMatch({error,{wrong_txn_fee,{_,0}}}, blockchain_txn_routing_v1:is_valid(SignedRoutingTx0, Chain)),
     ?assertMatch(ok, blockchain_txn_routing_v1:is_valid(SignedRoutingTx1, Chain)),
     ?assertMatch(ok, blockchain_txn_routing_v1:is_valid(SignedRoutingTx2, Chain)),
     %% check create block on tx with invalid txn fee and invalid staking fee
@@ -925,9 +925,9 @@ txn_fees_pay_with_dc(Config) ->
 
 
     %% check is_valid behaves as expected and returns correct error msgs
-    ?assertMatch({error,{wrong_txn_fee,_,0}}, blockchain_txn_routing_v1:is_valid(SignedRoutingSubnetTx0, Chain)),
-    ?assertMatch({error,{wrong_staking_fee,_,0}}, blockchain_txn_routing_v1:is_valid(SignedRoutingSubnetTx1, Chain)),
-    ?assertMatch({error,{wrong_staking_fee,_,_}}, blockchain_txn_routing_v1:is_valid(SignedRoutingSubnetTx4, Chain)),
+    ?assertMatch({error,{wrong_txn_fee,{_,0}}}, blockchain_txn_routing_v1:is_valid(SignedRoutingSubnetTx0, Chain)),
+    ?assertMatch({error,{wrong_staking_fee,{_,0}}}, blockchain_txn_routing_v1:is_valid(SignedRoutingSubnetTx1, Chain)),
+    ?assertMatch({error,{wrong_staking_fee,{_,_}}}, blockchain_txn_routing_v1:is_valid(SignedRoutingSubnetTx4, Chain)),
     ?assertMatch(ok, blockchain_txn_routing_v1:is_valid(SignedRoutingSubnetTx2, Chain)),
     ?assertMatch(ok, blockchain_txn_routing_v1:is_valid(SignedRoutingSubnetTx3, Chain)),
     %% check create block on tx with invalid txn fee and invalid staking fee
@@ -967,7 +967,7 @@ txn_fees_pay_with_dc(Config) ->
     SignedSecExchTx2 = blockchain_txn_security_exchange_v1:sign(SecExchTx2, PayerSigFun),
 
     %% check is_valid behaves as expected and returns correct error msgs
-    ?assertMatch({error,{wrong_txn_fee,_,0}}, blockchain_txn_security_exchange_v1:is_valid(SignedSecExchTx0, Chain)),
+    ?assertMatch({error,{wrong_txn_fee,{_,0}}}, blockchain_txn_security_exchange_v1:is_valid(SignedSecExchTx0, Chain)),
     ?assertMatch(ok, blockchain_txn_security_exchange_v1:is_valid(SignedSecExchTx1, Chain)),
     ?assertMatch(ok, blockchain_txn_security_exchange_v1:is_valid(SignedSecExchTx2, Chain)),
     %% check create block on tx with invalid txn fee
@@ -1008,7 +1008,7 @@ txn_fees_pay_with_dc(Config) ->
     SignedPaymentV2Tx2 = blockchain_txn_payment_v2:sign(PaymentV2Tx2, PayerSigFun),
 
     %% check is_valid behaves as expected and returns correct error msgs
-    ?assertMatch({error,{wrong_txn_fee,_,0}}, blockchain_txn_payment_v2:is_valid(SignedPaymentV2Tx0, Chain)),
+    ?assertMatch({error,{wrong_txn_fee,{_,0}}}, blockchain_txn_payment_v2:is_valid(SignedPaymentV2Tx0, Chain)),
     ?assertMatch(ok, blockchain_txn_payment_v2:is_valid(SignedPaymentV2Tx1, Chain)),
     ?assertMatch(ok, blockchain_txn_payment_v2:is_valid(SignedPaymentV2Tx2, Chain)),
     %% check create block on tx with invalid txn fee
@@ -1058,7 +1058,7 @@ txn_fees_pay_with_dc(Config) ->
     SignedSCTx2 = blockchain_txn_state_channel_open_v1:sign(SCTx2, RouterSigFun),
 
     %% check is_valid behaves as expected and returns blockchain_txn_state_channel_open_v1 error msgs
-    ?assertMatch({error,{wrong_txn_fee,_,0}}, blockchain_txn_state_channel_open_v1:is_valid(SignedSCTx0, Chain)),
+    ?assertMatch({error,{wrong_txn_fee,{_,0}}}, blockchain_txn_state_channel_open_v1:is_valid(SignedSCTx0, Chain)),
     ?assertMatch(ok, blockchain_txn_state_channel_open_v1:is_valid(SignedSCTx1, Chain)),
     ?assertMatch(ok, blockchain_txn_state_channel_open_v1:is_valid(SignedSCTx2, Chain)),
     %% check create block on tx with invalid txn fee
@@ -1133,9 +1133,9 @@ txn_fees_pay_with_hnt(Config) ->
 
 
     %% check is_valid behaves as expected and returns correct error msgs
-    ?assertMatch({error,{wrong_txn_fee,_,0}}, blockchain_txn_oui_v1:is_valid(SignedOUITx0, Chain)),
-    ?assertMatch({error,{wrong_staking_fee,_,1}}, blockchain_txn_oui_v1:is_valid(SignedOUITx1, Chain)),
-    ?assertMatch({error,{wrong_staking_fee,_,_}}, blockchain_txn_oui_v1:is_valid(SignedOUITx4, Chain)),
+    ?assertMatch({error,{wrong_txn_fee,{_,0}}}, blockchain_txn_oui_v1:is_valid(SignedOUITx0, Chain)),
+    ?assertMatch({error,{wrong_staking_fee,{_,1}}}, blockchain_txn_oui_v1:is_valid(SignedOUITx1, Chain)),
+    ?assertMatch({error,{wrong_staking_fee,{_,_}}}, blockchain_txn_oui_v1:is_valid(SignedOUITx4, Chain)),
     ?assertMatch(ok, blockchain_txn_oui_v1:is_valid(SignedOUITx2, Chain)),
     ?assertMatch(ok, blockchain_txn_oui_v1:is_valid(SignedOUITx3, Chain)),
     %% check create block on tx with invalid txn fee and invalid staking fee
@@ -1198,7 +1198,7 @@ staking_key_add_gateway(Config) ->
     SignedPaymentTx2 = blockchain_txn_payment_v1:sign(PaymentTx2, PayerSigFun),
 
     %% check is_valid behaves as expected and returns correct error msgs
-    ?assertMatch({error,{wrong_txn_fee,_,0}}, blockchain_txn_payment_v1:is_valid(SignedPaymentTx0, Chain)),
+    ?assertMatch({error,{wrong_txn_fee,{_,0}}}, blockchain_txn_payment_v1:is_valid(SignedPaymentTx0, Chain)),
     ?assertMatch(ok, blockchain_txn_payment_v1:is_valid(SignedPaymentTx1, Chain)),
     ?assertMatch(ok, blockchain_txn_payment_v1:is_valid(SignedPaymentTx2, Chain)),
     %% check create block on tx with invalid txn fee

--- a/test/blockchain_simple_SUITE.erl
+++ b/test/blockchain_simple_SUITE.erl
@@ -657,7 +657,7 @@ bogus_coinbase_test(Config) ->
     BogusCoinbaseTxn = blockchain_txn_coinbase_v1:new(FirstMemberAddr, 999999),
 
     %% This should error out cuz this is an invalid txn
-    {error, {invalid_txns, [BogusCoinbaseTxn]}} = test_utils:create_block(ConsensusMembers, [BogusCoinbaseTxn]),
+    {error, {invalid_txns, [{BogusCoinbaseTxn, _InvalidReason}]}} = test_utils:create_block(ConsensusMembers, [BogusCoinbaseTxn]),
 
     %% Check that the chain didn't grow
     ?assertEqual({ok, 1}, blockchain:height(Chain)),
@@ -680,7 +680,7 @@ bogus_coinbase_with_good_payment_test(Config) ->
     SignedGoodPaymentTxn = blockchain_txn_payment_v1:sign(Tx, SigFun),
 
     %% This should error out cuz this is an invalid txn
-    {error, {invalid_txns, [BogusCoinbaseTxn]}} = test_utils:create_block(ConsensusMembers,
+    {error, {invalid_txns, [{BogusCoinbaseTxn, _InvalidReason}]}} = test_utils:create_block(ConsensusMembers,
                                                                           [BogusCoinbaseTxn, SignedGoodPaymentTxn]),
     %% Check that the chain didnt' grow
     ?assertEqual({ok, 1}, blockchain:height(Chain)),
@@ -1199,7 +1199,7 @@ max_subnet_test(Config) ->
 
     RoutingTxn21 = blockchain_txn_routing_v1:sign(blockchain_txn_routing_v1:request_subnet(OUI1, Payer, 32, 21), SigFun),
 
-    {error, {invalid_txns, [RoutingTxn21]}} = test_utils:create_block(ConsensusMembers, RoutingTxns ++ [RoutingTxn21]),
+    {error, {invalid_txns, [{RoutingTxn21, _InvalidReason}]}} = test_utils:create_block(ConsensusMembers, RoutingTxns ++ [RoutingTxn21]),
 
     ok.
 
@@ -1751,7 +1751,7 @@ token_burn_test(Config) ->
     % Step 2: Token burn txn (without an oracle price set) should fail and stay at same block
     BurnTx0 = blockchain_txn_token_burn_v1:new(Payer, 10, 2),
     SignedBurnTx0 = blockchain_txn_token_burn_v1:sign(BurnTx0, SigFun),
-    {error, {invalid_txns, [SignedBurnTx0]}} = test_utils:create_block(ConsensusMembers, [SignedBurnTx0]),
+    {error, {invalid_txns, [{SignedBurnTx0, _InvalidReason}]}} = test_utils:create_block(ConsensusMembers, [SignedBurnTx0]),
 
     ?assertEqual({ok, blockchain_block:hash_block(Block2)}, blockchain:head_hash(Chain)),
     ?assertEqual({ok, Block2}, blockchain:head_block(Chain)),
@@ -2068,7 +2068,7 @@ zero_payment_v1_test(Config) ->
     SignedTx = blockchain_txn_payment_v1:sign(Tx, SigFun),
 
     %% TODO: update when dc stuff with better test_util add_block lands
-    {[], [SignedTx]} = blockchain_txn:validate([SignedTx], Chain),
+    {[], [{SignedTx, _InvalidReason}]} = blockchain_txn:validate([SignedTx], Chain),
 
     ok.
 
@@ -2087,7 +2087,7 @@ negative_payment_v1_test(Config) ->
     SignedTx = blockchain_txn_payment_v1:sign(Tx, SigFun),
 
     %% TODO: update when dc stuff with better test_util add_block lands
-    {[], [SignedTx]} = blockchain_txn:validate([SignedTx], Chain),
+    {[], [{SignedTx, _InvalidReason}]} = blockchain_txn:validate([SignedTx], Chain),
 
     ok.
 
@@ -2111,7 +2111,7 @@ zero_amt_htlc_create_test(Config) ->
     SignedCreateTx = blockchain_txn_create_htlc_v1:sign(CreateTx, SigFun),
 
     %% TODO: update when dc stuff with better test_util add_block lands
-    {[], [SignedCreateTx]} = blockchain_txn:validate([SignedCreateTx], Chain),
+    {[], [{SignedCreateTx, _InvalidReason}]} = blockchain_txn:validate([SignedCreateTx], Chain),
     ok.
 
 negative_amt_htlc_create_test(Config) ->
@@ -2134,7 +2134,7 @@ negative_amt_htlc_create_test(Config) ->
     SignedCreateTx = blockchain_txn_create_htlc_v1:sign(CreateTx, SigFun),
 
     %% TODO: update when dc stuff with better test_util add_block lands
-    {[], [SignedCreateTx]} = blockchain_txn:validate([SignedCreateTx], Chain),
+    {[], [{SignedCreateTx, _InvalidReason}]} = blockchain_txn:validate([SignedCreateTx], Chain),
     ok.
 
 update_gateway_oui_test(Config) ->

--- a/test/blockchain_state_channel_SUITE.erl
+++ b/test/blockchain_state_channel_SUITE.erl
@@ -557,7 +557,7 @@ replay_test(Config) ->
     ReplaySignedSCOpenTxn = create_sc_open_txn(RouterNode, ReplayID, ExpireWithin, 1, Nonce),
     ct:pal("ReplaySignedSCOpenTxn: ~p", [ReplaySignedSCOpenTxn]),
 
-    {error, {invalid_txns, [ReplaySignedSCOpenTxn]}} = ct_rpc:call(RouterNode, test_utils, create_block, [ConsensusMembers, [ReplaySignedSCOpenTxn]]),
+    {error, {invalid_txns, [{ReplaySignedSCOpenTxn, _InvalidReason}]}} = ct_rpc:call(RouterNode, test_utils, create_block, [ConsensusMembers, [ReplaySignedSCOpenTxn]]),
 
     ok = ct_rpc:call(RouterNode, meck, unload, [blockchain_worker]),
     ok.
@@ -984,7 +984,7 @@ open_without_oui_test(Config) ->
     ct:pal("SignedSCOpenTxn: ~p", [SignedSCOpenTxn]),
 
     %% Adding block
-    {error, {invalid_txns, [SignedSCOpenTxn]}} = add_block(RouterNode, RouterChain, ConsensusMembers, [SignedSCOpenTxn]),
+    {error, {invalid_txns, [{SignedSCOpenTxn, _InvalidReason}]}} = add_block(RouterNode, RouterChain, ConsensusMembers, [SignedSCOpenTxn]),
 
     ok.
 


### PR DESCRIPTION
Related miner pr: https://github.com/helium/miner/pull/432

This enables more meaningful error msgs to be returned to clients by ensuring the reason a txn is declared invalid is returned to the transaction manager.  The manager can then take care of pushing this back to ETL via the callback. 

To help with this I have enforced a consistent error msg format as the current code uses inconsistent msg formats, examples include:

{error, invalid_transaction};
{error, bad_owner, {assert_location, Owner, GwOwner}};
{error, {duplicate_group, ?MODULE:height(Txn), BaseHeight}}
{error, {insufficient_assert_res, {assert_location, Location, Gateway}}};
{error, {wrong_stacking_fee, ExpectedStakingFee, StakingFee}};
{error, {insufficient_balance, Fee, Balance}}

Any function which returns an error msg to any of the txns is_valid or absorb function will now use the consistent format of:

{error, Reason} 

where Reason can be:

atom()
{atom(), {any}}

So the above listed error msgs would now look like:

{error, invalid_transaction};
{error, {bad_owner, {assert_location, Owner, GwOwner}}};
{error, {duplicate_group, {?MODULE:height(Txn), BaseHeight}}}
{error, {insufficient_assert_res, {assert_location, Location, Gateway}}};
{error, {wrong_stacking_fee, {ExpectedStakingFee, StakingFee}}};
{error, {insufficient_balance, {Fee, Balance}}

A labelled version of the error msg would look like:

{error, atom())                           |  {error, {atom(), {any()}}}
{error, InvalidOrErrorReason}  |  {error, {InvalidOrErrorReason, {InvalidOrErrorDetails}}}

The InvalidOrErrorReason will be the msg returned to txn mgr for any failed transaction and ultimately be sent to ETL as the invalid reason via:

spawn(fun() -> Callback(Msg) end)

Where Msg will be 

ok |
{error, rejected}
{error, {invalid, InvalidReason}}




