### PR TITLE
Add assert_location_v2 txn

### DIFF
--- a/include/blockchain_utils.hrl
+++ b/include/blockchain_utils.hrl
@@ -49,3 +49,7 @@
                      11 => {-90,-35}}).
 
 -define(MAX_UNIQ_CLIENTS, 1100).
+
+%% default values for gateways
+-define(DEFAULT_GAIN, 12). %% as dBi * 10
+-define(DEFAULT_ELEVATION, 0). %% as AGL (above ground level) in meters

--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -403,3 +403,26 @@
 -define(hip17_res_12, hip17_res_12).
 -define(density_tgt_res, density_tgt_res).
 -define(hip17_interactivity_blocks, hip17_interactivity_blocks).
+
+%% ------------------------------------------------------------------
+%% assert_location_v2 transaction related vars
+
+%% Allowed values: 1, 2
+-define(assert_loc_txn_version, assert_loc_txn_version).
+
+%% Known antenna gains:
+%% Helium Hotspot (US 915) - 1.2 dBi
+%% Helium Hotspot (EU 868) - 2.3 dBi
+%% RAK Hotspot Miner (US 915) - 2.3 dBi
+%% RAK Hotspot Miner (EU 868) - 2.8 dBi
+%% Nebra Outdoor Hotspot - 3 dBi
+%% Bobcat Miner 300 (All) - 4 dBi
+%% Syncrob.it (US 915) - 1.2 dBi
+%% Syncrob.it (EU 868) - 2.3 dBi
+
+%% NOTE: Allow min_antenna_gain - max_antenna_gain (both inclusive)
+%% Both will be set as dBi x 10, so, 1 dBi = 10, 15 dBi = 150,
+%% Any gain value between min-max is acceptable
+-define(min_antenna_gain, min_antenna_gain).        %% Set to 10 (1 dBi)
+-define(max_antenna_gain, max_antenna_gain).        %% Set to 150 (15 dBi)
+%% ------------------------------------------------------------------

--- a/rebar.config
+++ b/rebar.config
@@ -39,7 +39,7 @@
     {erlang_stats, ".*", {git, "https://github.com/helium/erlang-stats.git", {branch, "master"}}},
     {e2qc, ".*", {git, "https://github.com/helium/e2qc", {branch, "master"}}},
     {vincenty, ".*", {git, "https://github.com/helium/vincenty", {branch, "master"}}},
-    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "master"}}},
+    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "rg/assert-loc-v2"}}},
     {merkerl, ".*", {git, "https://github.com/helium/merkerl.git", {branch, "master"}}},
     {xxhash, {git, "https://github.com/pierreis/erlang-xxhash", {branch, "master"}}},
     {exor_filter, ".*", {git, "https://github.com/mpope9/exor_filter", {branch, "master"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -39,7 +39,7 @@
     {erlang_stats, ".*", {git, "https://github.com/helium/erlang-stats.git", {branch, "master"}}},
     {e2qc, ".*", {git, "https://github.com/helium/e2qc", {branch, "master"}}},
     {vincenty, ".*", {git, "https://github.com/helium/vincenty", {branch, "master"}}},
-    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "rg/assert-loc-v2"}}},
+    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "master"}}},
     {merkerl, ".*", {git, "https://github.com/helium/merkerl.git", {branch, "master"}}},
     {xxhash, {git, "https://github.com/pierreis/erlang-xxhash", {branch, "master"}}},
     {exor_filter, ".*", {git, "https://github.com/mpope9/exor_filter", {branch, "master"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -41,7 +41,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"ad8aea4764727ff37ddf5248173467d0de6f8cfd"}},
+       {ref,"456591707ec9061776819ffba45de4940acae956"}},
   0},
  {<<"inert">>,{pkg,<<"inert">>,<<"1.0.1">>},2},
  {<<"inet_cidr">>,{pkg,<<"erl_cidr">>,<<"1.0.2">>},2},

--- a/rebar.lock
+++ b/rebar.lock
@@ -41,7 +41,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"ec3b6d0f2694434d2c71e91487ae5a1cac9f10d5"}},
+       {ref,"ad8aea4764727ff37ddf5248173467d0de6f8cfd"}},
   0},
  {<<"inert">>,{pkg,<<"inert">>,<<"1.0.1">>},2},
  {<<"inet_cidr">>,{pkg,<<"erl_cidr">>,<<"1.0.2">>},2},

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -51,6 +51,8 @@
     update_gateway/3,
     fixup_neighbors/4,
     add_gateway_location/4,
+    add_gateway_gain/4,
+    add_gateway_elevation/4,
     insert_witnesses/3,
     add_gateway_witnesses/3,
     refresh_gateway_witnesses/2,
@@ -1240,6 +1242,28 @@ add_gateway_location(GatewayAddress, Location, Nonce, Ledger) ->
             end
     end.
 
+-spec add_gateway_gain(libp2p_crypto:pubkey_bin(), integer(), non_neg_integer(), ledger()) -> ok | {error, no_active_gateway}.
+add_gateway_gain(GatewayAddress, Gain, Nonce, Ledger) ->
+    case ?MODULE:find_gateway_info(GatewayAddress, Ledger) of
+        {error, _} ->
+            {error, no_active_gateway};
+        {ok, Gw} ->
+            Gw1 = blockchain_ledger_gateway_v2:gain(Gain, Gw),
+            Gw2 = blockchain_ledger_gateway_v2:nonce(Nonce, Gw1),
+            update_gateway(Gw2, GatewayAddress, Ledger)
+    end.
+
+-spec add_gateway_elevation(libp2p_crypto:pubkey_bin(), integer(), non_neg_integer(), ledger()) -> ok | {error, no_active_gateway}.
+add_gateway_elevation(GatewayAddress, Elevation, Nonce, Ledger) ->
+    case ?MODULE:find_gateway_info(GatewayAddress, Ledger) of
+        {error, _} ->
+            {error, no_active_gateway};
+        {ok, Gw} ->
+            Gw1 = blockchain_ledger_gateway_v2:elevation(Elevation, Gw),
+            Gw2 = blockchain_ledger_gateway_v2:nonce(Nonce, Gw1),
+            update_gateway(Gw2, GatewayAddress, Ledger)
+    end.
+
 gateway_versions(Ledger) ->
     case config(?var_gw_inactivity_threshold, Ledger) of
         {error, not_found} ->
@@ -1834,8 +1858,9 @@ txn_fee_multiplier(Ledger)->
         {error, not_found} -> 1;
         {ok, V} -> V
     end.
+
 %%--------------------------------------------------------------------
-%% @doc  get staking fee chain var value for add gateway
+%% @doc  get staking fee chain var value for assert_location_v1
 %% or return default
 %% @end
 %%--------------------------------------------------------------------

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -38,7 +38,8 @@
              | blockchain_txn_gen_price_oracle_v1:txn_genesis_price_oracle()
              | blockchain_txn_transfer_hotspot_v1:txn_transfer_hotspot()
              | blockchain_txn_state_channel_close_v1:txn_state_channel_close()
-             | blockchain_txn_rewards_v2:txn_rewards_v2().
+             | blockchain_txn_rewards_v2:txn_rewards_v2()
+             | blockchain_txn_assert_location_v2:txn_assert_location().
 
 -type before_commit_callback() :: fun((blockchain:blockchain(), blockchain_block:hash()) -> ok | {error, any()}).
 -type txns() :: [txn()].
@@ -115,7 +116,8 @@
     {blockchain_txn_state_channel_close_v1, 24},
     {blockchain_txn_token_burn_v1, 25},
     {blockchain_txn_transfer_hotspot_v1, 26},
-    {blockchain_txn_rewards_v2, 27}
+    {blockchain_txn_rewards_v2, 27},
+    {blockchain_txn_assert_location_v2, 28}
 ]).
 
 block_delay() ->
