### PR TITLE
Add MIC to offer msg

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -39,7 +39,7 @@
     {erlang_stats, ".*", {git, "https://github.com/helium/erlang-stats.git", {branch, "master"}}},
     {e2qc, ".*", {git, "https://github.com/project-fifo/e2qc", {branch, "master"}}},
     {vincenty, ".*", {git, "https://github.com/helium/vincenty", {branch, "master"}}},
-    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "master"}}},
+    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "rg/offer-mic"}}},
     {merkerl, ".*", {git, "https://github.com/helium/merkerl.git", {branch, "master"}}},
     {xxhash, {git, "https://github.com/pierreis/erlang-xxhash", {branch, "master"}}},
     {exor_filter, ".*", {git, "https://github.com/Vagabond/exor_filter", {branch, "adt/binary_contains"}}}

--- a/rebar.lock
+++ b/rebar.lock
@@ -37,7 +37,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"5baedf16e08385684edd325c62cbf4b7490b033b"}},
+       {ref,"f99222e5dbf896a01dc97daeae23ae5f3b660d00"}},
   0},
  {<<"inert">>,
   {git,"https://github.com/msantos/inert",


### PR DESCRIPTION
MIC appears to be required by the router when handling the state_channel offer message. It's extracted from the payload depending on the message type when we construct the sc offer.