### PR TITLE
Fix FSPL calculation

### DIFF
--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -242,7 +242,10 @@ score_tagged_gateways(Height, Ledger) ->
 free_space_path_loss(Loc1, Loc2) ->
     Distance = blockchain_utils:distance(Loc1, Loc2),
     %% TODO support regional parameters for non-US based hotspots
-    ?TRANSMIT_POWER - (32.44 + 20*math:log10(?FREQUENCY) + 20*math:log10(Distance) - ?MAX_ANTENNA_GAIN - ?MAX_ANTENNA_GAIN).
+    %% TODO support variable Dt,Dr values for better FSPL values
+    %% FSPL = 10log_10(Dt*Dr*((4*pi*f*d)/(c))^2)
+    %%
+    ?TRANSMIT_POWER - (10*math:log10((1.8*1.8)*math:pow((4*math:pi()*(?FREQUENCY*100000)*(Distance*100000))/(299792458), 2))).
 
 -spec vars_binary_keys_to_atoms(map()) -> map().
 vars_binary_keys_to_atoms(Vars) ->

--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -18,6 +18,7 @@
     distance/2,
     score_gateways/1,
     free_space_path_loss/2,
+    free_space_path_loss/3,
     vars_binary_keys_to_atoms/1,
     icdf_select/2,
     find_txn/2,
@@ -242,27 +243,40 @@ score_tagged_gateways(Height, Ledger) ->
 free_space_path_loss(Loc1, Loc2) ->
     Distance = blockchain_utils:distance(Loc1, Loc2),
     %% TODO support regional parameters for non-US based hotspots
-    %% TODO support variable Dt,Dr values for better FSPL values
-    %% FSPL = 10log_10(Dt*Dr*((4*pi*f*d)/(c))^2)
-    %%
-    (10*math:log10((1.8*1.8)*math:pow((4*math:pi()*(?FREQUENCY*100000)*(Distance*100000))/(299792458), 2))).
+    ?TRANSMIT_POWER - (32.44 + 20*math:log10(?FREQUENCY) + 20*math:log10(Distance) - ?MAX_ANTENNA_GAIN - ?MAX_ANTENNA_GAIN).
 
-free_space_path_loss(Loc1, Loc2, Gt, Gl) ->
-    Distance = blockchain_utils:distance(Loc1, Loc2),
+-spec free_space_path_loss(Loc1 :: h3:index(),
+                           Loc2 :: h3:index(),
+                           Ledger :: blockchain_ledger_v1:ledger()) -> float().
+free_space_path_loss(Loc1, Loc2, Ledger) ->
     %% TODO support regional parameters for non-US based hotspots
     %% TODO support variable Dt,Dr values for better FSPL values
     %% FSPL = 10log_10(Dt*Dr*((4*pi*f*d)/(c))^2)
-    %%
-    (10*math:log10((Gt*Gl)*math:pow((4*math:pi()*(?FREQUENCY*100000)*(Distance*100000))/(299792458), 2))).
 
-%% Subtract FSPL from our transmit power to get the expected minimum received signal.
--spec min_rcv_sig(float(), float()) -> float().
-min_rcv_sig(Fspl, TxGain) ->
-   TxGain - Fspl.
-min_rcv_sig(Fspl) ->
-   ?TRANSMIT_POWER - Fspl.
+    case poc_version(Ledger) of
+        {ok, V} when V >= 9 ->
+            %% Do the new and correct calculation
+            Distance = blockchain_utils:distance(Loc1, Loc2),
+            10*math:log10((1.8*1.8)*math:pow((4*math:pi()*(?FREQUENCY*100000)*(Distance*100000))/(299792458), 2));
+        _ ->
+            %% Keep doing the old FSPL calculation
+            free_space_path_loss(Loc1, Loc2)
+    end.
 
