### PR TITLE
Fix state channel causality issues

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -301,7 +301,7 @@
 -define(sc_overcommit, sc_overcommit).
 %% Number of attempts we get to fix state_channel bugs, we'll set it to 1, max = 50
 -define(sc_open_validation_bugfix, sc_open_validation_bugfix).
-%% Number of attempts we get to fix state_channel causality bugs, we'll set it to 1, max = 50
+%% Number of attempts we get to fix state_channel causality bugs, we'll set it to 1, max = 1
 -define(sc_causality_fix, sc_causality_fix).
 
 %% ------------------------------------------------------------------

--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -301,6 +301,8 @@
 -define(sc_overcommit, sc_overcommit).
 %% Number of attempts we get to fix state_channel bugs, we'll set it to 1, max = 50
 -define(sc_open_validation_bugfix, sc_open_validation_bugfix).
+%% Number of attempts we get to fix state_channel causality bugs, we'll set it to 1, max = 50
+-define(sc_causality_fix, sc_causality_fix).
 
 %% ------------------------------------------------------------------
 %% snapshot vars

--- a/src/ledger/v1/blockchain_ledger_state_channel_v2.erl
+++ b/src/ledger/v1/blockchain_ledger_state_channel_v2.erl
@@ -138,6 +138,9 @@ close_proposal(Closer, SC, ExplicitConflict, SCEntry) ->
                     SCEntry;
                 true when ExplicitConflict == true; Overpaid == true ->
                     %% we've never gotten a close request for this before, so...
+                    lager:info("dispute filed for open sc id: ~p, closer: ~p",
+                               [libp2p_crypto:bin_to_b58(blockchain_state_channel_v1:id(SC)),
+                                libp2p_crypto:bin_to_b58(Closer)]),
                     SCEntry#ledger_state_channel_v2{closer=Closer, sc=SC, close_state=dispute};
                 true ->
                     %% we've never gotten a close request for this before, so...
@@ -153,11 +156,17 @@ close_proposal(Closer, SC, ExplicitConflict, SCEntry) ->
                     %% dispute it
                     case maybe_dispute(state_channel(SCEntry), SC) of
                         {closed, NewSC} when ExplicitConflict == true; Overpaid == true ->
+                            lager:info("dispute filed for closed sc id: ~p, closer: ~p",
+                                       [libp2p_crypto:bin_to_b58(blockchain_state_channel_v1:id(NewSC)),
+                                        libp2p_crypto:bin_to_b58(Closer)]),
                             SCEntry#ledger_state_channel_v2{closer=Closer, sc=NewSC, close_state=dispute};
                         {closed, NewSC} ->
                             SCEntry#ledger_state_channel_v2{closer=Closer, sc=NewSC, close_state=closed};
                         {dispute, NewSC} ->
                             %% store the "latest" (as judged by nonce)
+                            lager:info("newer dispute filed for disputed sc id: ~p, closer: ~p",
+                                       [libp2p_crypto:bin_to_b58(blockchain_state_channel_v1:id(NewSC)),
+                                        libp2p_crypto:bin_to_b58(Closer)]),
                             SCEntry#ledger_state_channel_v2{sc=NewSC, close_state=dispute}
                     end
             end;

--- a/src/ledger/v1/blockchain_ledger_state_channel_v2.erl
+++ b/src/ledger/v1/blockchain_ledger_state_channel_v2.erl
@@ -222,14 +222,20 @@ maybe_dispute(PreviousSC, CurrentSC, ConsiderEffectOf) ->
             {closed, CurrentSC};
         caused ->
             %% Previous caused Current, keep that one
-            {closed, PreviousSC};
+            case ConsiderEffectOf of
+                false ->
+                    %% Maintain backwards compatibility
+                    {closed, PreviousSC};
+                true ->
+                    {closed, CurrentSC}
+            end;
         effect_of ->
             case ConsiderEffectOf of
                 false ->
                     %% Maintain backwards compatibility
                     {dispute, blockchain_state_channel_v1:merge(CurrentSC, PreviousSC)};
                 true ->
-                    {closed, CurrentSC}
+                    {closed, PreviousSC}
             end
     end.
 

