### PR TITLE
release rocks snapshots manually

### DIFF
--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -2383,13 +2383,15 @@ current_oracle_price_list(Ledger) ->
             Other
     end.
 
-clean(#ledger_v1{dir=Dir, db=DB}=L) ->
+clean(#ledger_v1{dir=Dir, db=DB} = L) ->
     delete_context(L),
     DBDir = filename:join(Dir, ?DB_FILE),
     catch ok = rocksdb:close(DB),
+    drop_snapshots(L),
     rocksdb:destroy(DBDir, []).
 
-close(#ledger_v1{db=DB}) ->
+close(#ledger_v1{db=DB} = L) ->
+    drop_snapshots(L),
     rocksdb:close(DB).
 
 compact(#ledger_v1{db=DB, active=Active, delayed=Delayed}) ->


### PR DESCRIPTION
I don't know if this has anything to do with our current snapshot troubles, but this is a (small) memory leak from what we can tell, and also probably isn't great for disk and memory utilization for long-running nodes.