@@ -196,7 +198,9 @@ wrap_txn(#blockchain_txn_gen_price_oracle_v1_pb{}=Txn) ->
 wrap_txn(#blockchain_txn_transfer_hotspot_v1_pb{}=Txn) ->
     #blockchain_txn_pb{txn={transfer_hotspot, Txn}};
 wrap_txn(#blockchain_txn_rewards_v2_pb{}=Txn) ->
-    #blockchain_txn_pb{txn={rewards_v2, Txn}}.
+    #blockchain_txn_pb{txn={rewards_v2, Txn}};
+wrap_txn(#blockchain_txn_assert_location_v2_pb{}=Txn) ->
+    #blockchain_txn_pb{txn={assert_location_v2, Txn}}.
 
 -spec unwrap_txn(#blockchain_txn_pb{}) -> blockchain_txn:txn().
 unwrap_txn(#blockchain_txn_pb{txn={bundle, #blockchain_txn_bundle_v1_pb{transactions=Txns} = Bundle}}) ->
@@ -585,7 +589,9 @@ type(#blockchain_txn_gen_price_oracle_v1_pb{}) ->
 type(#blockchain_txn_transfer_hotspot_v1_pb{}) ->
     blockchain_txn_transfer_hotspot_v1;
 type(#blockchain_txn_rewards_v2_pb{}) ->
-    blockchain_txn_rewards_v2.
+    blockchain_txn_rewards_v2;
+type(#blockchain_txn_assert_location_v2_pb{}) ->
+    blockchain_txn_assert_location_v2.
 
 -spec validate_fields([{{atom(), iodata() | undefined},
                         {binary, pos_integer()} |
@@ -767,6 +773,8 @@ nonce(Txn) ->
             end;
         blockchain_txn_routing_v1 ->
             blockchain_txn_routing_v1:nonce(Txn);
+        blockchain_txn_assert_location_v2 ->
+            blockchain_txn_assert_location_v2:nonce(Txn);
         _ ->
             -1 %% other transactions sort first
     end.
@@ -813,6 +821,8 @@ actor(Txn) ->
         blockchain_txn_state_channel_close_v1 ->
             %% group by owner
             blockchain_txn_state_channel_close_v1:state_channel_owner(Txn);
+        blockchain_txn_assert_location_v2 ->
+            blockchain_txn_assert_location_v2:gateway(Txn);
         _ ->
             <<>>
     end.
@@ -879,6 +889,13 @@ depends_on(ThisTxn, CachedTxns) ->
                                  (type(Txn) == blockchain_txn_routing_v1 andalso actor(Txn) == Actor andalso nonce(Txn) < Nonce)
                          end,
                          CachedTxns);
+        blockchain_txn_assert_location_v2 ->
+            Actor = actor(ThisTxn),
+            Nonce = nonce(ThisTxn),
+            lists:filter(fun({_TxnKey, Txn, _TxnData}) ->
+                                 (type(Txn) == blockchain_txn_assert_location_v2 andalso actor(Txn) == Actor andalso nonce(Txn) < Nonce) orelse
+                                 (type(Txn) == blockchain_txn_add_gateway_v1 andalso blockchain_txn_add_gateway_v1:gateway(Txn) == Actor)
+                         end, CachedTxns);
         %% TODO: token exchange rate txn when it's time
         _ ->
             []
@@ -1336,6 +1353,34 @@ txn_fees_update_gateway_oui_v1_test() ->
     ?assertEqual(40000, Txn02Fee),
     ok.
 
+txn_fees_assert_location_v2_test() ->
+    [{Payer, PayerSigFun}] = gen_payers(1),
+    #{public := GWPubKey, secret := _GWPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
+    GWPubkeyBin = libp2p_crypto:pubkey_to_bin(GWPubKey),
+    #{public := OwnerPubKey, secret := OwnerPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
+    OwnerPubkeyBin = libp2p_crypto:pubkey_to_bin(OwnerPubKey),
+    OwnerSigFun = libp2p_crypto:mk_sig_fun(OwnerPrivKey),
 
+    %% create new txn, and confirm expected txn and staking fee
+    Txn00 = blockchain_txn_assert_location_v2:new(GWPubkeyBin, OwnerPubkeyBin, Payer, ?TEST_LOCATION, 1),
+    Txn00Fee = blockchain_txn_assert_location_v2:calculate_fee(Txn00, ignore_ledger, ?DC_PAYLOAD_SIZE, ?TXN_MULTIPLIER, true),
+    Txn00StakingFee = blockchain_txn_assert_location_v2:calculate_staking_fee(Txn00, ignore_ledger, ?ASSERT_LOC_STAKING_FEE, [], true),
+    Txn00LegacyStakingFee = blockchain_txn_assert_location_v2:calculate_staking_fee(Txn00, ignore_ledger, ?ASSERT_LOC_STAKING_FEE, [], false),
+    ?assertEqual(55000, Txn00Fee),
+    ?assertEqual(?ASSERT_LOC_STAKING_FEE, Txn00StakingFee),
+    ?assertEqual(1, Txn00LegacyStakingFee),
+
+    %% set the fee values of the txn, sign it and confirm the fees remains the same and unaffected by signatures
+    Txn01 = blockchain_txn_assert_location_v2:fee(Txn00, Txn00Fee),
+    Txn02 = blockchain_txn_assert_location_v2:staking_fee(Txn01, Txn00StakingFee),
+    Txn03 = blockchain_txn_assert_location_v2:sign(Txn02, OwnerSigFun),
+    Txn04 = blockchain_txn_assert_location_v2:sign_payer(Txn03, PayerSigFun),
+    Txn04Fee = blockchain_txn_assert_location_v2:calculate_fee(Txn04, ignore_ledger, ?DC_PAYLOAD_SIZE, ?TXN_MULTIPLIER, true),
+    Txn04StakingFee = blockchain_txn_assert_location_v2:calculate_staking_fee(Txn04, ignore_ledger, ?ASSERT_LOC_STAKING_FEE, [], true),
+    Txn04LegacyStakingFee = blockchain_txn_assert_location_v2:calculate_staking_fee(Txn04, ignore_ledger, ?ASSERT_LOC_STAKING_FEE, [], false),
+    ?assertEqual(55000, Txn04Fee),
+    ?assertEqual(?ASSERT_LOC_STAKING_FEE, Txn04StakingFee),
+    ?assertEqual(1, Txn04LegacyStakingFee),
+    ok.
 
 -endif.

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1121,10 +1121,10 @@ validate_var(?assert_loc_txn_version, Value) ->
     end;
 validate_var(?min_antenna_gain, Value) ->
     %% Initially set to 10 to imply 1 dBi
-    validate_int(Value, "min_antenna_gain", 1, 11, false);
+    validate_int(Value, "min_antenna_gain", 0, 10, false);
 validate_var(?max_antenna_gain, Value) ->
     %% Initially set to 150 to imply 15 dBi
-    validate_int(Value, "max_antenna_gain", 100, 600, false);
+    validate_int(Value, "max_antenna_gain", 10, 200, false);
 
 validate_var(Var, Value) ->
     %% something we don't understand, crash

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1114,6 +1114,18 @@ validate_var(?density_tgt_res, Value) ->
 validate_var(?hip17_interactivity_blocks, Value) ->
     validate_int(Value, "hip17_interactivity_blocks", 1, 5000, false);
 
+validate_var(?assert_loc_txn_version, Value) ->
+    case Value of
+        N when is_integer(N), N >= 1, N =< 2 -> ok;
+        _ -> throw({error, {invalid_assert_loc_txn_version, Value}})
+    end;
+validate_var(?min_antenna_gain, Value) ->
+    %% Initially set to 10 to imply 1 dBi
+    validate_int(Value, "min_antenna_gain", 1, 11, false);
+validate_var(?max_antenna_gain, Value) ->
+    %% Initially set to 150 to imply 15 dBi
+    validate_int(Value, "max_antenna_gain", 100, 600, false);
+
 validate_var(Var, Value) ->
     %% something we don't understand, crash
     invalid_var(Var, Value).

--- a/src/transactions/v2/blockchain_txn_assert_location_v2.erl
+++ b/src/transactions/v2/blockchain_txn_assert_location_v2.erl
@@ -1,0 +1,664 @@
+%%%-------------------------------------------------------------------
+%% @doc
+%% == Blockchain Transaction Assert Location V2 ==
+%% @end
+%%%-------------------------------------------------------------------
+-module(blockchain_txn_assert_location_v2).
+-include_lib("common_test/include/ct.hrl").
+
+-behavior(blockchain_txn).
+
+-behavior(blockchain_json).
+-include("blockchain_json.hrl").
+-include("blockchain_txn_fees.hrl").
+-include_lib("helium_proto/include/blockchain_txn_assert_location_v2_pb.hrl").
+-include("blockchain_vars.hrl").
+-include("blockchain_utils.hrl").
+
+-export([
+    new/4, new/5,
+    hash/1,
+    gateway/1,
+    owner/1,
+    payer/1,
+    location/1, location/2,
+    gain/1, gain/2,
+    elevation/1, elevation/2,
+    owner_signature/1,
+    payer_signature/1,
+    nonce/1,
+    staking_fee/1, staking_fee/2,
+    fee/1, fee/2,
+    sign_payer/2,
+    sign/2,
+    is_valid_owner/1,
+    is_valid_location/2,
+    is_valid_payer/1,
+    is_valid/2,
+    absorb/2,
+    calculate_fee/2, calculate_fee/5, calculate_staking_fee/2, calculate_staking_fee/5,
+    print/1,
+    to_json/2
+]).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-type location() :: h3:h3index().
+-type txn_assert_location() :: #blockchain_txn_assert_location_v2_pb{}.
+-export_type([txn_assert_location/0]).
+
+-spec new(Gateway :: libp2p_crypto:pubkey_bin(),
+          Owner :: libp2p_crypto:pubkey_bin(),
+          Location :: location(),
+          Nonce :: non_neg_integer()) -> txn_assert_location().
+new(Gateway, Owner, Location, Nonce) ->
+    #blockchain_txn_assert_location_v2_pb{
+        gateway=Gateway,
+        owner=Owner,
+        payer = <<>>,
+        location=h3:to_string(Location),
+        owner_signature = <<>>,
+        payer_signature = <<>>,
+        nonce=Nonce,
+        gain=?DEFAULT_GAIN,
+        elevation=?DEFAULT_ELEVATION,
+        staking_fee=?LEGACY_STAKING_FEE,
+        fee=?LEGACY_TXN_FEE
+    }.
+
+-spec new(Gateway :: libp2p_crypto:pubkey_bin(),
+          Owner :: libp2p_crypto:pubkey_bin(),
+          Payer :: libp2p_crypto:pubkey_bin(),
+          Location :: location(),
+          Nonce :: non_neg_integer()) -> txn_assert_location().
+new(Gateway, Owner, Payer, Location, Nonce) ->
+    #blockchain_txn_assert_location_v2_pb{
+        gateway=Gateway,
+        owner=Owner,
+        payer = Payer,
+        location=h3:to_string(Location),
+        owner_signature = <<>>,
+        payer_signature = <<>>,
+        nonce=Nonce,
+        gain=?DEFAULT_GAIN,
+        elevation=?DEFAULT_ELEVATION,
+        staking_fee=?LEGACY_STAKING_FEE,
+        fee=?LEGACY_TXN_FEE
+    }.
+
+-spec hash(txn_assert_location()) -> blockchain_txn:hash().
+hash(Txn) ->
+    BaseTxn = Txn#blockchain_txn_assert_location_v2_pb{owner_signature = <<>>},
+    EncodedTxn = blockchain_txn_assert_location_v2_pb:encode_msg(BaseTxn),
+    crypto:hash(sha256, EncodedTxn).
+
+-spec gateway(txn_assert_location()) -> libp2p_crypto:pubkey_bin().
+gateway(Txn) ->
+    Txn#blockchain_txn_assert_location_v2_pb.gateway.
+
+-spec owner(txn_assert_location()) -> libp2p_crypto:pubkey_bin().
+owner(Txn) ->
+    Txn#blockchain_txn_assert_location_v2_pb.owner.
+
+-spec payer(txn_assert_location()) -> libp2p_crypto:pubkey_bin() | <<>> | undefined.
+payer(Txn) ->
+    Txn#blockchain_txn_assert_location_v2_pb.payer.
+
+-spec location(txn_assert_location()) -> location().
+location(Txn) ->
+    h3:from_string(Txn#blockchain_txn_assert_location_v2_pb.location).
+
+-spec location(Location :: h3:index(), Txn :: txn_assert_location()) -> location().
+location(Location, Txn) ->
+    Txn#blockchain_txn_assert_location_v2_pb{location = h3:to_string(Location)}.
+
+-spec gain(Txn :: txn_assert_location()) -> integer().
+gain(Txn) ->
+    Txn#blockchain_txn_assert_location_v2_pb.gain.
+
+-spec gain(Txn :: txn_assert_location(), Gain :: integer()) -> txn_assert_location().
+gain(Txn, Gain) ->
+    Txn#blockchain_txn_assert_location_v2_pb{gain = Gain}.
+
+-spec elevation(txn_assert_location()) -> integer().
+elevation(Txn) ->
+    Txn#blockchain_txn_assert_location_v2_pb.elevation.
+
+-spec elevation(Txn :: txn_assert_location(), Elevation :: integer()) -> txn_assert_location().
+elevation(Txn, Elevation) ->
+    Txn#blockchain_txn_assert_location_v2_pb{elevation = Elevation}.
+
+-spec owner_signature(txn_assert_location()) -> binary().
+owner_signature(Txn) ->
+    Txn#blockchain_txn_assert_location_v2_pb.owner_signature.
+
+-spec payer_signature(txn_assert_location()) -> binary().
+payer_signature(Txn) ->
+    Txn#blockchain_txn_assert_location_v2_pb.payer_signature.
+
+-spec nonce(txn_assert_location()) -> non_neg_integer().
+nonce(Txn) ->
+    Txn#blockchain_txn_assert_location_v2_pb.nonce.
+
+-spec staking_fee(txn_assert_location()) -> non_neg_integer().
+staking_fee(Txn) ->
+    Txn#blockchain_txn_assert_location_v2_pb.staking_fee.
+
+-spec staking_fee(txn_assert_location(), non_neg_integer()) -> txn_assert_location().
+staking_fee(Txn, Fee) ->
+    Txn#blockchain_txn_assert_location_v2_pb{staking_fee=Fee}.
+
+-spec fee(txn_assert_location()) -> non_neg_integer().
+fee(Txn) ->
+    Txn#blockchain_txn_assert_location_v2_pb.fee.
+
+-spec fee(txn_assert_location(), non_neg_integer()) -> txn_assert_location().
+fee(Txn, Fee) ->
+    Txn#blockchain_txn_assert_location_v2_pb{fee=Fee}.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Calculate the txn fee
+%% Returned value is txn_byte_size / 24
+%% @end
+%%--------------------------------------------------------------------
+-spec calculate_fee(txn_assert_location(), blockchain:blockchain()) -> non_neg_integer().
+calculate_fee(Txn, Chain) ->
+    ?calculate_fee_prep(Txn, Chain).
+
+-spec calculate_fee(txn_assert_location(), blockchain_ledger_v1:ledger(), pos_integer(), pos_integer(), boolean()) -> non_neg_integer().
+calculate_fee(_Txn, _Ledger, _DCPayloadSize, _TxnFeeMultiplier, false) ->
+    ?LEGACY_TXN_FEE;
+calculate_fee(Txn, Ledger, DCPayloadSize, TxnFeeMultiplier, true) ->
+    case Txn#blockchain_txn_assert_location_v2_pb.payer of
+        Payer when Payer == undefined; Payer == <<>> ->
+          %% no payer signature if there's no payer
+          ?calculate_fee(Txn#blockchain_txn_assert_location_v2_pb{fee=0, staking_fee=0,
+                                                       owner_signature= <<0:512>>,
+                                                       payer_signature= <<>>}, Ledger, DCPayloadSize, TxnFeeMultiplier);
+        _ ->
+          ?calculate_fee(Txn#blockchain_txn_assert_location_v2_pb{fee=0, staking_fee=0,
+                                                       owner_signature= <<0:512>>,
+                                                       payer_signature= <<0:512>>}, Ledger, DCPayloadSize, TxnFeeMultiplier)
+    end.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Calculate the staking fee using the price oracles
+%% returns the fee in DC
+%% @end
+%%--------------------------------------------------------------------
+-spec calculate_staking_fee(txn_assert_location(), blockchain:blockchain()) -> non_neg_integer().
+calculate_staking_fee(Txn, Chain) ->
+    Ledger = blockchain:ledger(Chain),
+    Fee = blockchain_ledger_v1:staking_fee_txn_assert_location_v1(Ledger),
+    calculate_staking_fee(Txn, Ledger, Fee, [], blockchain_ledger_v1:txn_fees_active(Ledger)).
+
+-spec calculate_staking_fee(txn_assert_location(), blockchain_ledger_v1:ledger(), non_neg_integer(), [{atom(), non_neg_integer()}], boolean()) -> non_neg_integer().
+calculate_staking_fee(_Txn, _Ledger, _Fee, _ExtraData, false) ->
+    ?LEGACY_STAKING_FEE;
+calculate_staking_fee(_Txn, ignore_ledger, Fee, _ExtraData, true) ->
+    %% For testing
+    Fee;
+calculate_staking_fee(Txn, Ledger, Fee, _ExtraData, true) ->
+    %% fee is active
+    %% 0 staking_fee if the location hasn't actually changed
+    %% it's possible that the only change are gain/elevation
+    case is_new_location(Txn, Ledger) of
+        true -> Fee;
+        false -> 0
+    end.
+
+-spec sign_payer(txn_assert_location(), fun()) -> txn_assert_location().
+sign_payer(Txn, SigFun) ->
+    BaseTxn = Txn#blockchain_txn_assert_location_v2_pb{owner_signature= <<>>,
+                                                       payer_signature= <<>>},
+    EncodedTxn = blockchain_txn_assert_location_v2_pb:encode_msg(BaseTxn),
+    Txn#blockchain_txn_assert_location_v2_pb{payer_signature=SigFun(EncodedTxn)}.
+
+-spec sign(Txn :: txn_assert_location(),
+           SigFun :: libp2p_crypto:sig_fun()) -> txn_assert_location().
+sign(Txn, SigFun) ->
+    BaseTxn = Txn#blockchain_txn_assert_location_v2_pb{owner_signature= <<>>,
+                                                       payer_signature= <<>>},
+    BinTxn = blockchain_txn_assert_location_v2_pb:encode_msg(BaseTxn),
+    Txn#blockchain_txn_assert_location_v2_pb{owner_signature=SigFun(BinTxn)}.
+
+-spec is_valid_owner(txn_assert_location()) -> boolean().
+is_valid_owner(#blockchain_txn_assert_location_v2_pb{owner=PubKeyBin,
+                                                     owner_signature=Signature}=Txn) ->
+    BaseTxn = Txn#blockchain_txn_assert_location_v2_pb{owner_signature= <<>>,
+                                                       payer_signature= <<>>},
+    EncodedTxn = blockchain_txn_assert_location_v2_pb:encode_msg(BaseTxn),
+    PubKey = libp2p_crypto:bin_to_pubkey(PubKeyBin),
+    libp2p_crypto:verify(EncodedTxn, Signature, PubKey).
+
+-spec is_valid_location(txn_assert_location(), pos_integer()) -> boolean().
+is_valid_location(#blockchain_txn_assert_location_v2_pb{location=Location}, MinH3Res) ->
+    h3:get_resolution(h3:from_string(Location)) >= MinH3Res.
+
+-spec is_valid_gain(txn_assert_location(), pos_integer(), pos_integer()) -> boolean().
+is_valid_gain(#blockchain_txn_assert_location_v2_pb{gain=Gain}, MinGain, MaxGain) ->
+    not (Gain < MinGain orelse Gain > MaxGain).
+
+-spec is_valid_payer(txn_assert_location()) -> boolean().
+is_valid_payer(#blockchain_txn_assert_location_v2_pb{payer=undefined}) ->
+    %% no payer
+    true;
+is_valid_payer(#blockchain_txn_assert_location_v2_pb{payer= <<>>,
+                                                     payer_signature= <<>>}) ->
+    %% empty payer, empty signature
+    true;
+is_valid_payer(#blockchain_txn_assert_location_v2_pb{payer=PubKeyBin,
+                                                     payer_signature=Signature}=Txn) ->
+
+    BaseTxn = Txn#blockchain_txn_assert_location_v2_pb{owner_signature= <<>>,
+                                                       payer_signature= <<>>},
+    EncodedTxn = blockchain_txn_assert_location_v2_pb:encode_msg(BaseTxn),
+    PubKey = libp2p_crypto:bin_to_pubkey(PubKeyBin),
+    libp2p_crypto:verify(EncodedTxn, Signature, PubKey).
+
+-spec is_valid(txn_assert_location(), blockchain:blockchain()) -> ok | {error, any()}.
+is_valid(Txn, Chain) ->
+    Gateway = ?MODULE:gateway(Txn),
+    Owner = ?MODULE:owner(Txn),
+    Payer = ?MODULE:payer(Txn),
+    Location = ?MODULE:location(Txn),
+    Gain = ?MODULE:gain(Txn),
+    Elevation = ?MODULE:elevation(Txn),
+    Ledger = blockchain:ledger(Chain),
+
+    case blockchain:config(?assert_loc_txn_version, Ledger) of
+        {ok, V} when V >= 2 ->
+            case blockchain:config(?min_antenna_gain, Ledger) of
+                {ok, MinGain} ->
+                    case blockchain:config(?max_antenna_gain, Ledger) of
+                        {ok, MaxGain} ->
+                            case is_valid_gain(Txn, MinGain, MaxGain) of
+                                false ->
+                                    {error, {invalid_assert_loc_txn_v2, {invalid_antenna_gain, Gain, MinGain, MaxGain}}};
+                                true ->
+                                    Res = blockchain_txn:validate_fields([{{gateway, Gateway}, {address, libp2p}},
+                                                                          {{owner, Owner}, {address, libp2p}},
+                                                                          {{payer, Payer}, {address, libp2p}},
+                                                                          {{location, Location}, {is_integer, 0}},
+                                                                          {{elevation, Elevation}, {is_integer, -2147483648}}
+                                                                         ]),
+
+                                    case Res of
+                                        {error, _}=E -> E;
+                                        ok ->
+                                            do_is_valid_checks(Txn, Chain)
+                                    end
+                            end;
+                        _ ->
+                            {error, {invalid_assert_loc_txn_v2, max_antenna_gain_not_set}}
+                    end;
+                _ ->
+                    {error, {invalid_assert_loc_txn_v2, min_antenna_gain_not_set}}
+            end;
+        _ ->
+            {error, {invalid_assert_loc_txn_v2, insufficient_assert_loc_txn_version}}
+    end.
+
+
+-spec do_is_valid_checks(Txn :: txn_assert_location(),
+                         Chain :: blockchain:blockchain()) -> ok | {error, any()}.
+do_is_valid_checks(Txn, Chain) ->
+    Ledger = blockchain:ledger(Chain),
+    case {?MODULE:is_valid_owner(Txn),
+          ?MODULE:is_valid_payer(Txn)} of
+        {false, _} ->
+            {error, {bad_owner_signature, {assert_location_v2, owner(Txn)}}};
+        {_, false} ->
+            {error, {bad_payer_signature, {assert_location_v2, payer(Txn)}}};
+        {true, true} ->
+            AreFeesEnabled = blockchain_ledger_v1:txn_fees_active(Ledger),
+            StakingFee = ?MODULE:staking_fee(Txn),
+            ExpectedStakingFee = ?MODULE:calculate_staking_fee(Txn, Chain),
+            TxnFee = ?MODULE:fee(Txn),
+            ExpectedTxnFee = calculate_fee(Txn, Chain),
+            case {(ExpectedTxnFee =< TxnFee orelse not AreFeesEnabled), ExpectedStakingFee == StakingFee} of
+                {false,_} ->
+                    {error, {wrong_txn_fee, {assert_location_v2, ExpectedTxnFee, TxnFee}}};
+                {_,false} ->
+                    {error, {wrong_staking_fee, {assert_location_v2, ExpectedStakingFee, StakingFee}}};
+                {true, true} ->
+                    do_remaining_checks(Txn, TxnFee + StakingFee, Ledger)
+            end
+    end.
+
+-spec is_new_location(Txn :: txn_assert_location(), Ledger :: blockchain_ledger_v1:ledger()) -> boolean().
+is_new_location(Txn, Ledger) ->
+    GwPubkeyBin = ?MODULE:gateway(Txn),
+    NewLoc = ?MODULE:location(Txn),
+    {ok, Gw} = blockchain_ledger_v1:find_gateway_info(GwPubkeyBin, Ledger),
+    ExistingLoc = blockchain_ledger_gateway_v2:location(Gw),
+    NewLoc /= ExistingLoc.
+
+-spec do_remaining_checks(Txn :: txn_assert_location(),
+                          TotalFee :: non_neg_integer(),
+                          Ledger :: blockchain_ledger_v1:ledger()) -> ok | {error, any()}.
+do_remaining_checks(Txn, TotalFee, Ledger) ->
+    Owner = ?MODULE:owner(Txn),
+    Nonce = ?MODULE:nonce(Txn),
+    Payer = ?MODULE:payer(Txn),
+    AreFeesEnabled = blockchain_ledger_v1:txn_fees_active(Ledger),
+    ActualPayer = case Payer == undefined orelse Payer == <<>> of
+                      true -> Owner;
+                      false -> Payer
+                  end,
+    case blockchain_ledger_v1:check_dc_or_hnt_balance(ActualPayer, TotalFee, Ledger, AreFeesEnabled) of
+        {error, _}=Error ->
+            Error;
+        ok ->
+            Gateway = ?MODULE:gateway(Txn),
+            case blockchain_gateway_cache:get(Gateway, Ledger) of
+                {error, _} ->
+                    {error, {unknown_gateway, {assert_location_v2, Gateway, Ledger}}};
+                {ok, GwInfo} ->
+                    GwOwner = blockchain_ledger_gateway_v2:owner_address(GwInfo),
+                    case Owner == GwOwner of
+                        false ->
+                            {error, {bad_owner, {assert_location_v2, Owner, GwOwner}}};
+                        true ->
+                            {ok, MinAssertH3Res} = blockchain:config(?min_assert_h3_res, Ledger),
+                            Location = ?MODULE:location(Txn),
+                            case ?MODULE:is_valid_location(Txn, MinAssertH3Res) of
+                                false ->
+                                    {error, {insufficient_assert_res, {assert_location_v2, Location, Gateway}}};
+                                true ->
+                                    LedgerNonce = blockchain_ledger_gateway_v2:nonce(GwInfo),
+                                    case Nonce =:= LedgerNonce + 1 of
+                                        false ->
+                                            {error, {bad_nonce, {assert_location_v2, Nonce, LedgerNonce}}};
+                                        true ->
+                                            ok
+                                    end
+                            end
+                    end
+            end
+    end.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec absorb(txn_assert_location(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
+absorb(Txn, Chain) ->
+    Ledger = blockchain:ledger(Chain),
+    AreFeesEnabled = blockchain_ledger_v1:txn_fees_active(Ledger),
+    Gateway = ?MODULE:gateway(Txn),
+    Owner = ?MODULE:owner(Txn),
+    Location = ?MODULE:location(Txn),
+    Nonce = ?MODULE:nonce(Txn),
+    StakingFee = ?MODULE:staking_fee(Txn),
+    Fee = ?MODULE:fee(Txn),
+    Payer = ?MODULE:payer(Txn),
+    Gain = ?MODULE:gain(Txn),
+    Elevation = ?MODULE:elevation(Txn),
+    ActualPayer = case Payer == undefined orelse Payer == <<>> of
+        true -> Owner;
+        false -> Payer
+    end,
+
+    {ok, OldGw} = blockchain_gateway_cache:get(Gateway, Ledger, false),
+    %% NOTE: It is assumed that the staking_fee is set to 0 at user level for assert_location_v2 transactions
+    %% which only update gain/elevation
+    case blockchain_ledger_v1:debit_fee(ActualPayer, Fee + StakingFee, Ledger, AreFeesEnabled) of
+        {error, _Reason}=Error ->
+            Error;
+        ok ->
+            blockchain_ledger_v1:add_gateway_location(Gateway, Location, Nonce, Ledger),
+            blockchain_ledger_v1:add_gateway_gain(Gateway, Gain, Nonce, Ledger),
+            blockchain_ledger_v1:add_gateway_elevation(Gateway, Elevation, Nonce, Ledger),
+            maybe_alter_hex(OldGw, Gateway, Location, Ledger),
+            maybe_update_neighbors(Gateway, Ledger)
+    end.
+
+-spec maybe_update_neighbors(Gateway :: libp2p_crypto:pubkey_bin(),
+                             Ledger :: blockchain_ledger_v1:ledger()) -> ok.
+maybe_update_neighbors(Gateway, Ledger) ->
+    case blockchain:config(?poc_version, Ledger) of
+        {ok, V} when V > 3 ->
+            %% don't update neighbours anymore
+            ok;
+        _ ->
+            %% TODO gc this nonsense in some deterministic way
+            Gateways = blockchain_ledger_v1:active_gateways(Ledger),
+            Neighbors = blockchain_poc_path:neighbors(Gateway, Gateways, Ledger),
+            {ok, Gw} = blockchain_gateway_cache:get(Gateway, Ledger, false),
+            ok = blockchain_ledger_v1:fixup_neighbors(Gateway, Gateways, Neighbors, Ledger),
+            Gw1 = blockchain_ledger_gateway_v2:neighbors(Neighbors, Gw),
+            ok = blockchain_ledger_v1:update_gateway(Gw1, Gateway, Ledger)
+    end.
+
+-spec maybe_alter_hex(OldGw :: blockchain_ledger_gateway_v2:gateway(),
+                      Gateway :: libp2p_crypto:pubkey_bin(),
+                      Location :: h3:index(),
+                      Ledger :: blockchain_ledger_v1:ledger()) -> ok.
+maybe_alter_hex(OldGw, Gateway, Location, Ledger) ->
+    %% hex index update code needs to be unconditional and hard-coded
+    %% until we have chain var update hook
+    %% {ok, Res} = blockchain:config(?poc_target_hex_parent_res, Ledger),
+    Res = 5,
+    OldLoc = blockchain_ledger_gateway_v2:location(OldGw),
+    OldHex = case OldLoc of
+                 undefined ->
+                     undefined;
+                 _ ->
+                     h3:parent(OldLoc, Res)
+             end,
+
+    Hex = h3:parent(Location, Res),
+
+    case {OldLoc, Location, Hex} of
+        {undefined, New, H} ->
+            %% no previous location
+
+            %% add new hex
+            blockchain_ledger_v1:add_to_hex(H, Gateway, Ledger),
+            %% add new location of this gateway to h3dex
+            blockchain_ledger_v1:add_gw_to_hex(New, Gateway, Ledger);
+        {Old, Old, _H} ->
+            %% why even check this, same loc as old loc
+            ok;
+        {Old, New, H} when H == OldHex ->
+            %% moved within the same Hex
+
+            %% remove old location of this gateway from h3dex
+            blockchain_ledger_v1:remove_gw_from_hex(Old, Gateway, Ledger),
+
+            %% add new location of this gateway to h3dex
+            blockchain_ledger_v1:add_gw_to_hex(New, Gateway, Ledger);
+        {Old, New, H} ->
+            %% moved to a different hex
+
+            %% remove this hex
+            blockchain_ledger_v1:remove_from_hex(OldHex, Gateway, Ledger),
+            %% add new hex
+            blockchain_ledger_v1:add_to_hex(H, Gateway, Ledger),
+
+            %% remove old location of this gateway from h3dex
+            blockchain_ledger_v1:remove_gw_from_hex(Old, Gateway, Ledger),
+            %% add new location of this gateway to h3dex
+            blockchain_ledger_v1:add_gw_to_hex(New, Gateway, Ledger)
+    end.
+
+-spec print(txn_assert_location()) -> iodata().
+print(undefined) -> <<"type=assert_location, undefined">>;
+print(#blockchain_txn_assert_location_v2_pb{
+        gateway = Gateway, owner = Owner, payer = Payer,
+        location = Loc, gain = Gain, elevation = Elevation,
+        owner_signature = OS, payer_signature = PS, nonce = Nonce,
+        staking_fee = StakingFee, fee = Fee}) ->
+    io_lib:format("type=assert_location, gateway=~p, owner=~p, payer=~p, location=~p, owner_signature=~p, payer_signature=~p, nonce=~p, gain=~p, elevation=~p, staking_fee=~p, fee=~p", [?TO_ANIMAL_NAME(Gateway), ?TO_B58(Owner), ?TO_B58(Payer), Loc, OS, PS, Nonce, Gain, Elevation, StakingFee, Fee]).
+
+-spec to_json(txn_assert_location(), blockchain_json:opts()) -> blockchain_json:json_object().
+to_json(Txn, _Opts) ->
+    #{
+      type => <<"assert_location_v2">>,
+      hash => ?BIN_TO_B64(hash(Txn)),
+      gateway => ?BIN_TO_B58(gateway(Txn)),
+      owner => ?BIN_TO_B58(owner(Txn)),
+      payer => ?MAYBE_B58(payer(Txn)),
+      location => ?MAYBE_H3(location(Txn)),
+      nonce => nonce(Txn),
+      staking_fee => staking_fee(Txn),
+      fee => fee(Txn),
+      gain => gain(Txn),
+      elevation => elevation(Txn)
+     }.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+
+%% ------------------------------------------------------------------
+%% EUNIT Tests
+%% ------------------------------------------------------------------
+-ifdef(TEST).
+
+-define(TEST_LOCATION, 631210968840687103).
+
+new() ->
+    #blockchain_txn_assert_location_v2_pb{
+       gateway= <<"gateway_address">>,
+       owner= <<"owner_address">>,
+       payer= <<>>,
+       owner_signature= <<>>,
+       payer_signature= <<>>,
+       location= h3:to_string(?TEST_LOCATION),
+       nonce = 1,
+       staking_fee = ?LEGACY_STAKING_FEE,
+       fee = ?LEGACY_TXN_FEE,
+       gain = ?DEFAULT_GAIN,
+       elevation = ?DEFAULT_ELEVATION
+      }.
+
+invalid_new() ->
+    #blockchain_txn_assert_location_v2_pb{
+       gateway= <<"gateway_address">>,
+       owner= <<"owner_address">>,
+       owner_signature= << >>,
+       location= h3:to_string(599685771850416127),
+       nonce = 1,
+       staking_fee = ?LEGACY_STAKING_FEE,
+       fee = ?LEGACY_TXN_FEE
+      }.
+
+missing_payer_signature_new() ->
+    #{public := PubKey, secret := _PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
+    #blockchain_txn_assert_location_v2_pb{
+       gateway= <<"gateway_address">>,
+       owner= <<"owner_address">>,
+       payer= libp2p_crypto:pubkey_to_bin(PubKey),
+       payer_signature = <<>>,
+       owner_signature= << >>,
+       location= h3:to_string(599685771850416127),
+       nonce = 1,
+       staking_fee = ?LEGACY_STAKING_FEE,
+       fee = ?LEGACY_TXN_FEE
+      }.
+
+new_test() ->
+    Tx = new(),
+    ?assertEqual(Tx, new(<<"gateway_address">>, <<"owner_address">>, ?TEST_LOCATION, 1)).
+
+location_test() ->
+    Tx = new(),
+    ?assertEqual(?TEST_LOCATION, location(Tx)).
+
+nonce_test() ->
+    Tx = new(),
+    ?assertEqual(1, nonce(Tx)).
+
+staking_fee_test() ->
+    Tx = new(),
+    ?assertEqual(?LEGACY_STAKING_FEE, staking_fee(Tx)).
+
+fee_test() ->
+    Tx = new(),
+    ?assertEqual(?LEGACY_TXN_FEE, fee(Tx)).
+
+owner_test() ->
+    Tx = new(),
+    ?assertEqual(<<"owner_address">>, owner(Tx)).
+
+gateway_test() ->
+    Tx = new(),
+    ?assertEqual(<<"gateway_address">>, gateway(Tx)).
+
+payer_test() ->
+    Tx = new(),
+    ?assertEqual(<<>>, payer(Tx)).
+
+owner_signature_test() ->
+    Tx = new(),
+    ?assertEqual(<<>>, owner_signature(Tx)).
+
+payer_signature_missing_test() ->
+    Tx = missing_payer_signature_new(),
+    ?assertNot(is_valid_payer(Tx)).
+
+payer_signature_test() ->
+    Tx = new(),
+    ?assertEqual(<<>>, payer_signature(Tx)).
+
+sign_test() ->
+    #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
+    Tx0 = new(),
+    SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
+    Tx1 = sign(Tx0, SigFun),
+    Sig1 = owner_signature(Tx1),
+    BaseTxn1 = Tx1#blockchain_txn_assert_location_v2_pb{owner_signature = <<>>},
+    ?assert(libp2p_crypto:verify(blockchain_txn_assert_location_v2_pb:encode_msg(BaseTxn1), Sig1, PubKey)).
+
+sign_payer_test() ->
+    #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
+    Tx0 = new(),
+    SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
+    Tx1 = sign_payer(Tx0, SigFun),
+    Tx2 = sign(Tx1, SigFun),
+    Sig2 = payer_signature(Tx2),
+    BaseTx1 = Tx2#blockchain_txn_assert_location_v2_pb{owner_signature = <<>>, payer_signature= <<>>},
+    ?assert(libp2p_crypto:verify(blockchain_txn_assert_location_v2_pb:encode_msg(BaseTx1), Sig2, PubKey)).
+
+valid_location_test() ->
+    Tx = new(),
+    ?assert(is_valid_location(Tx, 12)).
+
+invalid_location_test() ->
+    Tx = invalid_new(),
+    ?assertNot(is_valid_location(Tx, 12)).
+
+to_json_test() ->
+    Tx = new(),
+    Json = to_json(Tx, []),
+    ?assert(lists:all(fun(K) -> maps:is_key(K, Json) end,
+                      [type, hash, gateway, owner, payer, location, nonce, staking_fee, fee])).
+
+is_valid_gain_test() ->
+    MinGain = 10,
+    MaxGain = 150,
+    Tx = new(),
+    InvT1 = gain(Tx, 9),
+    InvT2 = gain(Tx, 8),
+    InvT3 = gain(Tx, 151),
+    InvT4 = gain(Tx, 152),
+    ValidT1 = gain(Tx, 10),
+    ValidT2 = gain(Tx, 11),
+    ValidT3 = gain(Tx, 150),
+    ValidT4 = gain(Tx, 149),
+    ?assertNot(is_valid_gain(InvT1, MinGain, MaxGain)),
+    ?assertNot(is_valid_gain(InvT2, MinGain, MaxGain)),
+    ?assertNot(is_valid_gain(InvT3, MinGain, MaxGain)),
+    ?assertNot(is_valid_gain(InvT4, MinGain, MaxGain)),
+    ?assert(is_valid_gain(ValidT1, MinGain, MaxGain)),
+    ?assert(is_valid_gain(ValidT2, MinGain, MaxGain)),
+    ?assert(is_valid_gain(ValidT3, MinGain, MaxGain)),
+    ?assert(is_valid_gain(ValidT4, MinGain, MaxGain)).
+
+-endif.

--- a/test/blockchain_assert_loc_v2_SUITE.erl
+++ b/test/blockchain_assert_loc_v2_SUITE.erl
@@ -8,18 +8,34 @@
 -export([all/0, init_per_testcase/2, end_per_testcase/2]).
 
 -export([
-         basic_test/1,
-         zero_staking_fee_test/1,
-         same_loc_diff_gain_test/1,
-         same_loc_diff_elevation_test/1
-        ]).
+    basic_test/1,
+    bad_owner_sig_test/1,
+    bad_payer_sig_test/1,
+    zero_staking_fee_test/1,
+    same_loc_diff_gain_test/1,
+    same_loc_diff_elevation_test/1,
+    invalid_gain_test/1,
+    insufficient_assert_version_test/1,
+    insufficient_assert_res_test/1,
+    bad_nonce_test/1,
+    min_antenna_gain_not_set_test/1,
+    max_antenna_gain_not_set_test/1
+]).
 
 all() ->
     [
-     basic_test,
-     zero_staking_fee_test,
-     same_loc_diff_gain_test,
-     same_loc_diff_elevation_test
+        basic_test,
+        bad_owner_sig_test,
+        bad_payer_sig_test,
+        zero_staking_fee_test,
+        same_loc_diff_gain_test,
+        same_loc_diff_elevation_test,
+        invalid_gain_test,
+        insufficient_assert_version_test,
+        insufficient_assert_res_test,
+        bad_nonce_test,
+        min_antenna_gain_not_set_test,
+        max_antenna_gain_not_set_test
     ].
 
 %%--------------------------------------------------------------------
