### PR TITLE
DC overcommit and refund for state channels

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -288,6 +288,10 @@
 -define(sc_grace_blocks, sc_grace_blocks).
 %% DC Payload size, set to 24
 -define(dc_payload_size, dc_payload_size).
+%% state channel version
+-define(sc_version, sc_version).
+%% state channel overcommit multiplier
+-define(sc_overcommit, sc_overcommit).
 
 %% ------------------------------------------------------------------
 %% snapshot vars

--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -2072,7 +2072,7 @@ run_gc_hooks(Blockchain, Hash) ->
     try
         ok = blockchain_ledger_v1:maybe_gc_pocs(Blockchain, Ledger),
 
-        ok = blockchain_ledger_v1:maybe_gc_scs(Blockchain, Ledger),
+        ok = blockchain_ledger_v1:maybe_gc_scs(Blockchain),
 
         ok = blockchain_ledger_v1:maybe_recalc_price(Blockchain, Ledger),
 

--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -2072,7 +2072,7 @@ run_gc_hooks(Blockchain, Hash) ->
     try
         ok = blockchain_ledger_v1:maybe_gc_pocs(Blockchain, Ledger),
 
-        ok = blockchain_ledger_v1:maybe_gc_scs(Ledger),
+        ok = blockchain_ledger_v1:maybe_gc_scs(Blockchain, Ledger),
 
         ok = blockchain_ledger_v1:maybe_recalc_price(Blockchain, Ledger),
 

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -394,7 +394,7 @@ import(Chain, SHA,
                                       Hash = blockchain_block:hash_block(Block),
                                       ok = blockchain_ledger_v1:maybe_gc_pocs(Chain, Ledger2),
 
-                                      ok = blockchain_ledger_v1:maybe_gc_scs(Ledger2),
+                                      ok = blockchain_ledger_v1:maybe_gc_scs(Chain, Ledger2),
 
                                       ok = blockchain_ledger_v1:refresh_gateway_witnesses(Hash, Ledger2);
                                   _ ->

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -394,7 +394,7 @@ import(Chain, SHA,
                                       Hash = blockchain_block:hash_block(Block),
                                       ok = blockchain_ledger_v1:maybe_gc_pocs(Chain, Ledger2),
 
-                                      ok = blockchain_ledger_v1:maybe_gc_scs(Chain, Ledger2),
+                                      ok = blockchain_ledger_v1:maybe_gc_scs(Chain),
 
                                       ok = blockchain_ledger_v1:refresh_gateway_witnesses(Hash, Ledger2);
                                   _ ->

--- a/src/ledger/v1/blockchain_ledger_state_channel_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_state_channel_v1.erl
@@ -11,7 +11,8 @@
     owner/1, owner/2,
     nonce/1, nonce/2,
     expire_at_block/1, expire_at_block/2,
-    serialize/1, deserialize/1
+    serialize/1, deserialize/1,
+    is_v1/1
 ]).
 
 -ifdef(TEST).