-
+%% free_space_path_loss(Loc1, Loc2, Gt, Gl) ->
+%%     Distance = blockchain_utils:distance(Loc1, Loc2),
+%%     %% TODO support regional parameters for non-US based hotspots
+%%     %% TODO support variable Dt,Dr values for better FSPL values
+%%     %% FSPL = 10log_10(Dt*Dr*((4*pi*f*d)/(c))^2)
+%%     %%
+%%     (10*math:log10((Gt*Gl)*math:pow((4*math:pi()*(?FREQUENCY*100000)*(Distance*100000))/(299792458), 2))).
+%% 
+%% %% Subtract FSPL from our transmit power to get the expected minimum received signal.
+%% -spec min_rcv_sig(float(), float()) -> float().
+%% min_rcv_sig(Fspl, TxGain) ->
+%%    TxGain - Fspl.
+%% min_rcv_sig(Fspl) ->
+%%    ?TRANSMIT_POWER - Fspl.
 
 -spec vars_binary_keys_to_atoms(map()) -> map().
 vars_binary_keys_to_atoms(Vars) ->
@@ -285,6 +299,13 @@ icdf_select(PopulationList, Rnd) ->
 find_txn(Block, PredFun) ->
     Txns = blockchain_block:transactions(Block),
     lists:filter(fun(T) -> PredFun(T) end, Txns).
+
+-spec poc_version(Ledger :: blockchain_ledger_v1:ledger()) -> undefined | non_neg_integer().
+poc_version(Ledger) ->
+    case blockchain:config(?poc_version, Ledger, undefined) of
+        undefined -> undefined;
+        {ok, V} -> V
+    end.
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions

--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -245,7 +245,7 @@ free_space_path_loss(Loc1, Loc2) ->
     %% TODO support variable Dt,Dr values for better FSPL values
     %% FSPL = 10log_10(Dt*Dr*((4*pi*f*d)/(c))^2)
     %%
-    ?TRANSMIT_POWER - (10*math:log10((1.8*1.8)*math:pow((4*math:pi()*(?FREQUENCY*100000)*(Distance*100000))/(299792458), 2))).
+    -(10*math:log10((1.8*1.8)*math:pow((4*math:pi()*(?FREQUENCY*100000)*(Distance*100000))/(299792458), 2))).
 
 -spec vars_binary_keys_to_atoms(map()) -> map().
 vars_binary_keys_to_atoms(Vars) ->

--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -245,7 +245,24 @@ free_space_path_loss(Loc1, Loc2) ->
     %% TODO support variable Dt,Dr values for better FSPL values
     %% FSPL = 10log_10(Dt*Dr*((4*pi*f*d)/(c))^2)
     %%
-    -(10*math:log10((1.8*1.8)*math:pow((4*math:pi()*(?FREQUENCY*100000)*(Distance*100000))/(299792458), 2))).
+    (10*math:log10((1.8*1.8)*math:pow((4*math:pi()*(?FREQUENCY*100000)*(Distance*100000))/(299792458), 2))).
+
+free_space_path_loss(Loc1, Loc2, Gt, Gl) ->
+    Distance = blockchain_utils:distance(Loc1, Loc2),
+    %% TODO support regional parameters for non-US based hotspots
+    %% TODO support variable Dt,Dr values for better FSPL values
+    %% FSPL = 10log_10(Dt*Dr*((4*pi*f*d)/(c))^2)
+    %%
+    (10*math:log10((Gt*Gl)*math:pow((4*math:pi()*(?FREQUENCY*100000)*(Distance*100000))/(299792458), 2))).
+
+%% Subtract FSPL from our transmit power to get the expected minimum received signal.
+-spec min_rcv_sig(float(), float()) -> float().
+min_rcv_sig(Fspl, TxGain) ->
+   TxGain - Fspl.
+min_rcv_sig(Fspl) ->
+   ?TRANSMIT_POWER - Fspl.
+
+
 
 -spec vars_binary_keys_to_atoms(map()) -> map().
 vars_binary_keys_to_atoms(Vars) ->


### PR DESCRIPTION
Want to get this in with 593 if possible.

Fixing FSPL calculation. The actual value of FSPL is the power required at a minimum in free space for two radios to hear each other (sorta not really the definition).

Depending on how this value is used in other modules, we may want to subtract transmit power somewhere else? (i.e. calculating link budget of which FSPL is a component)