--- a/src/ledger/v1/blockchain_ledger_state_channel_v2.erl
+++ b/src/ledger/v1/blockchain_ledger_state_channel_v2.erl
@@ -305,10 +305,21 @@ maybe_dispute_test() ->
     SC1 = blockchain_state_channel_v1:new(<<"id2">>, <<"key2">>, 200),
     Nonce4 = blockchain_state_channel_v1:nonce(4, SC0),
     Nonce8 = blockchain_state_channel_v1:nonce(8, SC1),
+    ?assertEqual({closed, SC0}, maybe_dispute(SC0, SC0, false)),
+    ?assertEqual({closed, Nonce4}, maybe_dispute(Nonce4, Nonce8, false)),
+    ?assertEqual({dispute, Nonce8}, maybe_dispute(Nonce8, Nonce4, false)).
+
+maybe_dispute_with_effect_of_test() ->
+    SC0 = blockchain_state_channel_v1:new(<<"id1">>, <<"key1">>, 100),
+    SC1 = blockchain_state_channel_v1:new(<<"id2">>, <<"key2">>, 200),
+    Nonce4 = blockchain_state_channel_v1:nonce(4, SC0),
+    Nonce8 = blockchain_state_channel_v1:nonce(8, SC1),
+
+    io:format("compare_causality: ~p~n", [blockchain_state_channel_v1:compare_causality(Nonce4, Nonce8)]),
+
     ?assertEqual({closed, SC0}, maybe_dispute(SC0, SC0, true)),
-    ?assertEqual({closed, Nonce4}, maybe_dispute(Nonce4, Nonce8, true)),
-    ?assertEqual({dispute, Nonce8}, maybe_dispute(Nonce8, Nonce4, false)),
-    ?assertEqual({closed, Nonce4}, maybe_dispute(Nonce8, Nonce4, true)).
+    ?assertEqual({closed, Nonce8}, maybe_dispute(Nonce4, Nonce8, true)),
+    ?assertEqual({closed, Nonce8}, maybe_dispute(Nonce8, Nonce4, true)).
 
 is_sc_participant_test() ->
     Ids = [<<"key1">>, <<"key2">>, <<"key3">>],

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -2357,7 +2357,13 @@ close_state_channel(Owner, Closer, SC, SCID, HadConflict, Ledger) ->
             {ok, PrevSCE} = find_state_channel(SCID, Owner, Ledger),
             case blockchain_ledger_state_channel_v2:is_v2(PrevSCE) of
                 true ->
-                    NewSCE = blockchain_ledger_state_channel_v2:close_proposal(Closer, SC, HadConflict, PrevSCE),
+                    ConsiderEffectOf = case blockchain:config(?sc_causality_fix, Ledger) of
+                                           {ok, N} when N > 0 ->
+                                               true;
+                                           _ ->
+                                               false
+                                       end,
+                    NewSCE = blockchain_ledger_state_channel_v2:close_proposal(Closer, SC, HadConflict, PrevSCE, ConsiderEffectOf),
                     Bin = blockchain_ledger_state_channel_v2:serialize(NewSCE),
                     cache_put(Ledger, SCsCF, Key, Bin);
                 false ->