@@ -73,6 +74,10 @@ nonce(#ledger_state_channel_v1{nonce=Nonce}) ->
 nonce(Nonce, SC) ->
     SC#ledger_state_channel_v1{nonce=Nonce}.
 
+-spec is_v1(state_channel()) -> boolean().
+is_v1(#ledger_state_channel_v1{}) -> true;
+is_v1(_) -> false.
+
 %%--------------------------------------------------------------------
 %% @doc
 %% Version 1
@@ -129,5 +134,10 @@ nonce_test() ->
     SC = new(<<"id">>, <<"owner">>, 10, 1),
     ?assertEqual(1, nonce(SC)),
     ?assertEqual(2, nonce(nonce(2, SC))).
+
+is_v1_test() ->
+    SC = new(<<"id">>, <<"owner">>, 10, 1),
+    ?assertEqual(true, is_v1(SC)),
+    ?assertEqual(false, is_v1(<<"not v1">>)).
 
 -endif.

--- a/src/ledger/v1/blockchain_ledger_state_channel_v2.erl
+++ b/src/ledger/v1/blockchain_ledger_state_channel_v2.erl
@@ -26,23 +26,23 @@
 -endif.
 
 -record(ledger_state_channel_v2, {
-    id :: binary(),
-    owner :: binary(),
+    id :: blockchain_state_channel_v1:id(),
+    owner :: libp2p_crypto:pubkey_bin(),
     expire_at_block :: pos_integer(),
     original :: non_neg_integer(),
     amount :: non_neg_integer(),
     nonce :: non_neg_integer(),
     closer :: libp2p_crypto:pubkey_bin(),
-    sc :: blockchain_state_channel_v1:state_channel(),
-    close_state :: closed | dispute
+    sc :: undefined | blockchain_state_channel_v1:state_channel(),
+    close_state :: closed | dispute | undefined
 }).
 
 -type state_channel_v2() :: #ledger_state_channel_v2{}.
 
 -export_type([state_channel_v2/0]).
 
--spec new(ID :: binary(),
-          Owner :: binary(),
+-spec new(ID :: blockchain_state_channel_v1:id(),
+          Owner :: libp2p_crypto:pubkey_bin(),
           ExpireAtBlock :: pos_integer(),
           OriginalAmtDC :: non_neg_integer(),
           TotalAmtDC :: non_neg_integer(),
@@ -57,19 +57,19 @@ new(ID, Owner, ExpireAtBlock, OriginalAmount, TotalAmount, Nonce) ->
        nonce=Nonce
       }.
 
--spec id(state_channel_v2()) -> binary().
+-spec id(state_channel_v2()) -> blockchain_state_channel_v1:id().
 id(#ledger_state_channel_v2{id=ID}) ->
     ID.
 
--spec id(ID :: binary(), SC :: state_channel_v2()) -> state_channel_v2().
+-spec id(ID :: blockchain_state_channel_v1:id(), SC :: state_channel_v2()) -> state_channel_v2().
 id(ID, SC) ->
     SC#ledger_state_channel_v2{id=ID}.
 
--spec owner(state_channel_v2()) -> binary().
+-spec owner(state_channel_v2()) -> libp2p_crypto:pubkey_bin().
 owner(#ledger_state_channel_v2{owner=Owner}) ->
     Owner.
 
--spec owner(Owner :: binary(), SC :: state_channel_v2()) -> state_channel_v2().
+-spec owner(Owner :: libp2p_crypto:pubkey_bin(), SC :: state_channel_v2()) -> state_channel_v2().
 owner(Owner, SC) ->
     SC#ledger_state_channel_v2{owner=Owner}.
 

--- a/src/ledger/v1/blockchain_ledger_state_channel_v2.erl
+++ b/src/ledger/v1/blockchain_ledger_state_channel_v2.erl
@@ -146,7 +146,7 @@ close_proposal(Closer, SC, SCEntry) ->
             %% already marked as dispute
             %% Check to see if the nonce is updated, if so replace
             CurrentNonce = blockchain_state_channel_v1:nonce(SC),
-            PreviousNonce = blockchain_state_channel_v1:none(state_channel(SCEntry)),
+            PreviousNonce = blockchain_state_channel_v1:nonce(state_channel(SCEntry)),
 
             case CurrentNonce > PreviousNonce andalso Closer == closer(SCEntry) of
                 true ->

--- a/src/ledger/v1/blockchain_ledger_state_channel_v2.erl
+++ b/src/ledger/v1/blockchain_ledger_state_channel_v2.erl
@@ -143,8 +143,17 @@ close_proposal(Closer, SC, SCEntry) ->
                     SCEntry#ledger_state_channel_v2{closer=NewCloser, sc=NewSC, close_state=dispute}
             end;
         dispute ->
-            %% already marked as dispute, just keep it that way
-            SCEntry
+            %% already marked as dispute
+            %% Check to see if the nonce is updated, if so replace
+            CurrentNonce = blockchain_state_channel_v1:nonce(SC),
+            PreviousNonce = blockchain_state_channel_v1:none(state_channel(SCEntry)),
+
+            case CurrentNonce > PreviousNonce andalso Closer == closer(SCEntry) of
+                true ->
+                    SCEntry#ledger_state_channel_v2{sc=SC};
+                false ->
+                    SCEntry
+            end
     end.
 
 closer(SC) ->

--- a/src/ledger/v1/blockchain_ledger_state_channel_v2.erl
+++ b/src/ledger/v1/blockchain_ledger_state_channel_v2.erl
@@ -1,0 +1,222 @@
+%%%-------------------------------------------------------------------
+%% @doc
+%% == Blockchain Ledger State Channel v2 ==
+%% @end
+%%%-------------------------------------------------------------------
+-module(blockchain_ledger_state_channel_v2).
+
+-export([
+    new/5,
+    id/1, id/2,
+    owner/1, owner/2,
+    nonce/1, nonce/2,
+    amount/1, amount/2,
+    expire_at_block/1, expire_at_block/2,
+    serialize/1, deserialize/1,
+    close_proposal/3,
+    closer/1,
+    state_channel/1,
+    close_state/1
+]).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-record(ledger_state_channel_v2, {
+    id :: binary(),
+    owner :: binary(),
+    expire_at_block :: pos_integer(),
+    amount :: non_neg_integer(),
+    nonce :: non_neg_integer(),
+    closer :: libp2p_crypto:pubkey_bin(),
+    sc :: blockchain_state_channel_v1:state_channel(),
+    close_state :: closed | dispute
+}).
+
+-type state_channel_v2() :: #ledger_state_channel_v2{}.
+
+-export_type([state_channel_v2/0]).
+
+-spec new(ID :: binary(),
+          Owner :: binary(),
+          ExpireAtBlock :: pos_integer(),
+          Amount :: non_neg_integer(),
+          Nonce :: non_neg_integer()) -> state_channel_v2().
+new(ID, Owner, ExpireAtBlock, Amount, Nonce) ->
+    #ledger_state_channel_v2{
+       id=ID,
+       owner=Owner,
+       expire_at_block=ExpireAtBlock,
+       amount=Amount,
+       nonce=Nonce
+      }.
+
+-spec id(state_channel_v2()) -> binary().
+id(#ledger_state_channel_v2{id=ID}) ->
+    ID.
+
+-spec id(ID :: binary(), SC :: state_channel_v2()) -> state_channel_v2().
+id(ID, SC) ->
+    SC#ledger_state_channel_v2{id=ID}.
+
+-spec owner(state_channel_v2()) -> binary().
+owner(#ledger_state_channel_v2{owner=Owner}) ->
+    Owner.
+
+-spec owner(Owner :: binary(), SC :: state_channel_v2()) -> state_channel_v2().
+owner(Owner, SC) ->
+    SC#ledger_state_channel_v2{owner=Owner}.
+
+-spec expire_at_block(state_channel_v2()) -> pos_integer().
+expire_at_block(#ledger_state_channel_v2{expire_at_block=ExpireAtBlock}) ->
+    ExpireAtBlock.
+
+-spec expire_at_block(ExpireAtBlock :: pos_integer(), SC :: state_channel_v2()) -> state_channel_v2().
+expire_at_block(ExpireAtBlock, SC) ->
+    SC#ledger_state_channel_v2{expire_at_block=ExpireAtBlock}.
+
+-spec nonce(state_channel_v2()) -> non_neg_integer().
+nonce(#ledger_state_channel_v2{nonce=Nonce}) ->
+    Nonce.
+
+-spec nonce(Nonce :: non_neg_integer(), SC :: state_channel_v2()) -> state_channel_v2().
+nonce(Nonce, SC) ->
+    SC#ledger_state_channel_v2{nonce=Nonce}.
+
+-spec amount(state_channel_v2()) -> non_neg_integer().
+amount(#ledger_state_channel_v2{amount=Amount}) ->
+    Amount.
+
+-spec amount(Amount :: non_neg_integer(), SC :: state_channel_v2()) -> state_channel_v2().
+amount(Amount, SC) ->
+    SC#ledger_state_channel_v2{amount=Amount}.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Version 2
+%% @end
+%%--------------------------------------------------------------------
+-spec serialize(state_channel_v2()) -> binary().
+serialize(SC) ->
+    BinSC = erlang:term_to_binary(SC, [compressed]),
+    <<2, BinSC/binary>>.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Deserialize for v2
+%% @end
+%%--------------------------------------------------------------------
+-spec deserialize(binary()) -> state_channel_v2().
+deserialize(<<2, Bin/binary>>) ->
+    erlang:binary_to_term(Bin).
+
+-spec close_proposal( Closer :: libp2p_crypto:pubkey_bin(),
+                      StateChannel :: blockchain_state_channel_v1:state_channel(),
+                      SCEntry :: state_channel_v2() ) -> state_channel_v2().
+close_proposal(Closer, SC, SCEntry) ->
+    case close_state(SCEntry) of
+        undefined ->
+            %% we've never gotten a close request for this before, so...
+            SCEntry#ledger_state_channel_v2{closer=Closer, sc=SC, close_state=closed};
+        closed ->
+            %% ok so we've already marked this entry as closed... maybe we should
+            %% dispute it
+            case maybe_dispute(Closer, closer(SCEntry), SC, state_channel(SCEntry)) of
+                closed ->
+                    SCEntry#ledger_state_channel_v2{closer=Closer, sc=SC, close_state=closed};
+                {dispute, NewCloser, NewSC} ->
+                    %% store the "latest" (as judged by nonce)
+                    SCEntry#ledger_state_channel_v2{closer=NewCloser, sc=NewSC, close_state=dispute}
+            end;
+        dispute ->
+            %% already marked as dispute, just keep it that way
+            SCEntry
+    end.
+
+closer(SC) ->
+    SC#ledger_state_channel_v2.closer.
+
+state_channel(SC) ->
+    SC#ledger_state_channel_v2.sc.
+
+close_state(SC) ->
+    SC#ledger_state_channel_v2.close_state.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+maybe_dispute(Closer, Closer, SC, SC) -> closed;
+maybe_dispute(Closer, Closer, CurrentSC, PreviousSC) ->
+    CurrentNonce = blockchain_state_channel_v1:nonce(CurrentSC),
+    PreviousNonce = blockchain_state_channel_v1:nonce(PreviousSC),
+    if
+        CurrentNonce > PreviousNonce -> closed;
+        CurrentNonce < PreviousNonce -> {dispute, Closer, PreviousSC};
+        true -> closed
+    end;
+%% this could happen when some other actor sends a close that arrives
+%% late and has a more recent view of the state channel than the one we
+%% have in our ledger.
+maybe_dispute(_Closer, Other, CurrentSC, PreviousSC) ->
+    CurrentNonce = blockchain_state_channel_v1:nonce(CurrentSC),
+    PreviousNonce = blockchain_state_channel_v1:nonce(PreviousSC),
+    if
+        CurrentNonce > PreviousNonce -> {dispute, Other, CurrentSC};
+        CurrentNonce < PreviousNonce -> closed;
+        true -> closed
+    end.
+
+%% ------------------------------------------------------------------
+%% EUNIT Tests
+%% ------------------------------------------------------------------
+-ifdef(TEST).
+
+new_test() ->
+    SC = #ledger_state_channel_v2{
+        id = <<"id">>,
+        owner = <<"owner">>,
+        expire_at_block = 10,
+        amount = 10,
+        nonce = 1
+    },
+    ?assertEqual(SC, new(<<"id">>, <<"owner">>, 10, 10, 1)).
+
+id_test() ->
+    SC = new(<<"id">>, <<"owner">>, 10, 10, 1),
+    ?assertEqual(<<"id">>, id(SC)),
+    ?assertEqual(<<"id2">>, id(id(<<"id2">>, SC))).
+
+owner_test() ->
+    SC = new(<<"id">>, <<"owner">>, 10, 10, 1),
+    ?assertEqual(<<"owner">>, owner(SC)),
+    ?assertEqual(<<"owner2">>, owner(owner(<<"owner2">>, SC))).
+
+expire_at_block_test() ->
+    SC = new(<<"id">>, <<"owner">>, 10, 10, 1),
+    ?assertEqual(10, expire_at_block(SC)),
+    ?assertEqual(20, expire_at_block(expire_at_block(20, SC))).
+
+nonce_test() ->
+    SC = new(<<"id">>, <<"owner">>, 10, 10, 1),
+    ?assertEqual(1, nonce(SC)),
+    ?assertEqual(2, nonce(nonce(2, SC))).
+
+amount_test() ->
+    SC = new(<<"id">>, <<"owner">>, 10, 10, 1),
+    ?assertEqual(10, amount(SC)),
+    ?assertEqual(20, amount(amount(20, SC))).
+
+maybe_dispute_test() ->
+    SC0 = blockchain_state_channel_v1:new(<<"id1">>, <<"key1">>, 100),
+    SC1 = blockchain_state_channel_v1:new(<<"id2">>, <<"key2">>, 200),
+    Nonce4 = blockchain_state_channel_v1:nonce(4, SC0),
+    Nonce8 = blockchain_state_channel_v1:nonce(8, SC1),
+    Closer = <<"closer">>,
+    ?assertEqual(closed, maybe_dispute(Closer, Closer, SC0, SC0)),
+    ?assertEqual(closed, maybe_dispute(Closer, Closer, Nonce8, Nonce4)),
+    ?assertEqual({dispute, Closer, Nonce8}, maybe_dispute(Closer, Closer, Nonce4, Nonce8)),
+    ?assertEqual(closed, maybe_dispute(Closer, <<"other">>, Nonce4, Nonce8)),
+    ?assertEqual({dispute, <<"other">>, Nonce8}, maybe_dispute(Closer, <<"other">>, Nonce8, Nonce4)).
+
+-endif.

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -88,7 +88,7 @@
     update_routing/4,
 
     find_state_channel/3, find_sc_ids_by_owner/2, find_scs_by_owner/2,
-    add_state_channel/6,
+    add_state_channel/7,
     close_state_channel/5,
 
     allocate_subnet/2,
@@ -541,6 +541,9 @@ raw_fingerprint(#ledger_v1{mode = Mode} = Ledger, Extended) ->
             [cache_fold(Ledger, CF,
                         fun({K, V}, Acc) when Mod == t2b ->
                                 [{K, erlang:binary_to_term(V)} | Acc];
+                           ({K, V}, Acc) when Mod == state_channel ->
+                                {_Mod, SC} = deserialize_state_channel(V),
+                                [{K, SC} | Acc];
                            ({K, V}, Acc) when Mod /= undefined ->
                                 [{K, Mod:deserialize(V)} | Acc];
                            (X, Acc) -> [X | Acc]
@@ -554,7 +557,7 @@ raw_fingerprint(#ledger_v1{mode = Mode} = Ledger, Extended) ->
                      {PoCsCF, t2b},
                      {SecuritiesCF, blockchain_ledger_security_entry_v1},
                      {RoutingCF, blockchain_ledger_routing_v1},
-                     {SCsCF, get_sc_mod(Ledger)}, % depends on chain var
+                     {SCsCF, state_channel},
                      {SubnetsCF, undefined}
                     ]],
         L = lists:append(L0, DefaultVals),
@@ -2273,9 +2276,10 @@ find_scs_by_owner(Owner, Ledger) ->
                         Owner :: libp2p_crypto:pubkey_bin(),
                         ExpireWithin :: pos_integer(),
                         Nonce :: non_neg_integer(),
+                        Original :: non_neg_integer(),
                         Amount :: non_neg_integer(),
                         Ledger :: ledger()) -> ok | {error, any()}.
-add_state_channel(ID, Owner, ExpireWithin, Nonce, Amount, Ledger) ->
+add_state_channel(ID, Owner, ExpireWithin, Nonce, Original, Amount, Ledger) ->
     SCsCF = state_channels_cf(Ledger),
     {ok, CurrHeight} = ?MODULE:current_height(Ledger),
     Key = state_channel_key(ID, Owner),
@@ -2283,8 +2287,8 @@ add_state_channel(ID, Owner, ExpireWithin, Nonce, Amount, Ledger) ->
         {ok, 2} ->
             Routing = blockchain_ledger_state_channel_v2:new(ID, Owner,
                                                              CurrHeight+ExpireWithin,
-                                                             Amount, Nonce),
-            blockchain_ledger_state_channel_v1:serialize(Routing);
+                                                             Original, Amount, Nonce),
+            blockchain_ledger_state_channel_v2:serialize(Routing);
         _ ->
             Routing = blockchain_ledger_state_channel_v1:new(ID, Owner,
                                                              CurrHeight+ExpireWithin, Nonce),
@@ -3103,7 +3107,7 @@ load_state_channels(SCs, Ledger) ->
     SCsCF = state_channels_cf(Ledger),
     maps:map(
       fun(ID, Channel) ->
-              SCMod = get_sc_mod(Ledger),
+              SCMod = get_sc_mod(Channel, Ledger),
               BChannel = SCMod:serialize(Channel),
               cache_put(Ledger, SCsCF, ID, BChannel)
       end,
@@ -3140,9 +3144,13 @@ load_hexes(Hexes0, Ledger) ->
             ok
     end.
 
-get_sc_mod(Ledger) ->
+get_sc_mod(Channel, Ledger) ->
     case ?MODULE:config(?sc_version, Ledger) of
-        {ok, 2} -> blockchain_ledger_state_channel_v2;
+        {ok, 2} ->
+            case blockchain_ledger_state_channel_v2:is_v2(Channel) of
+                true -> blockchain_ledger_state_channel_v2;
+                false -> blockchain_ledger_state_channel_v1
+            end;
         _ -> blockchain_ledger_state_channel_v1
     end.
 

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -55,7 +55,7 @@
     request_poc/5,
     delete_poc/3, delete_pocs/2,
     maybe_gc_pocs/2,
-    maybe_gc_scs/2,
+    maybe_gc_scs/1,
 
     find_entry/2,
     credit_account/3, debit_account/4, debit_fee_from_account/3,
@@ -1420,7 +1420,8 @@ filtered_gateways_to_refresh(Hash, RefreshInterval, GatewayOffsets, RandN) ->
                  end,
                  GatewayOffsets).
 
-maybe_gc_scs(Chain, Ledger) ->
+maybe_gc_scs(Chain) ->
+    Ledger = blockchain:ledger(Chain),
     {ok, Height} = current_height(Ledger),
     {ok, Block} = blockchain:get_block(Height, Chain),
     {_Epoch, EpochStart} = blockchain_block_v1:election_info(Block),

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -88,8 +88,8 @@
     update_routing/4,
 
     find_state_channel/3, find_sc_ids_by_owner/2, find_scs_by_owner/2,
-    add_state_channel/5,
-    delete_state_channel/3,
+    add_state_channel/6,
+    close_state_channel/5,
 
     allocate_subnet/2,
 
@@ -222,7 +222,9 @@
 -type securities() :: #{libp2p_crypto:pubkey_bin() => blockchain_ledger_security_entry_v1:entry()}.
 -type hexmap() :: #{h3:h3_index() => non_neg_integer()}.
 -type gateway_offsets() :: [{pos_integer(), libp2p_crypto:pubkey_bin()}].
--type state_channel_map() ::  #{blockchain_state_channel_v1:id() => blockchain_ledger_state_channel_v1:state_channel()}.
+-type state_channel_map() ::  #{blockchain_state_channel_v1:id() =>
+                                    blockchain_ledger_state_channel_v1:state_channel()
+                                    | blockchain_ledger_state_channel_v2:state_channel_v2()}.
 
 -export_type([ledger/0]).
 
@@ -552,7 +554,7 @@ raw_fingerprint(#ledger_v1{mode = Mode} = Ledger, Extended) ->
                      {PoCsCF, t2b},
                      {SecuritiesCF, blockchain_ledger_security_entry_v1},
                      {RoutingCF, blockchain_ledger_routing_v1},
-                     {SCsCF, blockchain_ledger_state_channel_v1},
+                     {SCsCF, get_sc_mod(Ledger)}, % depends on chain var
                      {SubnetsCF, undefined}
                     ]],
         L = lists:append(L0, DefaultVals),
@@ -1428,13 +1430,27 @@ maybe_gc_scs(Ledger) ->
                                Ledger,
                                SCsCF,
                                fun({KeyHash, BinSC}, Acc) ->
-                                       SC = blockchain_ledger_state_channel_v1:deserialize(BinSC),
-                                       ExpireAtBlock = blockchain_ledger_state_channel_v1:expire_at_block(SC),
+                                       {Mod, SC} = deserialize_state_channel(BinSC),
+                                       ExpireAtBlock = Mod:expire_at_block(SC),
                                        case (ExpireAtBlock + Grace) < Height of
                                            false ->
                                                Acc;
                                            true ->
-                                               [KeyHash | Acc]
+                                               case Mod of
+                                                   blockchain_ledger_state_channel_v1 ->
+                                                       [KeyHash | Acc];
+                                                   blockchain_ledger_state_channel_v2 ->
+                                                       case blockchain_ledger_state_channel_v2:close_state(SC) of
+                                                           undefined -> [KeyHash | Acc]; %% due to tests must handle
+                                                           dispute -> [KeyHash | Acc]; %% confiscate overcommit
+                                                           closed ->
+                                                               SC0 = blockchain_ledger_state_channel_v2:state_channel(SC),
+                                                               Owner = blockchain_state_channel_v1:owner(SC0),
+                                                               Credit = calc_remaining_dcs(SC0),
+                                                               ok = credit_dc(Owner, Credit, Ledger),
+                                                               [KeyHash | Acc]
+                                                       end
+                                               end
                                        end
                                end, []),
                     ok = lists:foreach(fun(KeyHash) ->
@@ -1448,6 +1464,12 @@ maybe_gc_scs(Ledger) ->
         _ ->
             ok
     end.
+
+calc_remaining_dcs(SC) ->
+    UsedDC = blockchain_state_channel_v1:total_dcs(SC),
+    ReservedDC = blockchain_state_channel_v1:amount(SC),
+    max(0, ReservedDC - UsedDC).
+
 
 %%--------------------------------------------------------------------
 %% @doc  get staking server keys from chain var
@@ -2200,13 +2222,17 @@ update_routing(OUI, Action, Nonce, Ledger) ->
 
 -spec find_state_channel(ID :: binary(),
                          Owner :: libp2p_crypto:pubkey_bin(),
-                         Ledger :: ledger()) -> {ok, blockchain_ledger_state_channel_v1:state_channel()} | {error, any()}.
+                         Ledger :: ledger()) ->
+    {ok, blockchain_ledger_state_channel_v1:state_channel()}
+    | {ok, blockchain_ledger_state_channel_v2:state_channel()}
+    | {error, any()}.
 find_state_channel(ID, Owner, Ledger) ->
     SCsCF = state_channels_cf(Ledger),
     Key = state_channel_key(ID, Owner),
     case cache_get(Ledger, SCsCF, Key, []) of
         {ok, BinEntry} ->
-            {ok, blockchain_ledger_state_channel_v1:deserialize(BinEntry)};
+            {_Mod, SC} = deserialize_state_channel(BinEntry),
+            {ok, SC};
         not_found ->
             {error, not_found};
         Error ->
@@ -2237,30 +2263,54 @@ find_scs_by_owner(Owner, Ledger) ->
     {ok, cache_fold(Ledger, SCsCF,
                fun({K, V}, Acc) when erlang:binary_part(K, {0, OwnerLength}) == Owner ->
                        ID = binary:part(K, OwnerLength, byte_size(K) - OwnerLength),
-                       maps:put(ID, blockchain_ledger_state_channel_v1:deserialize(V), Acc);
+                       {_Mod, SC} = deserialize_state_channel(V),
+                       maps:put(ID, SC, Acc);
                   (_, Acc) ->
                        Acc
                end, #{}, [{start, Owner}, {iterate_upper_bound, increment_bin(Owner)}])}.
-
 
 -spec add_state_channel(ID :: binary(),
                         Owner :: libp2p_crypto:pubkey_bin(),
                         ExpireWithin :: pos_integer(),
                         Nonce :: non_neg_integer(),
+                        Amount :: non_neg_integer(),
                         Ledger :: ledger()) -> ok | {error, any()}.
-add_state_channel(ID, Owner, ExpireWithin, Nonce, Ledger) ->
+add_state_channel(ID, Owner, ExpireWithin, Nonce, Amount, Ledger) ->
     SCsCF = state_channels_cf(Ledger),
     {ok, CurrHeight} = ?MODULE:current_height(Ledger),
-    Routing = blockchain_ledger_state_channel_v1:new(ID, Owner, CurrHeight+ExpireWithin, Nonce),
-    Bin = blockchain_ledger_state_channel_v1:serialize(Routing),
     Key = state_channel_key(ID, Owner),
+    Bin = case ?MODULE:config(?sc_version, Ledger) of
+        {ok, 2} ->
+            Routing = blockchain_ledger_state_channel_v2:new(ID, Owner,
+                                                             CurrHeight+ExpireWithin,
+                                                             Amount, Nonce),
+            blockchain_ledger_state_channel_v1:serialize(Routing);
+        _ ->
+            Routing = blockchain_ledger_state_channel_v1:new(ID, Owner,
+                                                             CurrHeight+ExpireWithin, Nonce),
+            blockchain_ledger_state_channel_v1:serialize(Routing)
+          end,
     cache_put(Ledger, SCsCF, Key, Bin).
 
--spec delete_state_channel(binary(), libp2p_crypto:pubkey_bin(), ledger()) -> ok.
-delete_state_channel(ID, Owner, Ledger) ->
+close_state_channel(Owner, Closer, SC, SCID, Ledger) ->
     SCsCF = state_channels_cf(Ledger),
-    Key = state_channel_key(ID, Owner),
-    cache_delete(Ledger, SCsCF, Key).
+    Key = state_channel_key(SCID, Owner),
+    case ?MODULE:config(?sc_version, Ledger) of
+        {ok, 2} ->
+            %% DC overcommits are returned during SC garbage collection
+            %% because it's possible another actor might submit a
+            %% SC close txn with an updated nonce/state
+            %%
+            %% The internal close state of a SC would then be updated
+            %% by the `close_proposal' function. So we just record
+            %% it here and deal with overcommit during GC.
+            {ok, PrevSCE} = find_state_channel(SCID, Owner, Ledger),
+            NewSCE = blockchain_ledger_state_channel_v2:close_proposal(Closer, SC, PrevSCE),
+            Bin = blockchain_ledger_state_channel_v2:serialize(NewSCE),
+            cache_put(Ledger, SCsCF, Key, Bin);
+        _ ->
+            cache_delete(Ledger, SCsCF, Key)
+    end.
 
 -spec allocate_subnet(pos_integer(), ledger()) -> {ok, <<_:48>>} | {error, any()}.
 allocate_subnet(Size, Ledger=#ledger_v1{db=DB}) ->
@@ -3044,7 +3094,8 @@ snapshot_state_channels(Ledger) ->
           Ledger, SCsCF,
           fun({ID, V}, Acc) ->
                   %% do we need to decompose the ID here into Key and Owner?
-                  maps:put(ID, blockchain_ledger_state_channel_v1:deserialize(V), Acc)
+                  {_Mod, SC} = deserialize_state_channel(V),
+                  maps:put(ID, SC, Acc)
           end, #{},
           []))).
 
@@ -3052,7 +3103,8 @@ load_state_channels(SCs, Ledger) ->
     SCsCF = state_channels_cf(Ledger),
     maps:map(
       fun(ID, Channel) ->
-              BChannel = blockchain_ledger_state_channel_v1:serialize(Channel),
+              SCMod = get_sc_mod(Ledger),
+              BChannel = SCMod:serialize(Channel),
               cache_put(Ledger, SCsCF, ID, BChannel)
       end,
       maps:from_list(SCs)),
@@ -3087,6 +3139,17 @@ load_hexes(Hexes0, Ledger) ->
         error ->
             ok
     end.
+
+get_sc_mod(Ledger) ->
+    case ?MODULE:config(?sc_version, Ledger) of
+        {ok, 2} -> blockchain_ledger_state_channel_v2;
+        _ -> blockchain_ledger_state_channel_v1
+    end.
+
+deserialize_state_channel(<<1, SC/binary>>) ->
+    {blockchain_ledger_state_channel_v1, blockchain_ledger_state_channel_v1:deserialize(SC)};
+deserialize_state_channel(<<2, SC/binary>>) ->
+    {blockchain_ledger_state_channel_v2, blockchain_ledger_state_channel_v2:deserialize(SC)}.
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests
@@ -3492,7 +3555,7 @@ state_channels_test() ->
     ?assertEqual({ok, []}, find_sc_ids_by_owner(Owner, Ledger1)),
 
     Ledger2 = new_context(Ledger),
-    ok = add_state_channel(ID, Owner, 10, Nonce, Ledger2),
+    ok = add_state_channel(ID, Owner, 10, Nonce, 0, Ledger2),
     ok = commit_context(Ledger2),
     {ok, SC} = find_state_channel(ID, Owner, Ledger),
     ?assertEqual(ID, blockchain_ledger_state_channel_v1:id(SC)),
@@ -3501,12 +3564,48 @@ state_channels_test() ->
     ?assertEqual({ok, [ID]}, find_sc_ids_by_owner(Owner, Ledger)),
 
     Ledger3 = new_context(Ledger),
-    ok = delete_state_channel(ID, Owner, Ledger3),
+    ok = close_state_channel(Owner, Owner, SC, ID, Ledger3),
     ok = commit_context(Ledger3),
     ?assertEqual({error, not_found}, find_state_channel(ID, Owner, Ledger)),
     ?assertEqual({ok, []}, find_sc_ids_by_owner(Owner, Ledger)),
 
     ok.
+
+state_channels_v2_test() ->
+    meck:new(?MODULE, [passthrough]),
+    meck:expect(?MODULE, config, fun(?sc_version, _Ledger) -> {ok, 2} end),
+
+    BaseDir = test_utils:tmp_dir("state_channels_test_v2"),
+    Ledger = new(BaseDir),
+    Ledger1 = new_context(Ledger),
+    ID = crypto:strong_rand_bytes(32),
+    Owner = <<"owner">>,
+    Nonce = 1,
+    Amount = 100,
+
+    ?assertEqual({error, not_found}, find_state_channel(ID, Owner, Ledger1)),
+    ?assertEqual({ok, []}, find_sc_ids_by_owner(Owner, Ledger1)),
+
+    Ledger2 = new_context(Ledger),
+    ok = add_state_channel(ID, Owner, 10, Nonce, Amount, Ledger2),
+    ok = commit_context(Ledger2),
+    {ok, SC} = find_state_channel(ID, Owner, Ledger),
+    ?assertEqual(ID, blockchain_ledger_state_channel_v2:id(SC)),
+    ?assertEqual(Owner, blockchain_ledger_state_channel_v2:owner(SC)),
+    ?assertEqual(Nonce, blockchain_ledger_state_channel_v2:nonce(SC)),
+    ?assertEqual(Amount, blockchain_ledger_state_channel_v2:amount(SC)),
+    ?assertEqual({ok, [ID]}, find_sc_ids_by_owner(Owner, Ledger)),
+
+    Ledger3 = new_context(Ledger),
+    ok = close_state_channel(ID, Owner, Owner, Ledger3),
+    ok = commit_context(Ledger3),
+    {ok, SC0} = find_state_channel(ID, Owner, Ledger),
+    ?assertEqual(closed, blockchain_ledger_state_channel_v2:close_state(SC0)),
+
+    meck:unload(?MODULE),
+
+    ok.
+
 
 increment_bin_test() ->
     ?assertEqual(<<2>>, increment_bin(<<1>>)),
@@ -3529,8 +3628,8 @@ find_scs_by_owner_test() ->
 
     Ledger2 = new_context(Ledger),
     %% Add two state channels for this owner
-    ok = add_state_channel(ID1, Owner, 10, Nonce, Ledger2),
-    ok = add_state_channel(ID2, Owner, 10, Nonce, Ledger2),
+    ok = add_state_channel(ID1, Owner, 10, Nonce, 0, Ledger2),
+    ok = add_state_channel(ID2, Owner, 10, Nonce, 0, Ledger2),
     ok = commit_context(Ledger2),
 
     {ok, FoundIDs} = find_sc_ids_by_owner(Owner, Ledger),

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -3154,9 +3154,9 @@ get_sc_mod(Channel, Ledger) ->
         _ -> blockchain_ledger_state_channel_v1
     end.
 
-deserialize_state_channel(<<1, SC/binary>>) ->
+deserialize_state_channel(<<1, _/binary>> = SC) ->
     {blockchain_ledger_state_channel_v1, blockchain_ledger_state_channel_v1:deserialize(SC)};
-deserialize_state_channel(<<2, SC/binary>>) ->
+deserialize_state_channel(<<2, _/binary>> = SC) ->
     {blockchain_ledger_state_channel_v2, blockchain_ledger_state_channel_v2:deserialize(SC)}.
 
 %% ------------------------------------------------------------------
@@ -3563,7 +3563,7 @@ state_channels_test() ->
     ?assertEqual({ok, []}, find_sc_ids_by_owner(Owner, Ledger1)),
 
     Ledger2 = new_context(Ledger),
-    ok = add_state_channel(ID, Owner, 10, Nonce, 0, Ledger2),
+    ok = add_state_channel(ID, Owner, 10, Nonce, 0, 0, Ledger2),
     ok = commit_context(Ledger2),
     {ok, SC} = find_state_channel(ID, Owner, Ledger),
     ?assertEqual(ID, blockchain_ledger_state_channel_v1:id(SC)),
@@ -3595,7 +3595,7 @@ state_channels_v2_test() ->
     ?assertEqual({ok, []}, find_sc_ids_by_owner(Owner, Ledger1)),
 
     Ledger2 = new_context(Ledger),
-    ok = add_state_channel(ID, Owner, 10, Nonce, Amount, Ledger2),
+    ok = add_state_channel(ID, Owner, 10, Nonce, Amount, 50, Ledger2),
     ok = commit_context(Ledger2),
     {ok, SC} = find_state_channel(ID, Owner, Ledger),
     ?assertEqual(ID, blockchain_ledger_state_channel_v2:id(SC)),
@@ -3605,7 +3605,7 @@ state_channels_v2_test() ->
     ?assertEqual({ok, [ID]}, find_sc_ids_by_owner(Owner, Ledger)),
 
     Ledger3 = new_context(Ledger),
-    ok = close_state_channel(ID, Owner, Owner, Ledger3),
+    ok = close_state_channel(ID, Owner, Owner, ID, Ledger3),
     ok = commit_context(Ledger3),
     {ok, SC0} = find_state_channel(ID, Owner, Ledger),
     ?assertEqual(closed, blockchain_ledger_state_channel_v2:close_state(SC0)),
@@ -3636,8 +3636,8 @@ find_scs_by_owner_test() ->
 
     Ledger2 = new_context(Ledger),
     %% Add two state channels for this owner
-    ok = add_state_channel(ID1, Owner, 10, Nonce, 0, Ledger2),
-    ok = add_state_channel(ID2, Owner, 10, Nonce, 0, Ledger2),
+    ok = add_state_channel(ID1, Owner, 10, Nonce, 0, 0, Ledger2),
+    ok = add_state_channel(ID2, Owner, 10, Nonce, 0, 0, Ledger2),
     ok = commit_context(Ledger2),
 
     {ok, FoundIDs} = find_sc_ids_by_owner(Owner, Ledger),

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -2303,6 +2303,11 @@ add_state_channel(ID, Owner, ExpireWithin, Nonce, Original, Amount, Ledger) ->
           end,
     cache_put(Ledger, SCsCF, Key, Bin).
 
+-spec close_state_channel(Owner :: libp2p_crypto:pubkey_bin(),
+                          Closer :: libp2p_crypto:pubkey_bin(),
+                          SC :: blockchain_state_channel_v1:state_channel(),
+                          SCID :: blockchain_state_channel_v1:id(),
+                          Ledger :: ledger()) -> ok.
 close_state_channel(Owner, Closer, SC, SCID, Ledger) ->
     SCsCF = state_channels_cf(Ledger),
     Key = state_channel_key(SCID, Owner),
@@ -3602,7 +3607,11 @@ state_channels_v2_test() ->
     ?assertEqual({ok, []}, find_sc_ids_by_owner(Owner, Ledger1)),
 
     Ledger2 = new_context(Ledger),
+<<<<<<< HEAD
     ok = add_state_channel(ID, Owner, 10, Nonce, Amount, 50, Ledger2),
+=======
+    ok = add_state_channel(ID, Owner, 10, Nonce, Amount, Amount, Ledger2),
+>>>>>>> 8e9ebb5... WIP for Data Credit rewards
     ok = commit_context(Ledger2),
     {ok, SC} = find_state_channel(ID, Owner, Ledger),
     ?assertEqual(ID, blockchain_ledger_state_channel_v2:id(SC)),
@@ -3612,7 +3621,11 @@ state_channels_v2_test() ->
     ?assertEqual({ok, [ID]}, find_sc_ids_by_owner(Owner, Ledger)),
 
     Ledger3 = new_context(Ledger),
+<<<<<<< HEAD
     ok = close_state_channel(ID, Owner, Owner, ID, Ledger3),
+=======
+    ok = close_state_channel(Owner, Owner, SC, ID, Ledger3),
+>>>>>>> 8e9ebb5... WIP for Data Credit rewards
     ok = commit_context(Ledger3),
     {ok, SC0} = find_state_channel(ID, Owner, Ledger),
     ?assertEqual(closed, blockchain_ledger_state_channel_v2:close_state(SC0)),

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -55,7 +55,7 @@
     request_poc/5,
     delete_poc/3, delete_pocs/2,
     maybe_gc_pocs/2,
-    maybe_gc_scs/1,
+    maybe_gc_scs/2,
 
     find_entry/2,
     credit_account/3, debit_account/4, debit_fee_from_account/3,
@@ -1420,8 +1420,10 @@ filtered_gateways_to_refresh(Hash, RefreshInterval, GatewayOffsets, RandN) ->
                  end,
                  GatewayOffsets).
 
-maybe_gc_scs(Ledger) ->
+maybe_gc_scs(Chain, Ledger) ->
     {ok, Height} = current_height(Ledger),
+    {ok, Block} = blockchain:get_block(Height, Chain),
+    {_Epoch, EpochStart} = blockchain_block_v1:election_info(Block),
 
     case ?MODULE:config(?sc_grace_blocks, Ledger) of
         {ok, Grace} ->
@@ -1443,15 +1445,19 @@ maybe_gc_scs(Ledger) ->
                                                    blockchain_ledger_state_channel_v1 ->
                                                        [KeyHash | Acc];
                                                    blockchain_ledger_state_channel_v2 ->
-                                                       case blockchain_ledger_state_channel_v2:close_state(SC) of
-                                                           undefined -> [KeyHash | Acc]; %% due to tests must handle
-                                                           dispute -> [KeyHash | Acc]; %% confiscate overcommit
-                                                           closed ->
-                                                               SC0 = blockchain_ledger_state_channel_v2:state_channel(SC),
-                                                               Owner = blockchain_state_channel_v1:owner(SC0),
-                                                               Credit = calc_remaining_dcs(SC0),
-                                                               ok = credit_dc(Owner, Credit, Ledger),
-                                                               [KeyHash | Acc]
+                                                       case (ExpireAtBlock + Grace) < EpochStart of
+                                                           false -> Acc; %% we do not want to gc until rewards have been calculated and distributed
+                                                           true ->
+                                                               case blockchain_ledger_state_channel_v2:close_state(SC) of
+                                                                   undefined -> [KeyHash | Acc]; %% due to tests must handle
+                                                                   dispute -> [KeyHash | Acc];
+                                                                   closed -> %% refund overcommit DCs
+                                                                       SC0 = blockchain_ledger_state_channel_v2:state_channel(SC),
+                                                                       Owner = blockchain_state_channel_v1:owner(SC0),
+                                                                       Credit = calc_remaining_dcs(SC0),
+                                                                       ok = credit_dc(Owner, Credit, Ledger),
+                                                                       [KeyHash | Acc]
+                                                               end
                                                        end
                                                end
                                        end

--- a/src/state_channel/blockchain_state_channels_server.erl
+++ b/src/state_channel/blockchain_state_channels_server.erl
@@ -31,6 +31,7 @@
 ]).
 
 -include("blockchain.hrl").
+-include("blockchain_vars.hrl").
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -375,7 +376,11 @@ get_state_channels_txns_from_block(Chain, BlockHash, #state{state_channels=SCs, 
                  State :: state()) -> state().
 load_state(Ledger, #state{db=DB, owner={Owner, _}, chain=Chain}=State) ->
     {ok, SCMap} = blockchain_ledger_v1:find_scs_by_owner(Owner, Ledger),
-    ConvertedSCs = convert_to_state_channels(SCMap, Chain),
+    SCMod = case blockchain_ledger_v1:config(?sc_version, Ledger) of
+                {ok, 2} -> blockchain_ledger_state_channel_v2;
+                _ -> blockchain_ledger_state_channel_v1
+            end,
+    ConvertedSCs = convert_to_state_channels(SCMap, SCMod, Chain),
 
     DBSCs = case get_state_channels(DB) of
                 {error, _} ->
@@ -456,14 +461,19 @@ delete_closed_sc(DB, ID) ->
             end
     end.
 
--spec convert_to_state_channels(blockchain_ledger_v1:state_channel_map(), blockchain:blockchain()) -> state_channels().
-convert_to_state_channels(LedgerSCs, Chain) ->
+-spec convert_to_state_channels(blockchain_ledger_v1:state_channel_map(), atom(), blockchain:blockchain()) -> state_channels().
+convert_to_state_channels(LedgerSCs, SCMod, Chain) ->
     {ok, Head} = blockchain:head_block(Chain),
     maps:map(fun(ID, LedgerStateChannel) ->
-                     Owner = blockchain_ledger_state_channel_v1:owner(LedgerStateChannel),
-                     ExpireAt = blockchain_ledger_state_channel_v1:expire_at_block(LedgerStateChannel),
-                     SC0 = blockchain_state_channel_v1:new(ID, Owner),
-                     Nonce = blockchain_ledger_state_channel_v1:nonce(LedgerStateChannel),
+                     Owner = SCMod:owner(LedgerStateChannel),
+                     ExpireAt = SCMod:expire_at_block(LedgerStateChannel),
+                     Amount = case SCMod of
+                                  blockchain_ledger_state_channel_v2 -> SCMod:amount(LedgerStateChannel);
+                                  _ -> 0
+                              end,
+
+                     SC0 = blockchain_state_channel_v1:new(ID, Owner, Amount),
+                     Nonce = SCMod:nonce(LedgerStateChannel),
                      Filter = fun(T) -> blockchain_txn:type(T) == blockchain_txn_state_channel_open_v1 andalso
                                         blockchain_txn_state_channel_open_v1:id(T) == ID andalso
                                         blockchain_txn_state_channel_open_v1:nonce(T) == Nonce

--- a/src/state_channel/blockchain_state_channels_server.erl
+++ b/src/state_channel/blockchain_state_channels_server.erl
@@ -239,9 +239,11 @@ update_state_sc_open(Txn,
         %% Do the map put when we are the owner of the state_channel
         Owner ->
             ID = blockchain_txn_state_channel_open_v1:id(Txn),
+            Amt = blockchain_txn_state_channel_open_v1:amount(Txn),
             ExpireWithin = blockchain_txn_state_channel_open_v1:expire_within(Txn),
             {SC, Skewed} = blockchain_state_channel_v1:new(ID,
                                                            Owner,
+                                                           Amt,
                                                            BlockHash,
                                                            (BlockHeight + ExpireWithin)),
 

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -662,7 +662,7 @@ absorb_delayed_(Block, Chain0) ->
             Hash = blockchain_block:hash_block(Block),
             Ledger0 = blockchain:ledger(Chain0),
             ok = blockchain_ledger_v1:maybe_gc_pocs(Chain0, Ledger0),
-            ok = blockchain_ledger_v1:maybe_gc_scs(Ledger0),
+            ok = blockchain_ledger_v1:maybe_gc_scs(Chain0, Ledger0),
             ok = blockchain_ledger_v1:refresh_gateway_witnesses(Hash, Ledger0),
             ok = blockchain_ledger_v1:maybe_recalc_price(Chain0, Ledger0),
             ok;

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -883,12 +883,12 @@ sc_depends_on_test() ->
     RT2 = blockchain_txn_routing_v1:sign(blockchain_txn_routing_v1:update_router_addresses(2, Payer1, gen_pubkeys(3), 1), SigFun),
 
     %% sc opens for payer
-    SC1 = blockchain_txn_state_channel_open_v1:sign(blockchain_txn_state_channel_open_v1:new(crypto:strong_rand_bytes(24), Payer, 10, 1, 1), SigFun),
-    SC2 = blockchain_txn_state_channel_open_v1:sign(blockchain_txn_state_channel_open_v1:new(crypto:strong_rand_bytes(24), Payer, 20, 1, 2), SigFun),
-    SC3 = blockchain_txn_state_channel_open_v1:sign(blockchain_txn_state_channel_open_v1:new(crypto:strong_rand_bytes(24), Payer, 30, 1, 3), SigFun),
+    SC1 = blockchain_txn_state_channel_open_v1:sign(blockchain_txn_state_channel_open_v1:new(crypto:strong_rand_bytes(24), Payer, 10, 1, 1, 0), SigFun),
+    SC2 = blockchain_txn_state_channel_open_v1:sign(blockchain_txn_state_channel_open_v1:new(crypto:strong_rand_bytes(24), Payer, 20, 1, 2, 0), SigFun),
+    SC3 = blockchain_txn_state_channel_open_v1:sign(blockchain_txn_state_channel_open_v1:new(crypto:strong_rand_bytes(24), Payer, 30, 1, 3, 0), SigFun),
 
     %% sc open for payer1
-    SC4 = blockchain_txn_state_channel_open_v1:sign(blockchain_txn_state_channel_open_v1:new(crypto:strong_rand_bytes(24), Payer1, 30, 2, 1), SigFun),
+    SC4 = blockchain_txn_state_channel_open_v1:sign(blockchain_txn_state_channel_open_v1:new(crypto:strong_rand_bytes(24), Payer1, 30, 2, 1, 0), SigFun),
 
     ?assertEqual(lists:sort([O0, RT1, SC1, SC2]), lists:sort(depends_on(SC3, blockchain_utils:shuffle([O0, RT1, SC1, SC2])))),
     ?assertEqual(lists:sort([O0, RT1, SC1, SC2]), lists:sort(depends_on(SC3, blockchain_utils:shuffle([O0, O1, RT1, SC1, SC2])))),

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -662,7 +662,7 @@ absorb_delayed_(Block, Chain0) ->
             Hash = blockchain_block:hash_block(Block),
             Ledger0 = blockchain:ledger(Chain0),
             ok = blockchain_ledger_v1:maybe_gc_pocs(Chain0, Ledger0),
-            ok = blockchain_ledger_v1:maybe_gc_scs(Chain0, Ledger0),
+            ok = blockchain_ledger_v1:maybe_gc_scs(Chain0),
             ok = blockchain_ledger_v1:refresh_gateway_witnesses(Hash, Ledger0),
             ok = blockchain_ledger_v1:maybe_recalc_price(Chain0, Ledger0),
             ok;

--- a/src/transactions/v1/blockchain_txn_state_channel_close_v1.erl
+++ b/src/transactions/v1/blockchain_txn_state_channel_close_v1.erl
@@ -157,7 +157,7 @@ absorb(Txn, Chain) ->
     TxnFee = ?MODULE:fee(Txn),
     case blockchain_ledger_v1:debit_fee(Closer, TxnFee, Ledger, AreFeesEnabled) of
         {error, _Reason}=Error -> Error;
-        ok -> blockchain_ledger_v1:delete_state_channel(ID, Owner, Ledger)
+        ok -> blockchain_ledger_v1:close_state_channel(Owner, Closer, SC, ID, Ledger)
     end.
 
 
@@ -181,7 +181,7 @@ to_json(Txn, _Opts) ->
 -ifdef(TEST).
 
 new_test() ->
-    SC = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>),
+    SC = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>, 0),
     Tx = #blockchain_txn_state_channel_close_v1_pb{
         state_channel=SC,
         closer= <<"closer">>
@@ -189,28 +189,28 @@ new_test() ->
     ?assertEqual(Tx, new(SC, <<"closer">>)).
 
 state_channel_test() ->
-    SC = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>),
+    SC = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>, 0),
     Tx = new(SC, <<"closer">>),
     ?assertEqual(SC, state_channel(Tx)).
 
 closer_test() ->
-    SC = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>),
+    SC = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>, 0),
     Tx = new(SC, <<"closer">>),
     ?assertEqual(<<"closer">>, closer(Tx)).
 
 fee_test() ->
-    SC = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>),
+    SC = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>, 0),
     Tx = new(SC, <<"closer">>),
     ?assertEqual(0, fee(Tx)).
 
 signature_test() ->
-    SC = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>),
+    SC = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>, 0),
     Tx = new(SC, <<"closer">>),
     ?assertEqual(<<>>, signature(Tx)).
 
 sign_test() ->
     #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    SC = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>),
+    SC = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>, 0),
     Closer = libp2p_crypto:pubkey_to_bin(PubKey),
     Tx0 = new(SC, Closer),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
@@ -220,7 +220,7 @@ sign_test() ->
     ?assert(libp2p_crypto:verify(EncodedTx1, Sig1, PubKey)).
 
 to_json_test() ->
-    SC = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>),
+    SC = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>, 0),
     Tx = new(SC, <<"closer">>),
     Json = to_json(Tx, []),
     ?assert(lists:all(fun(K) -> maps:is_key(K, Json) end,

--- a/src/transactions/v1/blockchain_txn_state_channel_close_v1.erl
+++ b/src/transactions/v1/blockchain_txn_state_channel_close_v1.erl
@@ -18,6 +18,9 @@
     new/2,
     hash/1,
     state_channel/1,
+    state_channel_id/1,
+    state_channel_owner/1,
+    state_channel_expire_at/1,
     closer/1,
     fee/1, fee/2,
     calculate_fee/2, calculate_fee/5,
@@ -53,6 +56,18 @@ hash(Txn) ->
 -spec state_channel(txn_state_channel_close()) -> blockchain_state_channel_v1:state_channel().
 state_channel(Txn) ->
     Txn#blockchain_txn_state_channel_close_v1_pb.state_channel.
+
+-spec state_channel_id(txn_state_channel_close()) -> blockchain_state_channel_v1:id().
+state_channel_id(Txn) ->
+    blockchain_state_channel_v1:id(Txn#blockchain_txn_state_channel_close_v1_pb.state_channel).
+
+-spec state_channel_owner(txn_state_channel_close()) -> libp2p_crypto:pubkey_bin().
+state_channel_owner(Txn) ->
+    blockchain_state_channel_v1:owner(Txn#blockchain_txn_state_channel_close_v1_pb.state_channel).
+
+-spec state_channel_expire_at(txn_state_channel_close()) -> pos_integer().
+state_channel_expire_at(Txn) ->
+    blockchain_state_channel_v1:expire_at_block(Txn#blockchain_txn_state_channel_close_v1_pb.state_channel).
 
 -spec closer(txn_state_channel_close()) -> libp2p_crypto:pubkey_bin().
 closer(Txn) ->

--- a/src/transactions/v1/blockchain_txn_state_channel_open_v1.erl
+++ b/src/transactions/v1/blockchain_txn_state_channel_open_v1.erl
@@ -15,12 +15,13 @@
 -include_lib("helium_proto/include/blockchain_txn_state_channel_open_v1_pb.hrl").
 
 -export([
-    new/5,
+    new/6,
     hash/1,
     id/1,
     owner/1,
     oui/1,
     nonce/1,
+    amount/1,
     expire_within/1,
     fee/1, fee/2,
     calculate_fee/2, calculate_fee/5,
@@ -43,14 +44,17 @@
           Owner :: libp2p_crypto:pubkey_bin(),
           ExpireWithin :: pos_integer(),
           OUI :: non_neg_integer(),
-          Nonce :: non_neg_integer()) -> txn_state_channel_open().
-new(ID, Owner, ExpireWithin, OUI, Nonce) ->
+          Nonce :: non_neg_integer(),
+          Amount :: non_neg_integer()
+         ) -> txn_state_channel_open().
+new(ID, Owner, ExpireWithin, OUI, Nonce, Amount) ->
     #blockchain_txn_state_channel_open_v1_pb{
         id=ID,
         owner=Owner,
         expire_within=ExpireWithin,
         oui=OUI,
         nonce=Nonce,
+        amount=Amount,
         fee=?LEGACY_TXN_FEE,
         signature = <<>>
     }.
@@ -72,6 +76,10 @@ owner(Txn) ->
 -spec nonce(Txn :: txn_state_channel_open()) -> non_neg_integer().
 nonce(Txn) ->
     Txn#blockchain_txn_state_channel_open_v1_pb.nonce.
+
+-spec amount(Txn :: txn_state_channel_open()) -> non_neg_integer().
+amount(Txn) ->
+    Txn#blockchain_txn_state_channel_open_v1_pb.amount.
 
 -spec oui(Txn :: txn_state_channel_open()) -> non_neg_integer().
 oui(Txn) ->
@@ -144,12 +152,16 @@ absorb(Txn, Chain) ->
         {error, _Reason}=Error ->
             Error;
         ok ->
-            %% TODO we should debit the amount of DC the state channel holds, not 0
-            case blockchain_ledger_v1:debit_dc(Owner, Nonce, 0, Ledger) of
+            Amount = case blockchain_ledger_v1:config(?sc_overcommit, Ledger) of
+                        {ok, Overcommit} -> ?MODULE:amount(Txn) * Overcommit;
+                        _ -> 0
+                     end,
+            case blockchain_ledger_v1:debit_dc(Owner, Nonce, Amount, Ledger) of
                 {error, _}=Error2 ->
                     Error2;
                 ok ->
-                    blockchain_ledger_v1:add_state_channel(ID, Owner, ExpireWithin, Nonce, Ledger)
+                    blockchain_ledger_v1:add_state_channel(ID, Owner, ExpireWithin,
+                                                           Nonce, Amount, Ledger)
             end
     end.
 
@@ -243,35 +255,40 @@ new_test() ->
         owner= <<"owner">>,
         expire_within=10,
         oui=1,
+        amount=10,
         nonce=1,
         fee=?LEGACY_TXN_FEE,
         signature = <<>>
     },
-    ?assertEqual(Tx, new(<<"id">>, <<"owner">>, 10, 1, 1)).
+    ?assertEqual(Tx, new(<<"id">>, <<"owner">>, 10, 1, 1, 10)).
 
 id_test() ->
-    Tx = new(<<"id">>, <<"owner">>, 10, 1, 1),
+    Tx = new(<<"id">>, <<"owner">>, 10, 1, 1, 10),
     ?assertEqual(<<"id">>, id(Tx)).
 
 owner_test() ->
-    Tx = new(<<"id">>, <<"owner">>, 10, 1, 1),
+    Tx = new(<<"id">>, <<"owner">>, 10, 1, 1, 10),
     ?assertEqual(<<"owner">>, owner(Tx)).
 
 signature_test() ->
-    Tx = new(<<"id">>, <<"owner">>, 10, 1, 1),
+    Tx = new(<<"id">>, <<"owner">>, 10, 1, 1, 10),
     ?assertEqual(<<>>, signature(Tx)).
 
+amount_test() ->
+    Tx = new(<<"id">>, <<"owner">>, 10, 1, 1, 10),
+    ?assertEqual(10, amount(Tx)).
+
 oui_test() ->
-    Tx = new(<<"id">>, <<"owner">>, 10, 1, 1),
+    Tx = new(<<"id">>, <<"owner">>, 10, 1, 1, 10),
     ?assertEqual(1, oui(Tx)).
 
 fee_test() ->
-    Tx = new(<<"id">>, <<"owner">>, 10, 1, 1),
+    Tx = new(<<"id">>, <<"owner">>, 10, 1, 1, 10),
     ?assertEqual(?LEGACY_TXN_FEE, fee(Tx)).
 
 sign_test() ->
     #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    Tx0 = new(<<"id">>, <<"owner">>, 10, 1, 1),
+    Tx0 = new(<<"id">>, <<"owner">>, 10, 1, 1, 10),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     Tx1 = sign(Tx0, SigFun),
     Sig1 = signature(Tx1),
@@ -279,9 +296,9 @@ sign_test() ->
     ?assert(libp2p_crypto:verify(EncodedTx1, Sig1, PubKey)).
 
 to_json_test() ->
-    Tx = new(<<"id">>, <<"owner">>, 10, 1, 1),
+    Tx = new(<<"id">>, <<"owner">>, 10, 1, 1, 10),
     Json = to_json(Tx, []),
     ?assert(lists:all(fun(K) -> maps:is_key(K, Json) end,
-                      [type, hash, id, owner, oui, fee, nonce, expire_within])).
+                      [type, hash, id, owner, amount, oui, fee, nonce, expire_within])).
 
 -endif.

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -844,6 +844,10 @@ validate_var(?sc_grace_blocks, Value) ->
     validate_int(Value, "sc_grace_blocks", 1, 100, false);
 validate_var(?dc_payload_size, Value) ->
     validate_int(Value, "dc_payload_size", 1, 32, false);
+validate_var(?sc_version, Value) ->
+    validate_int(Value, "sc_version", 1, 10, false);
+validate_var(?sc_overcommit, Value) ->
+    validate_int(Value, "sc_overcommit", 1, 10, false); %% XXX should this be a float?
 
 %% txn snapshot vars
 validate_var(?snapshot_version, Value) ->

--- a/test/blockchain_price_oracle_SUITE.erl
+++ b/test/blockchain_price_oracle_SUITE.erl
@@ -1034,7 +1034,7 @@ txn_fees_pay_with_dc(Config) ->
     ID = crypto:strong_rand_bytes(24),
     ExpireWithin = 11,
     %% base txn
-    SCTx0 = blockchain_txn_state_channel_open_v1:new(ID, RouterPubKeyBin, ExpireWithin, OUI1, 1),
+    SCTx0 = blockchain_txn_state_channel_open_v1:new(ID, RouterPubKeyBin, ExpireWithin, OUI1, 1, 0),
 
     %% get the fees for this txn
     SCTxFee = blockchain_txn_state_channel_open_v1:calculate_fee(SCTx0, Chain),

--- a/test/blockchain_state_channel_SUITE.erl
+++ b/test/blockchain_state_channel_SUITE.erl
@@ -1705,7 +1705,7 @@ create_oui_txn(OUI, RouterNode, EUIs, SubnetSize) ->
 create_sc_open_txn(RouterNode, ID, Expiry, OUI, Nonce) ->
     {ok, RouterPubkey, RouterSigFun, _} = ct_rpc:call(RouterNode, blockchain_swarm, keys, []),
     RouterPubkeyBin = libp2p_crypto:pubkey_to_bin(RouterPubkey),
-    SCOpenTxn = blockchain_txn_state_channel_open_v1:new(ID, RouterPubkeyBin, Expiry, OUI, Nonce),
+    SCOpenTxn = blockchain_txn_state_channel_open_v1:new(ID, RouterPubkeyBin, Expiry, OUI, Nonce, 0),
     blockchain_txn_state_channel_open_v1:sign(SCOpenTxn, RouterSigFun).
 
 check_all_closed([]) ->


### PR DESCRIPTION
To encourage honest behavior by routers and hotspots, DCs are overcommitted at state channel open time and then potentially refunded during state channel garbage collection.

[CH 7796](https://app.clubhouse.io/hlm/story/7796/state-channels-v2)