### PR TITLE
Minimal state channel rollover

### DIFF
--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -27,6 +27,7 @@
     approx_blocks_in_week/1,
     vars_keys_to_list/1,
     calculate_dc_amount/2, calculate_dc_amount/3,
+    do_calculate_dc_amount/2,
     deterministic_subset/3
 ]).
 
@@ -65,6 +66,17 @@ calculate_dc_amount(Ledger, PayloadSize) ->
                           DCPayloadSize :: pos_integer()) -> pos_integer().
 calculate_dc_amount(_Ledger, PayloadSize, DCPayloadSize) ->
     do_calculate_dc_amount(PayloadSize, DCPayloadSize).
+
+-spec do_calculate_dc_amount(PayloadSize :: non_neg_integer(), DCPayloadSize :: pos_integer()) -> pos_integer().
+do_calculate_dc_amount(_PayloadSize, undefined) ->
+    0;
+do_calculate_dc_amount(PayloadSize, DCPayloadSize)->
+    case PayloadSize =< DCPayloadSize of
+        true ->
+            1;
+        false ->
+            erlang:ceil(PayloadSize/DCPayloadSize)
+    end.
 
 %%--------------------------------------------------------------------
 %% @doc Shuffle a list deterministically using a random binary as the seed.
@@ -257,14 +269,6 @@ find_txn(Block, PredFun) ->
 %% ------------------------------------------------------------------
 %% Internal Function Definitions
 %% ------------------------------------------------------------------
--spec do_calculate_dc_amount(PayloadSize :: non_neg_integer(), DCPayloadSize :: pos_integer()) -> pos_integer().
-do_calculate_dc_amount(PayloadSize, DCPayloadSize)->
-    case PayloadSize =< DCPayloadSize of
-        true ->
-            1;
-        false ->
-            erlang:ceil(PayloadSize/DCPayloadSize)
-    end.
 icdf_select([{_Node, 0.0}], _Rnd, _OrigRnd) ->
     {error, zero_weight};
 icdf_select([{Node, _Weight}], _Rnd, _OrigRnd) ->

--- a/src/state_channel/blockchain_state_channel_handler.erl
+++ b/src/state_channel/blockchain_state_channel_handler.erl
@@ -67,7 +67,7 @@ send_offer(Pid, Offer) ->
 
 -spec send_purchase(pid(), blockchain_state_channel_purchase_v1:purchase()) -> ok.
 send_purchase(Pid, Purchase) ->
-    lager:info("sending purchase: ~p, pid: ~p", [Purchase, Pid]),
+    %lager:info("sending purchase: ~p, pid: ~p", [Purchase, Pid]),
     Pid ! {send_purchase, Purchase},
     ok.
 
@@ -104,9 +104,9 @@ init(server, _Conn, [_Path, Blockchain]) ->
                     lager:info("sc_handler, empty banner: ~p", [SCBanner]),
                     {ok, #state{}, blockchain_state_channel_message_v1:encode(SCBanner)};
                 ActiveSC ->
-                    lager:info("sc_handler, active_sc: ~p", [ActiveSC]),
+                    %lager:info("sc_handler, active_sc: ~p", [ActiveSC]),
                     SCBanner = blockchain_state_channel_banner_v1:new(ActiveSC),
-                    lager:info("sc_handler, banner: ~p", [SCBanner]),
+                    %lager:info("sc_handler, banner: ~p", [SCBanner]),
                     {ok, #state{}, blockchain_state_channel_message_v1:encode(SCBanner)}
             end;
         _ -> {ok, #state{}}

--- a/src/state_channel/blockchain_state_channels_server.erl
+++ b/src/state_channel/blockchain_state_channels_server.erl
@@ -719,14 +719,14 @@ maybe_get_new_active(SCs) ->
                            {ok, X} -> X;
                            X -> X
                        end,
-            FilterFun = fun({_, SC}) ->
+            FilterFun = fun({_, {SC, _}}) ->
                                 blockchain_state_channel_v1:amount(SC) > (blockchain_state_channel_v1:total_dcs(SC) + Headroom)
                         end,
 
             case lists:filter(FilterFun, lists:sort(SCSortFun2, lists:sort(SCSortFun, L))) of
                 [] -> undefined;
                 Y ->
-                    {ID, _} = Y,
+                    [{ID, _}|_] = Y,
                     ID
             end
     end.

--- a/src/state_channel/blockchain_state_channels_server.erl
+++ b/src/state_channel/blockchain_state_channels_server.erl
@@ -786,6 +786,7 @@ update_sc_summary(ClientPubkeyBin, PayloadSize, Ledger, SC) ->
 -spec maybe_broadcast_banner(SC :: undefined | blockchain_state_channel_v1:state_channel(),
                              State :: state()) -> ok.
 maybe_broadcast_banner(undefined, _State) -> ok;
+maybe_broadcast_banner(_, #state{chain=undefined}) -> ok;
 maybe_broadcast_banner(SC, #state{chain=Chain}=State) ->
     case blockchain:config(sc_version, blockchain:ledger(Chain)) of
         {ok, 2} ->

--- a/src/state_channel/blockchain_state_channels_server.erl
+++ b/src/state_channel/blockchain_state_channels_server.erl
@@ -363,8 +363,8 @@ process_packet(ClientPubkeyBin, Packet, SC, Skewed, HandlerPid,
     ok = blockchain_state_channel_v1:save(DB, SignedSC, Skewed1),
     ok = store_active_sc_id(DB, SCF, ActiveSCID),
 
-    lager:info("packet: ~p successfully validated, updating state",
-                       [blockchain_utils:bin_to_hex(blockchain_helium_packet_v1:encode(Packet))]),
+    %lager:info("packet: ~p successfully validated, updating state",
+    %                   [blockchain_utils:bin_to_hex(blockchain_helium_packet_v1:encode(Packet))]),
 
     %% Put new state_channel in our map
     TempState = State#state{state_channels=maps:update(ActiveSCID, {SignedSC, Skewed1}, SCs)},

--- a/src/state_channel/v1/blockchain_state_channel_v1.erl
+++ b/src/state_channel/v1/blockchain_state_channel_v1.erl
@@ -251,7 +251,7 @@ decode(Binary) ->
            Skewed :: skewed:skewed()) -> ok.
 save(DB, SC, Skewed) ->
     ID = ?MODULE:id(SC),
-    ok = rocksdb:put(DB, ID, term_to_binary({?MODULE:encode(SC), Skewed}), [{sync, true}]).
+    ok = rocksdb:put(DB, ID, term_to_binary({?MODULE:encode(SC), Skewed}), [{sync, false}]).
 
 -spec fetch(rocksdb:db_handle(), id()) -> {ok, {state_channel(), skewed:skewed()}} | {error, any()}.
 fetch(DB, ID) ->


### PR DESCRIPTION
When a state channel has no more capacity, try to use a different one. Implement an API for router to use to get the current active count (modulo some headroom factor).