### PR TITLE
Roll to a new state channel (if available) when current is exhausted

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -29,20 +29,20 @@
 }.
 
 {deps, [
-    {lager, ".*", {git, "https://github.com/erlang-lager/lager.git", {branch, "master"}}},
+    {lager, {git, "https://github.com/erlang-lager/lager.git", {branch, "master"}}},
     {erl_base58, "0.0.1"},
     {base64url, "1.0.1"},
-    {libp2p, ".*", {git, "https://github.com/helium/erlang-libp2p.git", {branch, "master"}}},
-    {clique, ".*", {git, "https://github.com/helium/clique.git", {branch, "develop"}}},
-    {h3, ".*", {git, "https://github.com/helium/erlang-h3.git", {branch, "master"}}},
-    {erl_angry_purple_tiger, ".*", {git, "https://github.com/helium/erl_angry_purple_tiger.git", {branch, "master"}}},
-    {erlang_stats, ".*", {git, "https://github.com/helium/erlang-stats.git", {branch, "master"}}},
-    {e2qc, ".*", {git, "https://github.com/project-fifo/e2qc", {branch, "master"}}},
-    {vincenty, ".*", {git, "https://github.com/helium/vincenty", {branch, "master"}}},
-    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "master"}}},
-    {merkerl, ".*", {git, "https://github.com/helium/merkerl.git", {branch, "master"}}},
+    {libp2p, {git, "https://github.com/helium/erlang-libp2p.git", {branch, "master"}}},
+    {clique, {git, "https://github.com/helium/clique.git", {branch, "develop"}}},
+    {h3, {git, "https://github.com/helium/erlang-h3.git", {branch, "master"}}},
+    {erl_angry_purple_tiger, {git, "https://github.com/helium/erl_angry_purple_tiger.git", {branch, "master"}}},
+    {erlang_stats, {git, "https://github.com/helium/erlang-stats.git", {branch, "master"}}},
+    {e2qc, {git, "https://github.com/project-fifo/e2qc", {branch, "master"}}},
+    {vincenty, {git, "https://github.com/helium/vincenty", {branch, "master"}}},
+    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "mra/pending_close"}}},
+    {merkerl, {git, "https://github.com/helium/merkerl.git", {branch, "master"}}},
     {xxhash, {git, "https://github.com/pierreis/erlang-xxhash", {branch, "master"}}},
-    {exor_filter, ".*", {git, "https://github.com/Vagabond/exor_filter", {branch, "adt/binary_contains"}}}
+    {exor_filter, {git, "https://github.com/Vagabond/exor_filter", {branch, "adt/binary_contains"}}}
 ]}.
 
 {erl_opts, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -37,7 +37,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"5baedf16e08385684edd325c62cbf4b7490b033b"}},
+       {ref,"1163ce0b3ccc7539a5b2913c95fa62365eee45b7"}},
   0},
  {<<"inert">>,
   {git,"https://github.com/msantos/inert",

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -2272,7 +2272,7 @@ find_state_channel(ID, Owner, Ledger) ->
     end.
 
 -spec find_sc_ids_by_owner(Owner :: libp2p_crypto:pubkey_bin(),
-                           Ledger :: ledger()) -> {ok, [binary()]}.
+                           Ledger :: ledger()) -> {ok, [blockchain_state_channel_v1:id()]}.
 find_sc_ids_by_owner(Owner, Ledger) ->
     SCsCF = state_channels_cf(Ledger),
     OwnerLength = byte_size(Owner),

--- a/src/state_channel/blockchain_state_channels_server.erl
+++ b/src/state_channel/blockchain_state_channels_server.erl
@@ -18,7 +18,8 @@
     gc_state_channels/1,
     state_channels/0,
     active_sc_id/0,
-    active_sc/0
+    active_sc/0,
+    get_active_sc_count/0
 ]).
 
 %% ------------------------------------------------------------------
@@ -132,6 +133,10 @@ active_sc_id() ->
 active_sc() ->
     gen_server:call(?SERVER, active_sc, infinity).
 
+-spec get_active_sc_count() -> non_neg_integer().
+get_active_sc_count() ->
+    gen_server:call(?SERVER, get_active_sc_count, infinity).
+
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions
 %% ------------------------------------------------------------------
@@ -166,6 +171,15 @@ handle_call(active_sc, _From, State) ->
     {reply, active_sc(State), State};
 handle_call(active_sc_id, _From, #state{active_sc_id=ActiveSCID}=State) ->
     {reply, ActiveSCID, State};
+handle_call(get_active_sc_count, _From, #state{state_channels=SCs}=State) ->
+    Count = maps:fold(fun(_ID, {SC, _Skewed}, Acc) ->
+                              SCState = blockchain_state_channel_v1:state(SC),
+                              case SCState == open of
+                                  false -> Acc;
+                                  true -> Acc + 1
+                              end
+                      end, 0, SCs),
+    {reply, Count, State};
 handle_call(_Msg, _From, State) ->
     lager:warning("rcvd unknown call msg: ~p from: ~p", [_Msg, _From]),
     {reply, ok, State}.

--- a/src/state_channel/v1/blockchain_state_channel_v1.erl
+++ b/src/state_channel/v1/blockchain_state_channel_v1.erl
@@ -194,7 +194,7 @@ state(#blockchain_state_channel_v1_pb{state=State}) ->
 
 -spec state(state(), state_channel()) -> state_channel().
 state(pending_close, SC) ->
-    SC#blockchain_state_channel_v1_pb{state=pending_closed};
+    SC#blockchain_state_channel_v1_pb{state=pending_close};
 state(closed, SC) ->
     SC#blockchain_state_channel_v1_pb{state=closed};
 state(open, SC) ->

--- a/src/state_channel/v1/blockchain_state_channel_v1.erl
+++ b/src/state_channel/v1/blockchain_state_channel_v1.erl
@@ -43,7 +43,7 @@
 
 -type state_channel() :: #blockchain_state_channel_v1_pb{}.
 -type id() :: binary().
--type state() :: open | closed.
+-type state() :: open | pending_close | closed.
 -type summaries() :: [blockchain_state_channel_summary_v1:summary()].
 -type temporal_relation() :: equal | effect_of | caused | conflict.
 
@@ -193,6 +193,8 @@ state(#blockchain_state_channel_v1_pb{state=State}) ->
     State.
 
 -spec state(state(), state_channel()) -> state_channel().
+state(pending_close, SC) ->
+    SC#blockchain_state_channel_v1_pb{state=pending_closed};
 state(closed, SC) ->
     SC#blockchain_state_channel_v1_pb{state=closed};
 state(open, SC) ->

--- a/src/state_channel/v1/blockchain_state_channel_v1.erl
+++ b/src/state_channel/v1/blockchain_state_channel_v1.erl
@@ -292,6 +292,7 @@ to_json(SC, _Opts) ->
       root_hash => ?BIN_TO_B64(root_hash(SC)),
       state => case(state(SC)) of
                    open -> <<"open">>;
+                   pending_close -> <<"pending_close">>;
                    closed -> <<"closed">>
                end,
       expire_at_block => expire_at_block(SC)


### PR DESCRIPTION
Problem to solve: currently when a state channel is exhausted, we drop the packet. Instead, roll to a state channel with capacity and use that instead.