### PR TITLE
cache mode switch

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -2085,13 +2085,12 @@ run_absorb_block_hooks(Syncing, Hash, Blockchain) ->
                         end;
                     context ->
                         %% get context, insert into cache
-                        Ctxt = blockchain_ledger_v1:get_context(Ledger1),
-                        blockchain_ledger_v1:context_snapshot(Ctxt, Ledger1),
+                        %% Ctxt = blockchain_ledger_v1:get_context(Ledger1),
+                        %% blockchain_ledger_v1:context_snapshot(Ctxt, Ledger),
                         %% commit context
                         blockchain_ledger_v1:commit_context(Ledger1),
                         {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
-                        %% this should hit the just-cached value, and
-                        %% is maybe not as safe as a snapshot
+                        %% this should create the new cache entry?
                         {ok, Ledger2} = ledger_at(Height, Blockchain),
                         ok = blockchain_worker:notify({add_block, Hash, Syncing, Ledger2});
                     checkpoint ->

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -290,7 +290,7 @@ mark_key(Key, Ledger) ->
 -spec new_context(ledger()) -> ledger().
 new_context(Ledger) ->
     %% accumulate ledger changes in a read-through ETS cache
-    Cache = ets:new(txn_cache, [set, protected, {keypos, 1}]),
+    Cache = ets:new(ledger_cache, [set, protected, {keypos, 1}]),
     GwCache = ets:new(gw_cache, [set, protected, {keypos, 1}]),
     context_cache(Cache, GwCache, Ledger).
 
@@ -306,7 +306,7 @@ flatten_cache({Cache, GwCache}) ->
     {ets:tab2list(Cache), ets:tab2list(GwCache)}.
 
 install_context({FlatCache, FlatGwCache}, Ledger) ->
-    Cache = ets:new(txn_cache, [set, protected, {keypos, 1}]),
+    Cache = ets:new(ledger_cache, [set, protected, {keypos, 1}]),
     ets:insert(Cache, FlatCache),
     GwCache = ets:new(gw_cache, [set, protected, {keypos, 1}]),
     ets:insert(GwCache, FlatGwCache),

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -2555,7 +2555,7 @@ cache_fold(Ledger, CF, Fun0, OriginalAcc, Opts) ->
         {Cache, _GwCache} ->
             %% fold using the cache wrapper
             Fun = mk_cache_fold_fun(Cache, CF, Start, End, Fun0),
-            Keys = lists:usort(lists:flatten(ets:match(Cache, {{'_', '$1'}, '_'}))),
+            Keys = ets:select(Cache, [{{{'$1','$2'},'_'},[{'==','$1', CF}],['$2']}]),
             {TrailingKeys, Res0} = rocks_fold(Ledger, CF, Opts, Fun, {Keys, OriginalAcc}),
             process_fun(TrailingKeys, Cache, CF, Start, End, Fun0, Res0)
     end.


### PR DESCRIPTION
This should allow us to disable rocks snapshots, which seem to be causing some sync issues.  I can't seem to get the cache generated at commit time to work correctly, so this might not be as efficient as it should be.