### PR TITLE
As a temporary measure, drop snapshots on absorb failure

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -784,6 +784,13 @@ add_block_(Block, Blockchain, Syncing) ->
                     case blockchain_txn:Fun(Block, Blockchain, BeforeCommit, IsRescue) of
                         {error, Reason}=Error ->
                             lager:error("Error absorbing transaction, Ignoring Hash: ~p, Reason: ~p", [blockchain_block:hash_block(Block), Reason]),
+                            case application:get_env(blockchain, drop_snapshot_cache_on_absorb_failure, true) of
+                                true ->
+                                    lager:info("dropping all snapshots from cache"),
+                                    blockchain_ledger_v1:drop_snapshots(Ledger);
+                                false ->
+                                    ok
+                            end,
                             Error;
                         ok ->
                             run_absorb_block_hooks(Syncing, Hash, Blockchain)

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -17,6 +17,8 @@
 
     new_snapshot/1, context_snapshot/2, has_snapshot/2, release_snapshot/1, snapshot/1,
 
+    drop_snapshots/1,
+
     current_height/1, current_height/2, increment_height/2,
     consensus_members/1, consensus_members/2,
     election_height/1, election_height/2,
@@ -435,6 +437,11 @@ snapshot(Ledger) ->
         S ->
             {ok, S}
     end.
+
+-spec drop_snapshots(ledger()) -> ok.
+drop_snapshots(#ledger_v1{snapshots=Cache}) ->
+    ets:delete_all_objects(Cache),
+    ok.
 
 atom_to_cf(Atom, #ledger_v1{mode = Mode} = Ledger) ->
         SL = case Mode of


### PR DESCRIPTION
This should only be needed until we find the underlying cause of the
problems.