### PR TITLE
Attempt to rework the server side of the SC handler

### DIFF
--- a/src/state_channel/blockchain_state_channel_handler.erl
+++ b/src/state_channel/blockchain_state_channel_handler.erl
@@ -35,7 +35,11 @@
 -include("blockchain.hrl").
 -include("blockchain_vars.hrl").
 
--record(state, {ledger :: undefined | blockchain_ledger_v1:ledger()}).
+-record(state, {
+          ledger :: undefined | blockchain_ledger_v1:ledger(),
+          pending_packet_offer :: undefined | blockchain_state_channel_packet_offer_v1:offer(),
+          offer_queue = [] :: [blockchain_state_channel_packet_offer_v1:offer()]
+         }).
 
 %% ------------------------------------------------------------------
 %% API Function Definitions
@@ -128,16 +132,36 @@ handle_data(client, Data, State) ->
             blockchain_state_channels_client:response(Resp)
     end,
     {noreply, State};
-handle_data(server, Data, State) ->
+handle_data(server, Data, State=#state{pending_packet_offer=PendingOffer}) ->
     case blockchain_state_channel_message_v1:decode(Data) of
+        {offer, Offer} when PendingOffer == undefined ->
+            handle_offer(Offer, State);
         {offer, Offer} ->
-            lager:info("sc_handler server got offer: ~p", [Offer]),
-            blockchain_state_channels_server:offer(Offer, self());
+            %% queue the offer
+            {noreply, State#state{offer_queue=State#state.offer_queue ++ [Offer]}};
         {packet, Packet} ->
-            lager:debug("sc_handler server got packet: ~p", [Packet]),
-            blockchain_state_channels_server:packet(Packet, State#state.ledger, self())
-    end,
-    {noreply, State}.
+            case PendingOffer of
+                undefined ->
+                    lager:debug("sc_handler server got packet: ~p", [Packet]),
+                    blockchain_state_channels_server:packet(Packet, self()),
+                    {noreply, State};
+                _ ->
+                    case blockchain_state_channel_packet_v1:validate(Packet, PendingOffer) of
+                        {error, packet_offer_mismatch} ->
+                            %% might as well try it, it's free
+                            blockchain_state_channels_server:packet(Packet, self()),
+                            lager:warning("packet failed to validate ~p against offer ~p", [Packet, PendingOffer]),
+                            {stop, normal};
+                        {error, Reason} ->
+                            lager:warning("packet failed to validate ~p reason ~p", [Packet, Reason]),
+                            {stop, normal};
+                        true ->
+                            lager:debug("sc_handler server got packet: ~p", [Packet]),
+                            blockchain_state_channels_server:packet(Packet, self()),
+                            handle_next_offer(State#state{pending_packet_offer=undefined})
+                    end
+            end
+    end.
 
 handle_info(client, {send_offer, Offer}, State) ->
     Data = blockchain_state_channel_message_v1:encode(Offer),
@@ -164,3 +188,30 @@ handle_info(server, {send_response, Resp}, State) ->
 handle_info(_Type, _Msg, State) ->
     lager:warning("~p got unhandled msg: ~p", [_Type, _Msg]),
     {noreply, State}.
+
+handle_next_offer(State=#state{offer_queue=[]}) ->
+    {noreply, State};
+handle_next_offer(State=#state{offer_queue=[NextOffer|Offers]}) ->
+    handle_offer(NextOffer, State#state{offer_queue=Offers}).
+
+handle_offer(Offer, State) ->
+    lager:info("sc_handler server got offer: ~p", [Offer]),
+    case blockchain_state_channels_server:offer(Offer, State#state.ledger, self()) of
+        ok ->
+            %% offer is pending, just block the stream waiting for the purchase or rejection
+            receive
+                {send_purchase, SignedPurchaseSC, Hotspot, PacketHash, Region} ->
+                    %% NOTE: We're constructing the purchase with the hotspot obtained from offer here
+                    PurchaseMsg = blockchain_state_channel_purchase_v1:new(SignedPurchaseSC, Hotspot, PacketHash, Region),
+                    Data = blockchain_state_channel_message_v1:encode(PurchaseMsg),
+                    {noreply, State#state{pending_packet_offer=Offer}, Data};
+                {send_rejection, Rejection} ->
+                    Data = blockchain_state_channel_message_v1:encode(Rejection),
+                    {noreply, State, Data}
+            end;
+        reject ->
+            %% we were able to reject out of hand
+            Rejection = blockchain_state_channel_rejection_v1:new(),
+            Data = blockchain_state_channel_message_v1:encode(Rejection),
+            {noreply, State, Data}
+    end.

--- a/src/state_channel/blockchain_state_channel_handler.erl
+++ b/src/state_channel/blockchain_state_channel_handler.erl
@@ -40,7 +40,7 @@
           pending_packet_offers = #{} :: #{binary() => blockchain_state_channel_packet_offer_v1:offer()},
           offer_queue = [] :: [blockchain_state_channel_packet_offer_v1:offer()],
           handler_mod :: atom(),
-          pending_offer_limit :: pos_integer()
+          pending_offer_limit = undefined :: undefined | pos_integer()
          }).
 
 %% ------------------------------------------------------------------

--- a/src/state_channel/v1/blockchain_state_channel_packet_v1.erl
+++ b/src/state_channel/v1/blockchain_state_channel_packet_v1.erl
@@ -65,6 +65,7 @@ validate(Packet, Offer) ->
             %% compute the offer from the packet and check it compares to the original offer
             ExpectedOffer = blockchain_state_channel_offer_v1:from_packet(packet(Packet), hotspot(Packet), region(Packet)),
             %% signatures won't be the same, but we can compare everything else
+            lager:info("Original offer ~p, calculated offer ~p", [Offer, ExpectedOffer]),
             case blockchain_state_channel_offer_v1:packet_hash(Offer) == blockchain_state_channel_offer_v1:packet_hash(ExpectedOffer) andalso
                  blockchain_state_channel_offer_v1:payload_size(Offer) == blockchain_state_channel_offer_v1:payload_size(ExpectedOffer) andalso
                  blockchain_state_channel_offer_v1:routing(Offer) == blockchain_state_channel_offer_v1:routing(ExpectedOffer) andalso

--- a/test/blockchain_state_channel_SUITE.erl
+++ b/test/blockchain_state_channel_SUITE.erl
@@ -223,7 +223,9 @@ full_test(Config) ->
     true = check_sc_open(RouterNode, RouterChain, RouterPubkeyBin, ID),
 
     %% Check that the nonce of the sc server is okay
-    ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])),
+    ok = blockchain_ct_utils:wait_until(fun() ->
+        {ok, 0} == ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])
+    end, 30, timer:seconds(1)),
 
     %% Sending 1 packet
     DevNonce0 = crypto:strong_rand_bytes(2),
@@ -316,7 +318,9 @@ dup_packets_test(Config) ->
     true = check_sc_open(RouterNode, RouterChain, RouterPubkeyBin, ID),
 
     %% Check that the nonce of the sc server is okay
-    ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])),
+    ok = blockchain_ct_utils:wait_until(fun() ->
+        {ok, 0} == ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])
+    end, 30, timer:seconds(1)),
 
     %% Sending 1 packet
     Payload0 = crypto:strong_rand_bytes(120),
