### PR TITLE
don't crash on too-short handler removal, correct height test

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -55,7 +55,7 @@
   0},
  {<<"libp2p">>,
   {git,"https://github.com/helium/erlang-libp2p.git",
-       {ref,"601f8008e8a4d849fbf2331483b0adac7373d5f9"}},
+       {ref,"0c0a62f656ec1c0f2a8a9489d276415344744ea9"}},
   0},
  {<<"libp2p_crypto">>,{pkg,<<"libp2p_crypto">>,<<"1.1.0">>},1},
  {<<"merkerl">>,

--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -1919,7 +1919,12 @@ init_assumed_valid(Blockchain, HashAndHeight={Hash, Height}) when is_binary(Hash
 init_assumed_valid(Blockchain, _) ->
     maybe_continue_resync(Blockchain).
 
-init_blessed_snapshot(Blockchain, _HashAndHeight={Hash, Height}) when is_binary(Hash), is_integer(Height) ->
+init_blessed_snapshot(Blockchain, _HashAndHeight={Hash, Height0}) when is_binary(Hash), is_integer(Height0) ->
+    %% the height of the snapshot is the height it hit the chain,
+    %% rather than the height it leaves the ledger when it's fully
+    %% loaded.  before this fix, if we crashed after loading, even if
+    %% we succeeded loading, we'd redo that work.
+    Height = Height0 - 1,
     case blockchain:height(Blockchain) of
         %% already loaded the snapshot
         {ok, CurrHeight} when CurrHeight >= Height ->

--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -750,7 +750,7 @@ add_handlers(SwarmTID, Blockchain) ->
 -spec remove_handlers(ets:tab()) -> ok.
 remove_handlers(SwarmTID) ->
     %% remove the gossip handler
-    ok = libp2p_group_gossip:remove_handler(libp2p_swarm:gossip_group(SwarmTID), ?GOSSIP_PROTOCOL_V1),
+    catch libp2p_group_gossip:remove_handler(libp2p_swarm:gossip_group(SwarmTID), ?GOSSIP_PROTOCOL_V1),
 
     %% remove the sync handlers
     SyncRemoveFun = fun(ProtocolVersion) ->


### PR DESCRIPTION
these two things were combining to boot loop snapshot-loading spots. 