### PR TITLE
don't deserialize snap data to save memory and compat

### DIFF
--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -171,7 +171,6 @@ snapshot(Ledger0, Blocks) ->
                       try register(Regname, self()) of
                           true ->
                               Res = generate_snapshot(Ledger0, Blocks),
-                              timer:sleep(15000),
                               %% deliver to the caller
                               Parent ! {Ref, Res},
                               %% deliver to anyone else blocking
@@ -193,7 +192,7 @@ snapshot(Ledger0, Blocks) ->
                                 end
                       end
               end,
-              [{max_heap_size, application:get_env(blockchain, snapshot_memory_limit, 200) * 1024 * 1024 div erlang:system_info(wordsize)}, {fullsweep_after, 0}, monitor]),
+              [{max_heap_size, application:get_env(blockchain, snapshot_memory_limit, 75) * 1024 * 1024 div erlang:system_info(wordsize)}, {fullsweep_after, 0}, monitor]),
     receive
         {Ref, Res} ->
             Res;


### PR DESCRIPTION
creating snapshots results in a huge amount of GC pressure, which can OOM smaller hotspots.

this PR shouldn't create as much pressure, as a step on the road to streaming the information to disk piecewise, allowing less even less GC pressure.