@@ -424,7 +428,9 @@ expired_test(Config) ->
     true = check_sc_open(RouterNode, RouterChain, RouterPubkeyBin, ID),
 
     %% Check that the nonce of the sc server is okay
-    ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])),
+    ok = blockchain_ct_utils:wait_until(fun() ->
+        {ok, 0} == ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])
+    end, 30, timer:seconds(1)),
 
     %% Sending 1 packet
     DevNonce0 = crypto:strong_rand_bytes(2),
@@ -504,7 +510,9 @@ replay_test(Config) ->
     true = check_sc_open(RouterNode, RouterChain, RouterPubkeyBin, ID),
 
     %% Check that the nonce of the sc server is okay
-    ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])),
+    ok = blockchain_ct_utils:wait_until(fun() ->
+        {ok, 0} == ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])
+    end, 30, timer:seconds(1)),
 
     %% Sending 1 packet
     DevNonce0 = crypto:strong_rand_bytes(2),
@@ -599,7 +607,9 @@ multiple_test(Config) ->
     true = check_sc_open(RouterNode, RouterChain, RouterPubkeyBin, ID),
 
     %% Check that the nonce of the sc server is okay
-    ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])),
+    ok = blockchain_ct_utils:wait_until(fun() ->
+        {ok, 0} == ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])
+    end, 30, timer:seconds(1)),
 
     %% Add some fake blocks
     FakeBlocks = 20,
@@ -636,7 +646,9 @@ multiple_test(Config) ->
     %% Checking that state channel got created properly
     true = check_sc_open(RouterNode, RouterChain, RouterPubkeyBin, ID2),
 
