### PR TITLE
Fix validation for some old legacy txns with bad instances on chain

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -267,6 +267,12 @@
 %% Set this var to false to disable zero amount txns (payment_v1, payment_v2, htlc_create)
 -define(allow_zero_amount, allow_zero_amount).
 
+%% General txn vars
+
+%% Enable more robust validation on some legacy transactions with incorrect on-chain txns
+%% this is behind a chain variable to allow the bad txns to be synced through
+-define(txn_field_validation_version, txn_field_validation_version).
+
 %% ------------------------------------------------------------------
 %% State channel related vars
 %%

--- a/src/transactions/v1/blockchain_txn_create_htlc_v1.erl
+++ b/src/transactions/v1/blockchain_txn_create_htlc_v1.erl
@@ -150,9 +150,18 @@ is_valid(Txn, Chain) ->
     PubKey = libp2p_crypto:bin_to_pubkey(Payer),
     BaseTxn = Txn#blockchain_txn_create_htlc_v1_pb{signature = <<>>},
     EncodedTxn = blockchain_txn_create_htlc_v1_pb:encode_msg(BaseTxn),
-    case blockchain_txn:validate_fields([{{payee, ?MODULE:payee(Txn)}, {address, libp2p}},
-                                         {{hashlock, ?MODULE:hashlock(Txn)}, {binary, 32, 64}},
-                                         {{address, ?MODULE:address(Txn)}, {binary, 32, 33}}]) of
+    FieldValidation = case blockchain:config(?txn_field_validation_version, Ledger) of
+                          {ok, 1} ->
+                              [{{payee, ?MODULE:payee(Txn)}, {address, libp2p}},
+                               {{hashlock, ?MODULE:hashlock(Txn)}, {binary, 32}},
+                               {{address, ?MODULE:address(Txn)}, {address, libp2p}}];
+                          _ ->
+                              [{{payee, ?MODULE:payee(Txn)}, {address, libp2p}},
+                               {{hashlock, ?MODULE:hashlock(Txn)}, {binary, 32, 64}},
+                               {{address, ?MODULE:address(Txn)}, {binary, 32, 33}}]
+                      end,
+
+    case blockchain_txn:validate_fields(FieldValidation) of
         ok ->
             case blockchain_ledger_v1:find_htlc(?MODULE:address(Txn), Ledger) of
                 {ok, _HTLC} ->
@@ -336,5 +345,48 @@ to_json_test() ->
     Json = to_json(Tx, []),
     ?assert(lists:all(fun(K) -> maps:is_key(K, Json) end,
                       [type, hash, payer, payee, address, hashlock, timelock, amount, fee, nonce])).
+
+is_valid_with_extended_validation_test() ->
+    BaseDir = test_utils:tmp_dir("is_valid_with_extended_validation_test"),
+    Block = blockchain_block:new_genesis_block([]),
+    {ok, Chain} = blockchain:new(BaseDir, Block, undefined, undefined),
+    meck:new(blockchain_ledger_v1, [passthrough]),
+
+    %% These are all required
+    meck:expect(blockchain_ledger_v1, config,
+                fun(?deprecate_payment_v1, _) ->
+                        {ok, false};
+                   (?txn_field_validation_version, _) ->
+                        %% This is new
+                        {ok, 1};
+                   (?allow_zero_amount, _) ->
+                        {ok, false};
+                   (?dc_payload_size, _) ->
+                        {error, not_found};
+                   (?txn_fee_multiplier, _) ->
+                        {error, not_found}
+                end),
+    meck:expect(blockchain_ledger_v1, txn_fees_active, fun(_) -> true end),
+
+    #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
+    SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
+    Payer = libp2p_crypto:pubkey_to_bin(PubKey),
+    Tx = sign(new(Payer, <<"payee">>, <<"address">>, crypto:strong_rand_bytes(32), 0, 666, 1), SigFun),
+    ?assertEqual({error, {invalid_address, payee}}, is_valid(Tx, Chain)),
+
+    Tx1 = sign(new(Payer, libp2p_crypto:b58_to_bin("1BR9RgYoP5psbcw9aKh1cDskLaGMBmkb8"), <<"address">>, crypto:strong_rand_bytes(32), 0, 666, 1), SigFun),
+    ?assertEqual({error, {invalid_address, payee}}, is_valid(Tx1, Chain)),
+
+    #{public := PayeePubkey, secret := _PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
+    ValidPayee = libp2p_crypto:pubkey_to_bin(PayeePubkey),
+    Tx2 = sign(new(Payer, ValidPayee, ValidPayee, crypto:strong_rand_bytes(32), 0, 666, 1), SigFun),
+    %% This check can be improved but whatever (it fails on fee)
+    ?assertNotEqual({error, {invalid_address, payee}}, is_valid(Tx2, Chain)),
+
+    Tx3 = sign(new(Payer, ValidPayee, <<"address">>, crypto:strong_rand_bytes(32), 0, 666, 1), SigFun),
+    ?assertEqual({error, {invalid_address, address}}, is_valid(Tx3, Chain)),
+
+    meck:unload(blockchain_ledger_v1),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 -endif.

