### PR TITLE
Fix incorrect causality check

### DIFF
--- a/src/state_channel/blockchain_state_channel_handler.erl
+++ b/src/state_channel/blockchain_state_channel_handler.erl
@@ -115,10 +115,18 @@ init(server, _Conn, [_Path, Blockchain]) ->
 handle_data(client, Data, State) ->
     case blockchain_state_channel_message_v1:decode(Data) of
         {banner, Banner} ->
-            lager:info("sc_handler client got banner: ~p", [Banner]),
-            blockchain_state_channels_client:banner(Banner, self());
+            case blockchain_state_channel_banner_v1:sc(Banner) of
+                undefined ->
+                    %% empty banner, ignore
+                    ok;
+                BannerSC ->
+                    lager:info("sc_handler client got banner, sc_id: ~p",
+                               [blockchain_state_channel_v1:id(BannerSC)]),
+                    blockchain_state_channels_client:banner(Banner, self())
+            end;
         {purchase, Purchase} ->
-            lager:info("sc_handler client got purchase: ~p", [Purchase]),
+            lager:info("sc_handler client got purchase, sc_id: ~p",
+                       [blockchain_state_channel_v1:id(blockchain_state_channel_purchase_v1:sc(Purchase))]),
             blockchain_state_channels_client:purchase(Purchase, self());
         {reject, Rejection} ->
             lager:info("sc_handler client got rejection: ~p", [Rejection]),

--- a/src/state_channel/blockchain_state_channels_client.erl
+++ b/src/state_channel/blockchain_state_channels_client.erl
@@ -746,7 +746,8 @@ is_causally_correct_sc(SC, State) ->
             %% Check if SC is causally correct
             Check = (caused == blockchain_state_channel_v1:compare_causality(KnownSC, SC) orelse
                      equal == blockchain_state_channel_v1:compare_causality(KnownSC, SC)),
-            lager:info("causality check: ~p, this sc: ~p, known_sc: ~p", [Check, SC, KnownSC]),
+            lager:info("causality check: ~p, this sc_id: ~p, known_sc_id: ~p",
+                       [Check, SCID, blockchain_state_channel_v1:id(KnownSC)]),
             Check;
         {ok, KnownSCs} ->
             lager:error("multiple copies of state channels for id: ~p, found: ~p", [SCID, KnownSCs]),

--- a/src/state_channel/blockchain_state_channels_client.erl
+++ b/src/state_channel/blockchain_state_channels_client.erl
@@ -15,8 +15,8 @@
          purchase/2,
          banner/2,
          reject/2,
-         state/0,
          gc_state_channels/1,
+         get_known_channels/1,
          response/1]).
 
 %% ------------------------------------------------------------------
@@ -83,9 +83,9 @@ response(Resp) ->
 packet(Packet, DefaultRouters, Region) ->
     gen_server:cast(?SERVER, {packet, Packet, DefaultRouters, Region}).
 
--spec state() -> state().
-state() ->
-    gen_server:call(?SERVER, state).
+-spec get_known_channels(SCID :: blockchain_state_channel_v1:id()) -> {ok, [blockchain_state_channel_v1:state_channel()]} | {error, any()}.
+get_known_channels(SCID) ->
+    gen_server:call(?SERVER, {get_known_channels, SCID}).
 
 -spec purchase(Purchase :: blockchain_state_channel_purchase_v1:purchase(),
                HandlerPid :: pid()) -> ok.
@@ -215,8 +215,8 @@ handle_cast(_Msg, State) ->
     lager:debug("unhandled receive: ~p", [_Msg]),
     {noreply, State}.
 
-handle_call(state, _From, State) ->
-    {reply, {ok, State}, State};
+handle_call({get_known_channels, SCID}, _From, State) ->
+    {reply, get_state_channels(SCID, State), State};
 handle_call(_, _, State) ->
     {reply, ok, State}.
 


### PR DESCRIPTION
- Fix the causality check in sc client
- Add a debug application env var to output conflicting scs from sc client
- Add `is_causally_newer` fun to state channel module, enhance eunits for the same