-    ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID2])),
+    ok = blockchain_ct_utils:wait_until(fun() ->
+        {ok, 0} == ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])
+    end, 30, timer:seconds(1)),
 
     %% Add some fake blocks
     FakeBlocks = 20,
@@ -856,7 +868,10 @@ multi_active_sc_test(Config) ->
     true = check_sc_open(RouterNode, RouterChain, RouterPubkeyBin, ID),
 
     %% Check that the nonce of the sc server is okay
-    ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])),
+    ok = blockchain_ct_utils:wait_until(fun() ->
+        {ok, 0} == ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])
+    end, 30, timer:seconds(1)),
+
 
     %% Sending 1 packet
     DevNonce0 = crypto:strong_rand_bytes(2),
@@ -1270,8 +1285,10 @@ crash_multi_sc_test(Config) ->
     true = check_sc_open(RouterNode, RouterChain, RouterPubkeyBin, ID2),
 
     %% Check that the nonce of the sc server is okay
-    ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID1])),
-    ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID2])),
+    ok = blockchain_ct_utils:wait_until(fun() ->
+        {ok, 0} == ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID1]) andalso
+        {ok, 0} == ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID2])
+    end, 30, timer:seconds(1)),
 
     %% look at sc server before sending the packet
     {_, _, _} = debug(RouterNode),
@@ -1433,7 +1450,10 @@ sc_gc_test(Config) ->
     true = check_sc_open(RouterNode, RouterChain, RouterPubkeyBin, ID),
 
     %% Check that the nonce of the sc server is okay
-    ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])),
+    ok = blockchain_ct_utils:wait_until(fun() ->
+        {ok, 0} == ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])
+    end, 30, timer:seconds(1)),
+
 
     %% Sending 1 packet
     DevNonce0 = crypto:strong_rand_bytes(2),
@@ -1514,8 +1534,10 @@ multi_sc_gc_test(Config) ->
     true = check_sc_open(RouterNode, RouterChain, RouterPubkeyBin, ID2),
 
     %% Check that the nonce of the sc server is okay
-    ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID1])),
-    ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID2])),
+    ok = blockchain_ct_utils:wait_until(fun() ->
+        {ok, 0} == ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID1]) andalso
+        {ok, 0} == ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID2])
+    end, 30, timer:seconds(1)),
 
     %% Sending 1 packet
     DevNonce0 = crypto:strong_rand_bytes(2),
@@ -1608,7 +1630,9 @@ crash_sc_sup_test(Config) ->
     true = check_sc_open(RouterNode, RouterChain, RouterPubkeyBin, ID),
 
     %% Check that the nonce of the sc server is okay
-    ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])),
+    ok = blockchain_ct_utils:wait_until(fun() ->
+        {ok, 0} == ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])
+    end, 30, timer:seconds(1)),
 
     %% Sending 1 packet
     DevNonce0 = crypto:strong_rand_bytes(2),
@@ -1758,7 +1782,10 @@ hotspot_in_router_oui_test(Config) ->
     true = check_sc_open(RouterNode, RouterChain, RouterPubkeyBin, ID),
 
     %% Check that the nonce of the sc server is okay
-    ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])),
+    ok = blockchain_ct_utils:wait_until(fun() ->
+        {ok, 0} == ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])
+    end, 30, timer:seconds(1)),
+
 
     %% Sending 1 packet
     DevNonce0 = crypto:strong_rand_bytes(2),
@@ -1859,7 +1886,10 @@ default_routers_test(Config) ->
     true = check_sc_open(RouterNode, RouterChain, RouterPubkeyBin, ID),
 
     %% Check that the nonce of the sc server is okay
-    ?assertEqual({ok, 0}, ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])),
+    ok = blockchain_ct_utils:wait_until(fun() ->
+        {ok, 0} == ct_rpc:call(RouterNode, blockchain_state_channels_server, nonce, [ID])
+    end, 30, timer:seconds(1)),
+
 
     %% Sending first packet and routing using the default routers
     DevNonce0 = crypto:strong_rand_bytes(2),


### PR DESCRIPTION
The SC handler was too parallel and it lost track of offers and
corresponding packets. Additionally it was validating packets more
thoroughly than offers. This branch attempts to require an offer to be
followed up with a matching packet, if the offer is accepted. If the
client sends another offer, that second offer is queued pending the
first offer being processed and the corresponding packet being sent, if
purchased.