### PR TITLE
Bug fixes for SC V2

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -299,6 +299,8 @@
 -define(sc_version, sc_version).
 %% state channel overcommit multiplier
 -define(sc_overcommit, sc_overcommit).
+%% state channel validation bugfix, correctly check dc_balance
+-define(sc_open_validation_bugfix, sc_open_validation_bugfix).
 
 %% ------------------------------------------------------------------
 %% snapshot vars

--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -299,7 +299,7 @@
 -define(sc_version, sc_version).
 %% state channel overcommit multiplier
 -define(sc_overcommit, sc_overcommit).
-%% state channel validation bugfix, correctly check dc_balance
+%% Number of attempts we get to fix state_channel bugs, we'll set it to 1, max = 50
 -define(sc_open_validation_bugfix, sc_open_validation_bugfix).
 
 %% ------------------------------------------------------------------

--- a/src/state_channel/blockchain_state_channels_server.erl
+++ b/src/state_channel/blockchain_state_channels_server.erl
@@ -193,8 +193,10 @@ handle_cast({packet, SCPacket, HandlerPid},
                                       Skewed, HandlerPid, State),
             {noreply, NewState}
     end;
-handle_cast({offer, SCOffer, _Pid}, #state{active_sc_id=undefined}=State) ->
+handle_cast({offer, SCOffer, HandlerPid}, #state{active_sc_id=undefined}=State) ->
     lager:warning("Got offer: ~p when no sc is active", [SCOffer]),
+    %% Reject any offer if we don't have an active_sc as well, as a courtesy for the router
+    ok = send_rejection(HandlerPid),
     {noreply, State};
 handle_cast({reject_offer, SCOffer, HandlerPid}, State) ->
     lager:warning("Rejecting offer: ~p, from: ~p", [SCOffer, HandlerPid]),

--- a/src/transactions/v1/blockchain_txn_state_channel_open_v1.erl
+++ b/src/transactions/v1/blockchain_txn_state_channel_open_v1.erl
@@ -228,7 +228,7 @@ do_is_valid_checks(Txn, Chain) ->
                                                             AreFeesEnabled = blockchain_ledger_v1:txn_fees_active(Ledger),
                                                             TxnFee = ?MODULE:fee(Txn),
                                                             OriginalAmount = ?MODULE:amount(Txn),
-                                                            ActualAmount = ?MODULE:actual_amount(OriginalAmount, Ledger),
+                                                            ActualAmount = actual_amount(OriginalAmount, Ledger),
                                                             ExpectedTxnFee = ?MODULE:calculate_fee(Txn, Chain),
                                                             case ExpectedTxnFee =< TxnFee orelse not AreFeesEnabled of
                                                                 false ->

--- a/src/transactions/v1/blockchain_txn_state_channel_open_v1.erl
+++ b/src/transactions/v1/blockchain_txn_state_channel_open_v1.erl
@@ -235,7 +235,7 @@ do_is_valid_checks(Txn, Chain) ->
                                                                     {error, {wrong_txn_fee, ExpectedTxnFee, TxnFee}};
                                                                 true ->
                                                                     case blockchain:config(?sc_open_validation_bugfix, Ledger) of
-                                                                        {ok, true} ->
+                                                                        {ok, 1} ->
                                                                             %% Check whether the actual amount (overcommit *
                                                                             %% original amount) + txn_fee is payable by this
                                                                             %% owner

--- a/src/transactions/v1/blockchain_txn_state_channel_open_v1.erl
+++ b/src/transactions/v1/blockchain_txn_state_channel_open_v1.erl
@@ -234,10 +234,15 @@ do_is_valid_checks(Txn, Chain) ->
                                                                 false ->
                                                                     {error, {wrong_txn_fee, ExpectedTxnFee, TxnFee}};
                                                                 true ->
-                                                                    %% Check whether the actual amount (overcommit *
-                                                                    %% original amount) + txn_fee is payable by this
-                                                                    %% owner
-                                                                    blockchain_ledger_v1:check_dc_balance(Owner, ActualAmount + TxnFee, Ledger)
+                                                                    case blockchain:config(?sc_open_validation_bugfix, Ledger) of
+                                                                        {ok, true} ->
+                                                                            %% Check whether the actual amount (overcommit *
+                                                                            %% original amount) + txn_fee is payable by this
+                                                                            %% owner
+                                                                            blockchain_ledger_v1:check_dc_balance(Owner, ActualAmount + TxnFee, Ledger);
+                                                                        _ ->
+                                                                            blockchain_ledger_v1:check_dc_or_hnt_balance(Owner, TxnFee, Ledger, AreFeesEnabled)
+                                                                    end
                                                             end;
                                                         {ok, _} ->
                                                             {error, state_channel_already_exists};

--- a/src/transactions/v1/blockchain_txn_token_burn_v1.erl
+++ b/src/transactions/v1/blockchain_txn_token_burn_v1.erl
@@ -14,7 +14,7 @@
 -include("blockchain_vars.hrl").
 -include("blockchain_utils.hrl").
 
-  -export([
+-export([
     new/3, new/4,
     hash/1,
     payer/1,

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -854,11 +854,7 @@ validate_var(?sc_version, Value) ->
 validate_var(?sc_overcommit, Value) ->
     validate_int(Value, "sc_overcommit", 1, 10, false); %% integer multiplier of amount
 validate_var(?sc_open_validation_bugfix, Value) ->
-    case Value of
-        true -> ok;
-        false -> ok;
-        _ -> throw({error, {invalid_sc_open_validation_bugfix, Value}})
-    end;
+    validate_int(Value, "sc_open_validation_bugfix", 1, 50, false);
 
 %% txn snapshot vars
 validate_var(?snapshot_version, Value) ->

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -853,6 +853,12 @@ validate_var(?sc_version, Value) ->
     validate_int(Value, "sc_version", 1, 10, false);
 validate_var(?sc_overcommit, Value) ->
     validate_int(Value, "sc_overcommit", 1, 10, false); %% integer multiplier of amount
+validate_var(?sc_open_validation_bugfix, Value) ->
+    case Value of
+        true -> ok;
+        false -> ok;
+        _ -> throw({error, {invalid_sc_open_validation_bugfix, Value}})
+    end;
 
 %% txn snapshot vars
 validate_var(?snapshot_version, Value) ->


### PR DESCRIPTION
* As a courtesy for the router, we now reject any offer that the state_channel_server gets when it has no active_sc.
* The validation for `state_channel_open_v1` had a mismatch with the absorb. We were _only_ checking the fee while trying to validate the txn, which would pass, however, the absorb would fail as it would try to debit dcs which the router doesn't have. Instead, we should check the dc_balance in sc_open txn validation _before_ we move to the absorb phase. This fixes it, I think.

The validation fix is guarded behind `sc_open_validation_bugfix` chain variable as we already have some incorrect state channel open txns on the chain.