--- a/src/transactions/v1/blockchain_txn_payment_v1.erl
+++ b/src/transactions/v1/blockchain_txn_payment_v1.erl
@@ -125,7 +125,13 @@ is_valid(Txn, Chain) ->
         {ok, true} ->
             {error, payment_v1_deprecated};
         _ ->
-            case blockchain_txn:validate_fields([{{payee, Payee}, {binary, 20, 33}}]) of
+            FieldValidation = case blockchain:config(?txn_field_validation_version, Ledger) of
+                                  {ok, 1} ->
+                                      [{{payee, Payee}, {address, libp2p}}];
+                                  _ ->
+                                      [{{payee, Payee}, {binary, 20, 33}}]
+                              end,
+            case blockchain_txn:validate_fields(FieldValidation) of
                 ok ->
                     case libp2p_crypto:verify(EncodedTxn, Signature, PubKey) of
                         false ->
@@ -260,5 +266,45 @@ to_json_test() ->
     Json = to_json(Tx, []),
     ?assert(lists:all(fun(K) -> maps:is_key(K, Json) end,
                       [type, hash, payer, payee, amount, fee, nonce])).
+
+is_valid_with_extended_validation_test() ->
+    BaseDir = test_utils:tmp_dir("is_valid_with_extended_validation_test"),
+    Block = blockchain_block:new_genesis_block([]),
+    {ok, Chain} = blockchain:new(BaseDir, Block, undefined, undefined),
+    meck:new(blockchain_ledger_v1, [passthrough]),
+
+    %% These are all required
+    meck:expect(blockchain_ledger_v1, config,
+                fun(?deprecate_payment_v1, _) ->
+                        {ok, false};
+                   (?txn_field_validation_version, _) ->
+                        %% This is new
+                        {ok, 1};
+                   (?allow_zero_amount, _) ->
+                        {ok, false};
+                   (?dc_payload_size, _) ->
+                        {error, not_found};
+                   (?txn_fee_multiplier, _) ->
+                        {error, not_found}
+                end),
+    meck:expect(blockchain_ledger_v1, txn_fees_active, fun(_) -> true end),
+
+    #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
+    SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
+    Payer = libp2p_crypto:pubkey_to_bin(PubKey),
+    Tx = sign(new(Payer, <<"payee">>, 666, 1), SigFun),
+    ?assertEqual({error, {invalid_address, payee}}, is_valid(Tx, Chain)),
+
+    Tx1 = sign(new(Payer, libp2p_crypto:b58_to_bin("1BR9RgYoP5psbcw9aKh1cDskLaGMBmkb8"), 666, 1), SigFun),
+    ?assertEqual({error, {invalid_address, payee}}, is_valid(Tx1, Chain)),
+
+    #{public := PayeePubkey, secret := _PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
+    ValidPayee = libp2p_crypto:pubkey_to_bin(PayeePubkey),
+    Tx2 = sign(new(Payer, ValidPayee, 666, 1), SigFun),
+    %% This check can be improved but whatever (it fails on fee)
+    ?assertNotEqual({error, {invalid_address, payee}}, is_valid(Tx2, Chain)),
+
+    meck:unload(blockchain_ledger_v1),
+    test_utils:cleanup_tmp_dir(BaseDir).
 
 -endif.

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -824,6 +824,11 @@ validate_var(?allow_zero_amount, Value) ->
         _ -> throw({error, {invalid_allow_zero_amount, Value}})
     end;
 
+%% general txn vars
+
+validate_var(?txn_field_validation_version, Value) ->
+    validate_int(Value, "txn_field_validation_version", 1, 50, false);
+
 %% state channel vars
 %% XXX: what are some reasonable limits here?
 validate_var(?min_expire_within, Value) ->


### PR DESCRIPTION
In the past people submitted some bad transactions with invalid fields.
This change enables stricter validation of those txns, but is done
behind a chain var so that the historically bad transactions will be
valid when syncing.