@@ -31,13 +47,7 @@ init_per_testcase(TestCase, Config) ->
     Balance = 5000,
     {ok, Sup, {PrivKey, PubKey}, Opts} = test_utils:init(?config(base_dir, Config0)),
 
-    ExtraVars = #{
-                  txn_fees => true,
-                  staking_fee_txn_assert_location_v1 => 1000000,
-                  assert_loc_txn_version => 2,
-                  min_antenna_gain => 10,
-                  max_antenna_gain => 150
-                 },
+    ExtraVars = extra_vars(TestCase),
 
     {ok, GenesisMembers, _GenesisBlock, ConsensusMembers, Keys} =
         test_utils:init_chain(Balance, {PrivKey, PubKey}, true, ExtraVars),
@@ -49,25 +59,28 @@ init_per_testcase(TestCase, Config) ->
     % Check ledger to make sure everyone has the right balance
     Ledger = blockchain:ledger(Chain),
     Entries = blockchain_ledger_v1:entries(Ledger),
-    _ = lists:foreach(fun(Entry) ->
-                              Balance = blockchain_ledger_entry_v1:balance(Entry),
-                              0 = blockchain_ledger_entry_v1:nonce(Entry)
-                      end, maps:values(Entries)),
+    _ = lists:foreach(
+        fun(Entry) ->
+            Balance = blockchain_ledger_entry_v1:balance(Entry),
+            0 = blockchain_ledger_entry_v1:nonce(Entry)
+        end,
+        maps:values(Entries)
+    ),
 
     [
-     {balance, Balance},
-     {sup, Sup},
-     {pubkey, PubKey},
-     {privkey, PrivKey},
-     {opts, Opts},
-     {chain, Chain},
-     {swarm, Swarm},
-     {n, N},
-     {consensus_members, ConsensusMembers},
-     {genesis_members, GenesisMembers},
-     {ledger, Ledger},
-     {keys, Keys}
-     | Config0
+        {balance, Balance},
+        {sup, Sup},
+        {pubkey, PubKey},
+        {privkey, PrivKey},
+        {opts, Opts},
+        {chain, Chain},
+        {swarm, Swarm},
+        {n, N},
+        {consensus_members, ConsensusMembers},
+        {genesis_members, GenesisMembers},
+        {ledger, Ledger},
+        {keys, Keys}
+        | Config0
     ].
 
 %%--------------------------------------------------------------------