--- a/src/state_channel/blockchain_state_channels_client.erl
+++ b/src/state_channel/blockchain_state_channels_client.erl
@@ -816,14 +816,17 @@ close_state_channel(SC, State=#state{swarm=Swarm}) ->
             ok
     end.
 
+-spec conflicts(SCA :: blockchain_state_channel_v1:state_channel(),
+                SCB :: blockchain_state_channel_v1:state_channel()) -> boolean().
 conflicts(SCA, SCB) ->
     case blockchain_state_channel_v1:compare_causality(SCA, SCB) of
-        caused ->
-            false;
-        equal ->
-            false;
+        conflict ->
+            lager:info("sc_client reports state_channel conflict, SCA_ID: ~p, SCB_ID: ~p",
+                       [libp2p_crypto:bin_to_b58(blockchain_state_channel_v1:id(SCA)),
+                        libp2p_crypto:bin_to_b58(blockchain_state_channel_v1:id(SCB))]),
+            true;
         _ ->
-            true
+            false
     end.
 
 %% ------------------------------------------------------------------

--- a/src/state_channel/v1/blockchain_state_channel_v1.erl
+++ b/src/state_channel/v1/blockchain_state_channel_v1.erl
@@ -334,7 +334,7 @@ compare_causality(OlderSC, CurrentSC) ->
                    {OlderNonce, CurrentNonce} when CurrentNonce < OlderNonce ->
                        %% The current nonce is smaller than the older nonce;
                        %% that's a conflict
-                       check_causality(?MODULE:summaries(OlderSC), CurrentSC, effect_of)
+                       check_causality(?MODULE:summaries(CurrentSC), OlderSC, effect_of)
                end,
     Res.
 

--- a/src/state_channel/v1/blockchain_state_channel_v1.erl
+++ b/src/state_channel/v1/blockchain_state_channel_v1.erl
@@ -297,10 +297,11 @@ to_json(SC, _Opts) ->
 
 %%--------------------------------------------------------------------
 %% @doc
-%% Get causal relation between older SC and the current SC.
+%% Get causal relation between older SC and current SC.
 %%
-%% If current dominates older, return caused
-%% If current == older, return equal
+%% If SC1 -> SC2, return caused
+%% If SC2 -> SC1, return effect_of
+%% If SC1 == SC2, return equal
 %% In all other scenarios, return conflict
 %%
 %% Important: The expected older state channel should be passed <b>first</b>.
@@ -329,11 +330,11 @@ compare_causality(OlderSC, CurrentSC) ->
                        %% Every hotspot in older summary must have either
                        %% the same/lower packet and dc count when compared
                        %% to current summary
-                       check_causality(?MODULE:summaries(OlderSC), CurrentSC);
+                       check_causality(?MODULE:summaries(OlderSC), CurrentSC, caused);
                    {OlderNonce, CurrentNonce} when CurrentNonce < OlderNonce ->
                        %% The current nonce is smaller than the older nonce;
                        %% that's a conflict
-                       {done, conflict}
+                       check_causality(?MODULE:summaries(CurrentSC), OlderSC, effect_of)
                end,
     Res.
 
@@ -380,8 +381,9 @@ can_fit(ClientPubkeyBin, Summaries) ->
     end.
 
 -spec check_causality(SCSummaries :: summaries(),
-                      OtherSC :: state_channel()) -> {done, temporal_relation()}.
-check_causality(SCSummaries, OtherSC) ->
+                      OtherSC :: state_channel(),
+                      Init :: caused | effect_of) -> {done, temporal_relation()}.
+check_causality(SCSummaries, OtherSC, Init) ->
     lists:foldl(fun(_SCSummary, {done, Acc}) ->
                         {done, Acc};
                    (SCSummary, {not_done, Acc}) ->
@@ -405,7 +407,7 @@ check_causality(SCSummaries, OtherSC) ->
                                         {not_done, Acc}
                                 end
                         end
-                end, {not_done, caused}, SCSummaries).
+                end, {not_done, Init}, SCSummaries).
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests
@@ -550,7 +552,7 @@ causality_test() ->
     SC1 = new(<<"1">>, <<"owner">>, 1),
     SC2 = nonce(1, new(<<"1">>, <<"owner">>, 1)),
     ?assertEqual(caused, compare_causality(SC1, SC2)),
-    ?assertEqual(conflict, compare_causality(SC2, SC1)),
+    ?assertEqual(effect_of, compare_causality(SC2, SC1)),
 
     %% 0 (same) nonce, with differing summary, conflict
     SC3 = summaries([Summary2], new(<<"1">>, <<"owner">>, 1)),
@@ -562,13 +564,13 @@ causality_test() ->
     SC5 = new(<<"1">>, <<"owner">>, 1),
     SC6 = summaries([Summary1], nonce(1, new(<<"1">>, <<"owner">>, 1))),
     ?assertEqual(caused, compare_causality(SC5, SC6)),
