### PR TITLE
witness retention limits

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -149,6 +149,9 @@
 %% during targeting
 -define(poc_witness_consideration_limit, poc_witness_consideration_limit).
 
+%% Number of witnesses a gateway will be allowed to be retain on disk
+-define(poc_witness_retention_limit, poc_witness_retention_limit).
+
 %%%
 %%% score vars
 %%%

--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -172,10 +172,10 @@ addr2name(Addr) ->
     {ok, N} = erl_angry_purple_tiger:animal_name(B58Addr),
     N.
 
--spec rand_state(Hash :: binary()) -> rand:state().
-rand_state(Hash) ->
+-spec rand_state(HashableBin :: binary()) -> rand:state().
+rand_state(HashableBin) ->
     <<A:85/integer-unsigned-little, B:85/integer-unsigned-little,
-      C:86/integer-unsigned-little, _/binary>> = crypto:hash(sha256, Hash),
+      C:86/integer-unsigned-little, _/binary>> = crypto:hash(sha256, HashableBin),
     rand:seed_s(exs1024s, {A, B, C}).
 
 distance(L1, L1) ->

--- a/src/ledger/v1/blockchain_ledger_gateway_v2.erl
+++ b/src/ledger/v1/blockchain_ledger_gateway_v2.erl
@@ -404,7 +404,7 @@ witnesses(Gateway) ->
     Gateway#gateway_v2.witnesses.
 
 -spec witnesses(#{libp2p_crypto:pubkey_bin() => gateway_witness()}, gateway()) ->
-                       #{libp2p_crypto:pubkey_bin() => gateway_witness()}.
+                       gateway().
 witnesses(Witnesses, Gateway) ->
     Gateway#gateway_v2{witnesses = Witnesses}.
 

--- a/src/ledger/v1/blockchain_ledger_gateway_v2.erl
+++ b/src/ledger/v1/blockchain_ledger_gateway_v2.erl
@@ -26,7 +26,7 @@
     has_witness/2,
     clear_witnesses/1,
     remove_witness/2,
-    witnesses/1,
+    witnesses/1, witnesses/2,
     witness_hist/1, witness_recent_time/1, witness_first_time/1,
     oui/1, oui/2
 ]).
@@ -402,6 +402,11 @@ has_witness(#gateway_v2{witnesses=Witnesses}, WitnessAddr) ->
 -spec witnesses(gateway()) -> #{libp2p_crypto:pubkey_bin() => gateway_witness()}.
 witnesses(Gateway) ->
     Gateway#gateway_v2.witnesses.
+
+-spec witnesses(#{libp2p_crypto:pubkey_bin() => gateway_witness()}, gateway()) ->
+                       #{libp2p_crypto:pubkey_bin() => gateway_witness()}.
+witnesses(Witnesses, Gateway) ->
+    Gateway#gateway_v2{witnesses = Witnesses}.
 
 -spec witness_hist(gateway_witness()) -> erlang:error(no_histogram) | histogram().
 witness_hist(Witness) ->

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -1167,8 +1167,10 @@ add_gateway_witnesses(GatewayAddress, WitnessInfo, Ledger) ->
                           {ok, Height} = current_height(Ledger),
                           %% this doesn't need to be hard to predict, just random
                           RandState = blockchain_utils:rand_state(integer_to_binary(Height)),
-                          Witnesses1 = blockchain_utils:deterministic_subset(Limit, RandState, Witnesses),
-                          blockchain_ledger_gateway_v2:witnesses(Witnesses1, GW1);
+                          %% TODO this will need to change when 513 lands
+                          {_, Witnesses1} = blockchain_utils:deterministic_subset(Limit, RandState,
+                                                                                  maps:to_list(Witnesses)),
+                          blockchain_ledger_gateway_v2:witnesses(maps:from_list(Witnesses1), GW1);
                       _ -> GW1
                   end,
             update_gateway(GW2, GatewayAddress, Ledger)

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -725,7 +725,7 @@ validate_var(?poc_path_limit, Value) ->
 validate_var(?poc_witness_consideration_limit, Value) ->
     validate_int(Value, "poc_witness_consideration_limit", 10, 100, false);
 validate_var(?poc_witness_retention_limit, Value) ->
-    validate_int(Value, "poc_witness_consideration_limit", 10, 100, false);
+    validate_int(Value, "poc_witness_retention_limit", 10, 100, false);
 validate_var(?poc_v4_exclusion_cells, Value) ->
     validate_int(Value, "poc_v4_exclusion_cells", 8, 12, false);
 validate_var(?poc_v4_parent_res, Value) ->

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -724,6 +724,8 @@ validate_var(?poc_path_limit, Value) ->
     validate_int(Value, "poc_path_limit", 3, 10, false);
 validate_var(?poc_witness_consideration_limit, Value) ->
     validate_int(Value, "poc_witness_consideration_limit", 10, 100, false);
+validate_var(?poc_witness_retention_limit, Value) ->
+    validate_int(Value, "poc_witness_consideration_limit", 10, 100, false);
 validate_var(?poc_v4_exclusion_cells, Value) ->
     validate_int(Value, "poc_v4_exclusion_cells", 8, 12, false);
 validate_var(?poc_v4_parent_res, Value) ->


### PR DESCRIPTION
This PR establishes a chain var controlled limit on how many witnesses are allowed to be stored per gateway.  The limit is enforced by random selection of a subset of the witnesses.