@@ -94,7 +107,7 @@ basic_test(Config) ->
     Chain = ?config(chain, Config),
     ConsensusMembers = ?config(consensus_members, Config),
 
-    [_, {Owner, {_OwnerPubkey, _OwnerPrivKey, OwnerSigFun}}|_] = ConsensusMembers,
+    [_, {Owner, {_OwnerPubkey, _OwnerPrivKey, OwnerSigFun}} | _] = ConsensusMembers,
 
     %% NOTE: gateway pubkey bin = owner = payer for the tests
     GatewayPubkeyBin = Owner,
@@ -102,7 +115,7 @@ basic_test(Config) ->
 
     %% Construct a simple assert_location_v2 transaction
     NewLoc = 631252734740306943,
-    {_Txn1, Txn2} = base_assert_loc_v2_txn(GatewayPubkeyBin, Owner, Payer, NewLoc, Chain),
+    {_Txn1, Txn2} = base_assert_loc_v2_txn(GatewayPubkeyBin, Owner, Payer, NewLoc, 1, Chain),
     STxn0 = blockchain_txn_assert_location_v2:sign(Txn2, OwnerSigFun),
     STxn1 = blockchain_txn_assert_location_v2:sign_payer(STxn0, OwnerSigFun),
 
@@ -119,11 +132,15 @@ basic_test(Config) ->
 
     ok.
 