-    ?assertEqual(conflict, compare_causality(SC6, SC5)),
+    ?assertEqual(effect_of, compare_causality(SC6, SC5)),
 
     %% SC7 is allowed after SC5
     %% NOTE: skipped a nonce here (should this actually be allowed?)
     SC7 = summaries([Summary1], nonce(2, new(<<"1">>, <<"owner">>, 1))),
     ?assertEqual(caused, compare_causality(SC5, SC7)),
-    ?assertEqual(conflict, compare_causality(SC7, SC5)),
+    ?assertEqual(effect_of, compare_causality(SC7, SC5)),
 
     %% SC9 has higher nonce than SC8, however,
     %% SC9 does not have summary which SC8 has, conflict
@@ -587,7 +589,7 @@ causality_test() ->
     SC12 = summaries([Summary1], nonce(10, new(<<"1">>, <<"owner">>, 1))),
     SC13 = summaries([Summary2], nonce(11, new(<<"1">>, <<"owner">>, 1))),
     ?assertEqual(caused, compare_causality(SC12, SC13)),
-    ?assertEqual(conflict, compare_causality(SC13, SC12)),
+    ?assertEqual(effect_of, compare_causality(SC13, SC12)),
 
     %% definite conflict, since summary for a client is missing in higher nonce sc
     SC14 = summaries([Summary1], nonce(11, new(<<"1">>, <<"owner">>, 1))),
@@ -599,7 +601,7 @@ causality_test() ->
     SC16 = summaries([Summary1], nonce(10, new(<<"1">>, <<"owner">>, 1))),
     SC17 = summaries([Summary2, Summary3], nonce(11, new(<<"1">>, <<"owner">>, 1))),
     ?assertEqual(caused, compare_causality(SC16, SC17)),
-    ?assertEqual(conflict, compare_causality(SC17, SC16)),
+    ?assertEqual(effect_of, compare_causality(SC17, SC16)),
 
     %% another definite conflict, since higher nonce sc does not have previous summary
     SC18 = summaries([Summary1, Summary3], nonce(10, new(<<"1">>, <<"owner">>, 1))),
@@ -617,7 +619,7 @@ causality_test() ->
     SC22 = summaries([Summary1], nonce(10, new(<<"1">>, <<"owner">>, 1))),
     SC23 = summaries([Summary2, Summary3], nonce(12, new(<<"1">>, <<"owner">>, 1))),
     ?assertEqual(caused, compare_causality(SC22, SC23)),
-    ?assertEqual(conflict, compare_causality(SC23, SC22)),
+    ?assertEqual(effect_of, compare_causality(SC23, SC22)),
 
     ok.
 

--- a/src/state_channel/v1/blockchain_state_channel_v1.erl
+++ b/src/state_channel/v1/blockchain_state_channel_v1.erl
@@ -334,7 +334,7 @@ compare_causality(OlderSC, CurrentSC) ->
                    {OlderNonce, CurrentNonce} when CurrentNonce < OlderNonce ->
                        %% The current nonce is smaller than the older nonce;
                        %% that's a conflict
-                       check_causality(?MODULE:summaries(CurrentSC), OlderSC, effect_of)
+                       check_causality(?MODULE:summaries(OlderSC), CurrentSC, effect_of)
                end,
     Res.
 

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -854,7 +854,11 @@ validate_var(?sc_version, Value) ->
 validate_var(?sc_overcommit, Value) ->
     validate_int(Value, "sc_overcommit", 1, 10, false); %% integer multiplier of amount
 validate_var(?sc_open_validation_bugfix, Value) ->
+    %% NOTE: Can't just increment this directly and expect version to update.
+    %% It would need to be set to 51, and the limits would have to be increased.
     validate_int(Value, "sc_open_validation_bugfix", 1, 50, false);
+validate_var(?sc_causality_fix, Value) ->
+    validate_int(Value, "sc_causality_fix", 1, 1, false);
 
 %% txn snapshot vars
 validate_var(?snapshot_version, Value) ->


### PR DESCRIPTION
This re-introduces `effect_of` temporal relation between two state channels. On chain, we are incorrectly marking state channels as having conflicts when in fact they don't.

Also introduced here is `sc_causality_fix` chain var, which would ensure that we still adhere to existing behavior if the var is not set.