-zero_staking_fee_test(Config) ->
+bad_owner_sig_test(Config) ->
     Chain = ?config(chain, Config),
     ConsensusMembers = ?config(consensus_members, Config),
 
-    [_, {Owner, {_OwnerPubkey, _OwnerPrivKey, OwnerSigFun}}|_] = ConsensusMembers,
+    [
+        {_NotOwner, {_NotOwnerPubkey, _NotOwnerPrivKey, NotOwnerSigFun}},
+        {Owner, {_OwnerPubkey, _OwnerPrivKey, OwnerSigFun}}
+        | _
+    ] = ConsensusMembers,
 
     %% NOTE: gateway pubkey bin = owner = payer for the tests
     GatewayPubkeyBin = Owner,
@@ -131,17 +148,69 @@ zero_staking_fee_test(Config) ->
 
     %% Construct a simple assert_location_v2 transaction
     NewLoc = 631252734740306943,
-    {Txn1, _Txn2} = base_assert_loc_v2_txn(GatewayPubkeyBin, Owner, Payer, NewLoc, Chain),
+    {_Txn1, Txn2} = base_assert_loc_v2_txn(GatewayPubkeyBin, Owner, Payer, NewLoc, 1, Chain),
+    STxn0 = blockchain_txn_assert_location_v2:sign(Txn2, NotOwnerSigFun),
+    STxn1 = blockchain_txn_assert_location_v2:sign_payer(STxn0, OwnerSigFun),
+
+    %% This transaction should be invalid
+    {error, {bad_owner_signature, _}} = blockchain_txn_assert_location_v2:is_valid(STxn1, Chain),
+
+    ok.
+
+bad_payer_sig_test(Config) ->
+    Chain = ?config(chain, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+
+    [
+        {_NotPayer, {_NotPayerPubkey, _NotPayerPrivKey, NotPayerSigFun}},
+        {Owner, {_OwnerPubkey, _OwnerPrivKey, OwnerSigFun}}
+        | _
+    ] = ConsensusMembers,
+
+    %% NOTE: gateway pubkey bin = owner = payer for the tests
+    GatewayPubkeyBin = Owner,
+    Payer = Owner,
+
+    %% Construct a simple assert_location_v2 transaction
+    NewLoc = 631252734740306943,
+    {_Txn1, Txn2} = base_assert_loc_v2_txn(GatewayPubkeyBin, Owner, Payer, NewLoc, 1, Chain),
+    STxn0 = blockchain_txn_assert_location_v2:sign(Txn2, OwnerSigFun),
+    STxn1 = blockchain_txn_assert_location_v2:sign_payer(STxn0, NotPayerSigFun),
+
+    %% This transaction should be invalid
+    {error, {bad_payer_signature, _}} = blockchain_txn_assert_location_v2:is_valid(STxn1, Chain),
+
+    ok.
+
+zero_staking_fee_test(Config) ->
+    Chain = ?config(chain, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+
+    [_, {Owner, {_OwnerPubkey, _OwnerPrivKey, OwnerSigFun}} | _] = ConsensusMembers,
+
+    %% NOTE: gateway pubkey bin = owner = payer for the tests
+    GatewayPubkeyBin = Owner,
+    Payer = Owner,
+
+    %% Construct a simple assert_location_v2 transaction
+    NewLoc = 631252734740306943,
+    {Txn1, _Txn2} = base_assert_loc_v2_txn(GatewayPubkeyBin, Owner, Payer, NewLoc, 1, Chain),
 
     %% Zero-ing out the staking_fee
     ZeroStakingFee = 0,
     ZeroStakingFeeTxn = blockchain_txn_assert_location_v2:staking_fee(Txn1, ZeroStakingFee),
     ZeroStakingFeeSTxn0 = blockchain_txn_assert_location_v2:sign(ZeroStakingFeeTxn, OwnerSigFun),
-    ZeroStakingFeeSTxn1 = blockchain_txn_assert_location_v2:sign_payer(ZeroStakingFeeSTxn0, OwnerSigFun),
+    ZeroStakingFeeSTxn1 = blockchain_txn_assert_location_v2:sign_payer(
+        ZeroStakingFeeSTxn0,
+        OwnerSigFun
+    ),
 
     %% This transaction should be invalid
     %% Reason: We have zero-ed the staking_fee but a new location was specified
-    {error, {wrong_staking_fee, {assert_location_v2, _, _}}} = blockchain_txn_assert_location_v2:is_valid(ZeroStakingFeeSTxn1, Chain),
+    {error, {wrong_staking_fee, {assert_location_v2, _, _}}} = blockchain_txn_assert_location_v2:is_valid(
+        ZeroStakingFeeSTxn1,
+        Chain
+    ),
 
     ok.
 
@@ -150,7 +219,7 @@ same_loc_diff_gain_test(Config) ->
     Chain = ?config(chain, Config),
     ConsensusMembers = ?config(consensus_members, Config),
 
-    [_, {Owner, {_OwnerPubkey, _OwnerPrivKey, OwnerSigFun}}|_] = ConsensusMembers,
+    [_, {Owner, {_OwnerPubkey, _OwnerPrivKey, OwnerSigFun}} | _] = ConsensusMembers,
 
     %% NOTE: gateway pubkey bin = owner = payer for the tests
     GatewayPubkeyBin = Owner,
@@ -165,13 +234,31 @@ same_loc_diff_gain_test(Config) ->
     %% and supply 0 staking_fee
     ZeroStakingFee = 0,
     NewGain = 23,
-    SameLocDiffGainTxn0 = blockchain_txn_assert_location_v2:new(GatewayPubkeyBin, Owner, Payer, ExistingLocation, 1),
-    SameLocDiffGainFee = blockchain_txn_assert_location_v2:calculate_fee(SameLocDiffGainTxn0, Chain),
-    SameLocDiffGainTxn1 = blockchain_txn_assert_location_v2:fee(SameLocDiffGainTxn0, SameLocDiffGainFee),
+    SameLocDiffGainTxn0 = blockchain_txn_assert_location_v2:new(
+        GatewayPubkeyBin,
+        Owner,
+        Payer,
+        ExistingLocation,
+        1
+    ),
+    SameLocDiffGainFee = blockchain_txn_assert_location_v2:calculate_fee(
+        SameLocDiffGainTxn0,
+        Chain
+    ),
+    SameLocDiffGainTxn1 = blockchain_txn_assert_location_v2:fee(
+        SameLocDiffGainTxn0,
+        SameLocDiffGainFee
+    ),
     SameLocDiffGainTxn2 = blockchain_txn_assert_location_v2:gain(SameLocDiffGainTxn1, NewGain),
-    SameLocDiffGainTxn3 = blockchain_txn_assert_location_v2:staking_fee(SameLocDiffGainTxn2, ZeroStakingFee),
+    SameLocDiffGainTxn3 = blockchain_txn_assert_location_v2:staking_fee(
+        SameLocDiffGainTxn2,
+        ZeroStakingFee
+    ),
     SameLocDiffGainSTxn0 = blockchain_txn_assert_location_v2:sign(SameLocDiffGainTxn3, OwnerSigFun),
-    SameLocDiffGainSTxn1 = blockchain_txn_assert_location_v2:sign_payer(SameLocDiffGainSTxn0, OwnerSigFun),
+    SameLocDiffGainSTxn1 = blockchain_txn_assert_location_v2:sign_payer(
+        SameLocDiffGainSTxn0,
+        OwnerSigFun
+    ),
 
     %% This transaction should be valid
     ok = blockchain_txn_assert_location_v2:is_valid(SameLocDiffGainSTxn1, Chain),
@@ -196,7 +283,7 @@ same_loc_diff_elevation_test(Config) ->
     Chain = ?config(chain, Config),
     ConsensusMembers = ?config(consensus_members, Config),
 
-    [_, {Owner, {_OwnerPubkey, _OwnerPrivKey, OwnerSigFun}}|_] = ConsensusMembers,
+    [_, {Owner, {_OwnerPubkey, _OwnerPrivKey, OwnerSigFun}} | _] = ConsensusMembers,
 
     %% NOTE: gateway pubkey bin = owner = payer for the tests
     GatewayPubkeyBin = Owner,
@@ -210,13 +297,37 @@ same_loc_diff_elevation_test(Config) ->
     %% and supply 0 staking_fee
     ZeroStakingFee = 0,
     NewElevation = 5,
-    SameLocDiffElevationTxn0 = blockchain_txn_assert_location_v2:new(GatewayPubkeyBin, Owner, Payer, ExistingLocation, 1),
-    SameLocDiffElevationFee = blockchain_txn_assert_location_v2:calculate_fee(SameLocDiffElevationTxn0, Chain),
-    SameLocDiffElevationTxn1 = blockchain_txn_assert_location_v2:fee(SameLocDiffElevationTxn0, SameLocDiffElevationFee),
-    SameLocDiffElevationTxn2 = blockchain_txn_assert_location_v2:elevation(SameLocDiffElevationTxn1, NewElevation),
-    SameLocDiffElevationTxn3 = blockchain_txn_assert_location_v2:staking_fee(SameLocDiffElevationTxn2, ZeroStakingFee),
-    SameLocDiffElevationSTxn0 = blockchain_txn_assert_location_v2:sign(SameLocDiffElevationTxn3, OwnerSigFun),
-    SameLocDiffElevationSTxn1 = blockchain_txn_assert_location_v2:sign_payer(SameLocDiffElevationSTxn0, OwnerSigFun),
+    SameLocDiffElevationTxn0 = blockchain_txn_assert_location_v2:new(
+        GatewayPubkeyBin,
+        Owner,
+        Payer,
+        ExistingLocation,
+        1
+    ),
+    SameLocDiffElevationFee = blockchain_txn_assert_location_v2:calculate_fee(
+        SameLocDiffElevationTxn0,
+        Chain
+    ),
+    SameLocDiffElevationTxn1 = blockchain_txn_assert_location_v2:fee(
+        SameLocDiffElevationTxn0,
+        SameLocDiffElevationFee
+    ),
+    SameLocDiffElevationTxn2 = blockchain_txn_assert_location_v2:elevation(
+        SameLocDiffElevationTxn1,
+        NewElevation
+    ),
+    SameLocDiffElevationTxn3 = blockchain_txn_assert_location_v2:staking_fee(
+        SameLocDiffElevationTxn2,
+        ZeroStakingFee
+    ),
+    SameLocDiffElevationSTxn0 = blockchain_txn_assert_location_v2:sign(
+        SameLocDiffElevationTxn3,
+        OwnerSigFun
+    ),
+    SameLocDiffElevationSTxn1 = blockchain_txn_assert_location_v2:sign_payer(
+        SameLocDiffElevationSTxn0,
+        OwnerSigFun
+    ),
 
     %% This transaction should be valid
     ok = blockchain_txn_assert_location_v2:is_valid(SameLocDiffElevationSTxn1, Chain),
@@ -236,13 +347,220 @@ same_loc_diff_elevation_test(Config) ->
 
     ok.
 
+invalid_gain_test(Config) ->
+    Ledger = ?config(ledger, Config),
+    Chain = ?config(chain, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+
+    [_, {Owner, {_OwnerPubkey, _OwnerPrivKey, OwnerSigFun}} | _] = ConsensusMembers,
+
+    %% NOTE: gateway pubkey bin = owner = payer for the tests
+    GatewayPubkeyBin = Owner,
+    Payer = Owner,
+
+    %% assert that the default gain is set correctly
+    {ok, GW} = blockchain_ledger_v1:find_gateway_info(GatewayPubkeyBin, Ledger),
+    ?assertEqual(?DEFAULT_GAIN, blockchain_ledger_gateway_v2:gain(GW)),
+    ExistingLocation = blockchain_ledger_gateway_v2:location(GW),
+
+    %% We will not change the location of the gateway and supply 0 staking_fee
+    ZeroStakingFee = 0,
+    %% NOTE: Supply a gain value outside of the allowed range (16 dbi = 160)
+    NewGain = 160,
+
+    SameLocDiffGainTxn0 = blockchain_txn_assert_location_v2:new(
+        GatewayPubkeyBin,
+        Owner,
+        Payer,
+        ExistingLocation,
+        1
+    ),
+    SameLocDiffGainFee = blockchain_txn_assert_location_v2:calculate_fee(
+        SameLocDiffGainTxn0,
+        Chain
+    ),
+    SameLocDiffGainTxn1 = blockchain_txn_assert_location_v2:fee(
+        SameLocDiffGainTxn0,
+        SameLocDiffGainFee
+    ),
+    SameLocDiffGainTxn2 = blockchain_txn_assert_location_v2:gain(SameLocDiffGainTxn1, NewGain),
+    SameLocDiffGainTxn3 = blockchain_txn_assert_location_v2:staking_fee(
+        SameLocDiffGainTxn2,
+        ZeroStakingFee
+    ),
+    SameLocDiffGainSTxn0 = blockchain_txn_assert_location_v2:sign(SameLocDiffGainTxn3, OwnerSigFun),
+    SameLocDiffGainSTxn1 = blockchain_txn_assert_location_v2:sign_payer(
+        SameLocDiffGainSTxn0,
+        OwnerSigFun
+    ),
+
+    %% This transaction should be invalid
+    {error, {invalid_assert_loc_txn_v2, {invalid_antenna_gain, 160, 10, 150}}} = blockchain_txn_assert_location_v2:is_valid(
+        SameLocDiffGainSTxn1,
+        Chain
+    ),
+
+    ok.
+
+insufficient_assert_version_test(Config) ->
+    Chain = ?config(chain, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+
+    [_, {Owner, {_OwnerPubkey, _OwnerPrivKey, OwnerSigFun}} | _] = ConsensusMembers,
+
+    %% NOTE: gateway pubkey bin = owner = payer for the tests
+    GatewayPubkeyBin = Owner,
+    Payer = Owner,
+
+    %% Construct a simple assert_location_v2 transaction
+    NewLoc = 631252734740306943,
+    {_Txn1, Txn2} = base_assert_loc_v2_txn(GatewayPubkeyBin, Owner, Payer, NewLoc, 1, Chain),
+    STxn0 = blockchain_txn_assert_location_v2:sign(Txn2, OwnerSigFun),
+    STxn1 = blockchain_txn_assert_location_v2:sign_payer(STxn0, OwnerSigFun),
+
+    {error, {invalid_assert_loc_txn_v2, insufficient_assert_loc_txn_version}} = blockchain_txn_assert_location_v2:is_valid(
+        STxn1,
+        Chain
+    ),
+
+    ok.
+
+insufficient_assert_res_test(Config) ->
+    Chain = ?config(chain, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+
+    [_, {Owner, {_OwnerPubkey, _OwnerPrivKey, OwnerSigFun}} | _] = ConsensusMembers,
+
+    %% NOTE: gateway pubkey bin = owner = payer for the tests
+    GatewayPubkeyBin = Owner,
+    Payer = Owner,
+
+    %% Construct a simple assert_location_v2 transaction
+    NewLoc = h3:parent(631252734740306943, 9),
+    {_Txn1, Txn2} = base_assert_loc_v2_txn(GatewayPubkeyBin, Owner, Payer, NewLoc, 1, Chain),
+    STxn0 = blockchain_txn_assert_location_v2:sign(Txn2, OwnerSigFun),
+    STxn1 = blockchain_txn_assert_location_v2:sign_payer(STxn0, OwnerSigFun),
+
+    %% This transaction should be valid
+    {error, {insufficient_assert_res, _}} = blockchain_txn_assert_location_v2:is_valid(
+        STxn1,
+        Chain
+    ),
+
+    ok.
+
+bad_nonce_test(Config) ->
+    Chain = ?config(chain, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+
+    [_, {Owner, {_OwnerPubkey, _OwnerPrivKey, OwnerSigFun}} | _] = ConsensusMembers,
+
+    %% NOTE: gateway pubkey bin = owner = payer for the tests
+    GatewayPubkeyBin = Owner,
+    Payer = Owner,
+
+    %% Some random bad nonce
+    BadNonce = 10,
+
+    %% Construct a simple assert_location_v2 transaction
+    NewLoc = 631252734740306943,
+    {_Txn1, Txn2} = base_assert_loc_v2_txn(GatewayPubkeyBin, Owner, Payer, NewLoc, BadNonce, Chain),
+    STxn0 = blockchain_txn_assert_location_v2:sign(Txn2, OwnerSigFun),
+    STxn1 = blockchain_txn_assert_location_v2:sign_payer(STxn0, OwnerSigFun),
+
+    %% This transaction should be valid
+    {error, {bad_nonce, {assert_location_v2, BadNonce, 0}}} = blockchain_txn_assert_location_v2:is_valid(
+        STxn1,
+        Chain
+    ),
+
+    ok.
+
+min_antenna_gain_not_set_test(Config) ->
+    Chain = ?config(chain, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+
+    [_, {Owner, {_OwnerPubkey, _OwnerPrivKey, OwnerSigFun}} | _] = ConsensusMembers,
+
+    %% NOTE: gateway pubkey bin = owner = payer for the tests
+    GatewayPubkeyBin = Owner,
+    Payer = Owner,
+
+    %% Construct a simple assert_location_v2 transaction
+    NewLoc = 631252734740306943,
+    {_Txn1, Txn2} = base_assert_loc_v2_txn(GatewayPubkeyBin, Owner, Payer, NewLoc, 1, Chain),
+    STxn0 = blockchain_txn_assert_location_v2:sign(Txn2, OwnerSigFun),
+    STxn1 = blockchain_txn_assert_location_v2:sign_payer(STxn0, OwnerSigFun),
+
+    {error, {invalid_assert_loc_txn_v2, min_antenna_gain_not_set}} = blockchain_txn_assert_location_v2:is_valid(
+        STxn1,
+        Chain
+    ),
+
+    ok.
+
+max_antenna_gain_not_set_test(Config) ->
+    Chain = ?config(chain, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+
+    [_, {Owner, {_OwnerPubkey, _OwnerPrivKey, OwnerSigFun}} | _] = ConsensusMembers,
+
+    %% NOTE: gateway pubkey bin = owner = payer for the tests
+    GatewayPubkeyBin = Owner,
+    Payer = Owner,
+
+    %% Construct a simple assert_location_v2 transaction
+    NewLoc = 631252734740306943,
+    {_Txn1, Txn2} = base_assert_loc_v2_txn(GatewayPubkeyBin, Owner, Payer, NewLoc, 1, Chain),
+    STxn0 = blockchain_txn_assert_location_v2:sign(Txn2, OwnerSigFun),
+    STxn1 = blockchain_txn_assert_location_v2:sign_payer(STxn0, OwnerSigFun),
+
+    %% This transaction should be invalid
+    {error, {invalid_assert_loc_txn_v2, max_antenna_gain_not_set}} = blockchain_txn_assert_location_v2:is_valid(
+        STxn1,
+        Chain
+    ),
+
+    ok.
+
 %%--------------------------------------------------------------------
 %% HELPERS
 %%--------------------------------------------------------------------
 
-base_assert_loc_v2_txn(GatewayPubkeyBin, Owner, Payer, Loc, Chain) ->
-    Txn0 = blockchain_txn_assert_location_v2:new(GatewayPubkeyBin, Owner, Payer, Loc, 1),
+base_assert_loc_v2_txn(GatewayPubkeyBin, Owner, Payer, Loc, Nonce, Chain) ->
+    Txn0 = blockchain_txn_assert_location_v2:new(GatewayPubkeyBin, Owner, Payer, Loc, Nonce),
     Fee = blockchain_txn_assert_location_v2:calculate_fee(Txn0, Chain),
     SFee = blockchain_txn_assert_location_v2:calculate_staking_fee(Txn0, Chain),
     Txn1 = blockchain_txn_assert_location_v2:fee(Txn0, Fee),
     {Txn1, blockchain_txn_assert_location_v2:staking_fee(Txn1, SFee)}.
+
+extra_vars(min_antenna_gain_not_set_test) ->
+    #{
+        txn_fees => true,
+        staking_fee_txn_assert_location_v1 => 1000000,
+        assert_loc_txn_version => 2,
+        max_antenna_gain => 150
+    };
+extra_vars(max_antenna_gain_not_set_test) ->
+    #{
+        txn_fees => true,
+        staking_fee_txn_assert_location_v1 => 1000000,
+        assert_loc_txn_version => 2,
+        min_antenna_gain => 10
+    };
+extra_vars(insufficient_assert_version_test) ->
+    #{
+        txn_fees => true,
+        staking_fee_txn_assert_location_v1 => 1000000,
+        assert_loc_txn_version => 1,
+        min_antenna_gain => 10,
+        max_antenna_gain => 150
+    };
+extra_vars(_) ->
+    #{
+        txn_fees => true,
+        staking_fee_txn_assert_location_v1 => 1000000,
+        assert_loc_txn_version => 2,
+        min_antenna_gain => 10,
+        max_antenna_gain => 150
+    }.

--- a/test/blockchain_assert_loc_v2_SUITE.erl
+++ b/test/blockchain_assert_loc_v2_SUITE.erl
@@ -1,0 +1,248 @@
+-module(blockchain_assert_loc_v2_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include("blockchain_vars.hrl").
+-include("blockchain_utils.hrl").
+
+-export([all/0, init_per_testcase/2, end_per_testcase/2]).
+
+-export([
+         basic_test/1,
+         zero_staking_fee_test/1,
+         same_loc_diff_gain_test/1,
+         same_loc_diff_elevation_test/1
+        ]).
+
+all() ->
+    [
+     basic_test,
+     zero_staking_fee_test,
+     same_loc_diff_gain_test,
+     same_loc_diff_elevation_test
+    ].
+
+%%--------------------------------------------------------------------
+%% TEST CASE SETUP
+%%--------------------------------------------------------------------
+
+init_per_testcase(TestCase, Config) ->
+    Config0 = blockchain_ct_utils:init_base_dir_config(?MODULE, TestCase, Config),
+    Balance = 5000,
+    {ok, Sup, {PrivKey, PubKey}, Opts} = test_utils:init(?config(base_dir, Config0)),
+
+    ExtraVars = #{
+                  txn_fees => true,
+                  staking_fee_txn_assert_location_v1 => 1000000,
+                  assert_loc_txn_version => 2,
+                  min_antenna_gain => 10,
+                  max_antenna_gain => 150
+                 },
+
+    {ok, GenesisMembers, _GenesisBlock, ConsensusMembers, Keys} =
+        test_utils:init_chain(Balance, {PrivKey, PubKey}, true, ExtraVars),
+
+    Chain = blockchain_worker:blockchain(),
+    Swarm = blockchain_swarm:swarm(),
+    N = length(ConsensusMembers),
+
+    % Check ledger to make sure everyone has the right balance
+    Ledger = blockchain:ledger(Chain),
+    Entries = blockchain_ledger_v1:entries(Ledger),
+    _ = lists:foreach(fun(Entry) ->
+                              Balance = blockchain_ledger_entry_v1:balance(Entry),
+                              0 = blockchain_ledger_entry_v1:nonce(Entry)
+                      end, maps:values(Entries)),
+
+    [
+     {balance, Balance},
+     {sup, Sup},
+     {pubkey, PubKey},
+     {privkey, PrivKey},
+     {opts, Opts},
+     {chain, Chain},
+     {swarm, Swarm},
+     {n, N},
+     {consensus_members, ConsensusMembers},
+     {genesis_members, GenesisMembers},
+     {ledger, Ledger},
+     {keys, Keys}
+     | Config0
+    ].
+
+%%--------------------------------------------------------------------
+%% TEST CASE TEARDOWN
+%%--------------------------------------------------------------------
+
+end_per_testcase(_, Config) ->
+    Sup = ?config(sup, Config),
+    % Make sure blockchain saved on file = in memory
+    case erlang:is_process_alive(Sup) of
+        true ->
+            true = erlang:exit(Sup, normal),
+            ok = test_utils:wait_until(fun() -> false =:= erlang:is_process_alive(Sup) end);
+        false ->
+            ok
+    end,
+    ok.
+
+%%--------------------------------------------------------------------
+%% TEST CASES
+%%--------------------------------------------------------------------
+
+basic_test(Config) ->
+    Chain = ?config(chain, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+
+    [_, {Owner, {_OwnerPubkey, _OwnerPrivKey, OwnerSigFun}}|_] = ConsensusMembers,
+
+    %% NOTE: gateway pubkey bin = owner = payer for the tests
+    GatewayPubkeyBin = Owner,
+    Payer = Owner,
+
+    %% Construct a simple assert_location_v2 transaction
+    NewLoc = 631252734740306943,
+    {_Txn1, Txn2} = base_assert_loc_v2_txn(GatewayPubkeyBin, Owner, Payer, NewLoc, Chain),
+    STxn0 = blockchain_txn_assert_location_v2:sign(Txn2, OwnerSigFun),
+    STxn1 = blockchain_txn_assert_location_v2:sign_payer(STxn0, OwnerSigFun),
+
+    %% This transaction should be valid
+    ok = blockchain_txn_assert_location_v2:is_valid(STxn1, Chain),
+
+    %% Check that the transaction propogates properly
+    {ok, Block} = test_utils:create_block(ConsensusMembers, [STxn1]),
+    _ = blockchain_gossip_handler:add_block(Block, Chain, self(), blockchain_swarm:swarm()),
+    ?assertEqual({ok, blockchain_block:hash_block(Block)}, blockchain:head_hash(Chain)),
+    ?assertEqual({ok, Block}, blockchain:head_block(Chain)),
+    ?assertEqual({ok, 2}, blockchain:height(Chain)),
+    ?assertEqual({ok, Block}, blockchain:get_block(2, Chain)),
+
+    ok.
+
+zero_staking_fee_test(Config) ->
+    Chain = ?config(chain, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+
+    [_, {Owner, {_OwnerPubkey, _OwnerPrivKey, OwnerSigFun}}|_] = ConsensusMembers,
+
+    %% NOTE: gateway pubkey bin = owner = payer for the tests
+    GatewayPubkeyBin = Owner,
+    Payer = Owner,
+
+    %% Construct a simple assert_location_v2 transaction
+    NewLoc = 631252734740306943,
+    {Txn1, _Txn2} = base_assert_loc_v2_txn(GatewayPubkeyBin, Owner, Payer, NewLoc, Chain),
+
+    %% Zero-ing out the staking_fee
+    ZeroStakingFee = 0,
+    ZeroStakingFeeTxn = blockchain_txn_assert_location_v2:staking_fee(Txn1, ZeroStakingFee),
+    ZeroStakingFeeSTxn0 = blockchain_txn_assert_location_v2:sign(ZeroStakingFeeTxn, OwnerSigFun),
+    ZeroStakingFeeSTxn1 = blockchain_txn_assert_location_v2:sign_payer(ZeroStakingFeeSTxn0, OwnerSigFun),
+
+    %% This transaction should be invalid
+    %% Reason: We have zero-ed the staking_fee but a new location was specified
+    {error, {wrong_staking_fee, {assert_location_v2, _, _}}} = blockchain_txn_assert_location_v2:is_valid(ZeroStakingFeeSTxn1, Chain),
+
+    ok.
+
+same_loc_diff_gain_test(Config) ->
+    Ledger = ?config(ledger, Config),
+    Chain = ?config(chain, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+
+    [_, {Owner, {_OwnerPubkey, _OwnerPrivKey, OwnerSigFun}}|_] = ConsensusMembers,
+
+    %% NOTE: gateway pubkey bin = owner = payer for the tests
+    GatewayPubkeyBin = Owner,
+    Payer = Owner,
+
+    %% assert that the default gain is set correctly
+    {ok, GW} = blockchain_ledger_v1:find_gateway_info(GatewayPubkeyBin, Ledger),
+    ?assertEqual(?DEFAULT_GAIN, blockchain_ledger_gateway_v2:gain(GW)),
+    ExistingLocation = blockchain_ledger_gateway_v2:location(GW),
+
+    %% We will not change the location of the gateway but will update the gain
+    %% and supply 0 staking_fee
+    ZeroStakingFee = 0,
+    NewGain = 23,
+    SameLocDiffGainTxn0 = blockchain_txn_assert_location_v2:new(GatewayPubkeyBin, Owner, Payer, ExistingLocation, 1),
+    SameLocDiffGainFee = blockchain_txn_assert_location_v2:calculate_fee(SameLocDiffGainTxn0, Chain),
+    SameLocDiffGainTxn1 = blockchain_txn_assert_location_v2:fee(SameLocDiffGainTxn0, SameLocDiffGainFee),
+    SameLocDiffGainTxn2 = blockchain_txn_assert_location_v2:gain(SameLocDiffGainTxn1, NewGain),
+    SameLocDiffGainTxn3 = blockchain_txn_assert_location_v2:staking_fee(SameLocDiffGainTxn2, ZeroStakingFee),
+    SameLocDiffGainSTxn0 = blockchain_txn_assert_location_v2:sign(SameLocDiffGainTxn3, OwnerSigFun),
+    SameLocDiffGainSTxn1 = blockchain_txn_assert_location_v2:sign_payer(SameLocDiffGainSTxn0, OwnerSigFun),
+
+    %% This transaction should be valid
+    ok = blockchain_txn_assert_location_v2:is_valid(SameLocDiffGainSTxn1, Chain),
+
+    %% Check that the transaction propogates properly
+    {ok, Block} = test_utils:create_block(ConsensusMembers, [SameLocDiffGainSTxn1]),
+    _ = blockchain_gossip_handler:add_block(Block, Chain, self(), blockchain_swarm:swarm()),
+    ?assertEqual({ok, blockchain_block:hash_block(Block)}, blockchain:head_hash(Chain)),
+    ?assertEqual({ok, Block}, blockchain:head_block(Chain)),
+    ?assertEqual({ok, 2}, blockchain:height(Chain)),
+    ?assertEqual({ok, Block}, blockchain:get_block(2, Chain)),
+
+    %% Check that the new elevation reflects properly
+    Ledger1 = blockchain:ledger(Chain),
+    {ok, GW1} = blockchain_ledger_v1:find_gateway_info(GatewayPubkeyBin, Ledger1),
+    ?assertEqual(NewGain, blockchain_ledger_gateway_v2:gain(GW1)),
+
+    ok.
+
+same_loc_diff_elevation_test(Config) ->
+    Ledger = ?config(ledger, Config),
+    Chain = ?config(chain, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+
+    [_, {Owner, {_OwnerPubkey, _OwnerPrivKey, OwnerSigFun}}|_] = ConsensusMembers,
+
+    %% NOTE: gateway pubkey bin = owner = payer for the tests
+    GatewayPubkeyBin = Owner,
+    Payer = Owner,
+
+    {ok, GW} = blockchain_ledger_v1:find_gateway_info(GatewayPubkeyBin, Ledger),
+    ?assertEqual(?DEFAULT_ELEVATION, blockchain_ledger_gateway_v2:elevation(GW)),
+    ExistingLocation = blockchain_ledger_gateway_v2:location(GW),
+
+    %% We will not change the location of the gateway but will update the gain
+    %% and supply 0 staking_fee
+    ZeroStakingFee = 0,
+    NewElevation = 5,
+    SameLocDiffElevationTxn0 = blockchain_txn_assert_location_v2:new(GatewayPubkeyBin, Owner, Payer, ExistingLocation, 1),
+    SameLocDiffElevationFee = blockchain_txn_assert_location_v2:calculate_fee(SameLocDiffElevationTxn0, Chain),
+    SameLocDiffElevationTxn1 = blockchain_txn_assert_location_v2:fee(SameLocDiffElevationTxn0, SameLocDiffElevationFee),
+    SameLocDiffElevationTxn2 = blockchain_txn_assert_location_v2:elevation(SameLocDiffElevationTxn1, NewElevation),
+    SameLocDiffElevationTxn3 = blockchain_txn_assert_location_v2:staking_fee(SameLocDiffElevationTxn2, ZeroStakingFee),
+    SameLocDiffElevationSTxn0 = blockchain_txn_assert_location_v2:sign(SameLocDiffElevationTxn3, OwnerSigFun),
+    SameLocDiffElevationSTxn1 = blockchain_txn_assert_location_v2:sign_payer(SameLocDiffElevationSTxn0, OwnerSigFun),
+
+    %% This transaction should be valid
+    ok = blockchain_txn_assert_location_v2:is_valid(SameLocDiffElevationSTxn1, Chain),
+
+    %% Check that the transaction propogates properly
+    {ok, Block} = test_utils:create_block(ConsensusMembers, [SameLocDiffElevationSTxn1]),
+    _ = blockchain_gossip_handler:add_block(Block, Chain, self(), blockchain_swarm:swarm()),
+    ?assertEqual({ok, blockchain_block:hash_block(Block)}, blockchain:head_hash(Chain)),
+    ?assertEqual({ok, Block}, blockchain:head_block(Chain)),
+    ?assertEqual({ok, 2}, blockchain:height(Chain)),
+    ?assertEqual({ok, Block}, blockchain:get_block(2, Chain)),
+
+    %% Check that the new elevation reflects properly
+    Ledger1 = blockchain:ledger(Chain),
+    {ok, GW1} = blockchain_ledger_v1:find_gateway_info(GatewayPubkeyBin, Ledger1),
+    ?assertEqual(NewElevation, blockchain_ledger_gateway_v2:elevation(GW1)),
+
+    ok.
+
+%%--------------------------------------------------------------------
+%% HELPERS
+%%--------------------------------------------------------------------
+
+base_assert_loc_v2_txn(GatewayPubkeyBin, Owner, Payer, Loc, Chain) ->
+    Txn0 = blockchain_txn_assert_location_v2:new(GatewayPubkeyBin, Owner, Payer, Loc, 1),
+    Fee = blockchain_txn_assert_location_v2:calculate_fee(Txn0, Chain),
+    SFee = blockchain_txn_assert_location_v2:calculate_staking_fee(Txn0, Chain),
+    Txn1 = blockchain_txn_assert_location_v2:fee(Txn0, Fee),
+    {Txn1, blockchain_txn_assert_location_v2:staking_fee(Txn1, SFee)}.


### PR DESCRIPTION
This adds support for `assert_location_v2` transaction.

Noteworthy details:
- No `gateway_signature` field
- Adds support for `gain` and `elevation` fields
- Slightly modified logic for validation (vs assert_location_v1) which does not require any `staking_fee` when only the `gain` or `elevation` is changed, `txn_fee` is still required though
- Added a basic test case which covers only validity of the transaction

TODO:

- [x] Update ledger
- [x] Update absorb for assert_loc_v2
- [x] Fix ledger_gateway_v2 deserialization issue
- [ ] Switch proto to master once it lands

Proto: https://github.com/helium/proto/pull/41