### PR TITLE
Testing single arity get_channels

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -39,7 +39,7 @@
     {erlang_stats, ".*", {git, "https://github.com/helium/erlang-stats.git", {branch, "master"}}},
     {e2qc, ".*", {git, "https://github.com/project-fifo/e2qc", {branch, "master"}}},
     {vincenty, ".*", {git, "https://github.com/helium/vincenty", {branch, "master"}}},
-    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "master"}}},
+    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "adt/block-hash-in-receipts"}}},
     {merkerl, ".*", {git, "https://github.com/helium/merkerl.git", {branch, "master"}}},
     {xxhash, {git, "https://github.com/pierreis/erlang-xxhash", {branch, "master"}}},
     {exor_filter, ".*", {git, "https://github.com/Vagabond/exor_filter", {branch, "adt/binary_contains"}}}

--- a/rebar.lock
+++ b/rebar.lock
@@ -37,7 +37,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"fba7ad5a7e23da3035c7ace8c5033af3a42528cc"}},
+       {ref,"692c7c69925cacca0f7442e40c8c3b81ba6c9a7c"}},
   0},
  {<<"inert">>,
   {git,"https://github.com/msantos/inert",

--- a/rebar.lock
+++ b/rebar.lock
@@ -37,7 +37,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"692c7c69925cacca0f7442e40c8c3b81ba6c9a7c"}},
+       {ref,"f50590d29925b517310ce874b8d17e0506fa8898"}},
   0},
  {<<"inert">>,
   {git,"https://github.com/msantos/inert",

--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -15,12 +15,14 @@
 
 -export([
     new/4,
+    new/5,
     hash/1,
     onion_key_hash/1,
     challenger/1,
     secret/1,
     path/1,
     fee/1,
+    block_hash/1,
     signature/1,
     sign/2,
     is_valid/2,
@@ -61,6 +63,20 @@ new(Challenger, Secret, OnionKeyHash, Path) ->
         fee=0,
         signature = <<>>
     }.
+
+-spec new(libp2p_crypto:pubkey_bin(), binary(), binary(), binary(),
+          blockchain_poc_path_element_v1:path()) -> txn_poc_receipts().
+new(Challenger, Secret, OnionKeyHash, BlockHash, Path) ->
+    #blockchain_txn_poc_receipts_v1_pb{
+        challenger=Challenger,
+        secret=Secret,
+        onion_key_hash=OnionKeyHash,
+        path=Path,
+        fee=0,
+        block_hash=BlockHash,
+        signature = <<>>
+    }.
+
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -112,6 +128,9 @@ path(Txn) ->
 fee(_Txn) ->
     0.
 
+block_hash(Txn) ->
+    Txn#blockchain_txn_poc_receipts_v1_pb.block_hash.
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -150,7 +169,7 @@ is_valid(Txn, Chain) ->
                 true ->
                     {error, empty_path};
                 false ->
-                    case check_is_valid_poc(Txn, Chain, true) of
+                    case check_is_valid_poc(Txn, Chain) of
                         ok -> ok;
                         {ok, _} ->
                             ok;
@@ -160,9 +179,8 @@ is_valid(Txn, Chain) ->
     end.
 
 -spec check_is_valid_poc(Txn :: txn_poc_receipts(),
-                         Chain :: blockchain:blockchain(),
-                         RunValidation :: boolean()) -> ok | {ok, [non_neg_integer(), ...]} | {error, any()}.
-check_is_valid_poc(Txn, Chain, RunValidation) ->
+                         Chain :: blockchain:blockchain()) -> ok | {ok, [non_neg_integer(), ...]} | {error, any()}.
+check_is_valid_poc(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Challenger = ?MODULE:challenger(Txn),
     {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
@@ -314,21 +332,25 @@ check_is_valid_poc(Txn, Chain, RunValidation) ->
                                                                                       <<IntData:16/integer-unsigned-little>> = Layer,
                                                                                       IntData rem 8
                                                                               end, LayerData),
-                                                            %% We are on poc v9, check whether we need to run
-                                                            %% validation (presumably invoked from is_valid)
-                                                            case RunValidation of
-                                                                false ->
-                                                                    %% no need to run validations
+                                                            %% We are on poc v9
+                                                            %% %% run validations
+                                                            Ret = case POCVer > 10 of
+                                                                        true ->
+                                                                            %% check the block hash in the receipt txn is correct
+                                                                            case PoCAbsorbedAtBlockHash == ?MODULE:block_hash(Txn) of
+                                                                                true ->
+                                                                                    validate(Txn, Path, LayerData, LayerHashes, OldLedger);
+                                                                                false ->
+                                                                                    {error, bad_poc_receipt_block_hash}
+                                                                            end;
+                                                                        false ->
+                                                                            validate(Txn, Path, LayerData, LayerHashes, OldLedger)
+                                                                    end,
+                                                            maybe_log_duration(receipt_validation, StartV),
+                                                            case Ret of
+                                                                ok ->
                                                                     {ok, Channels};
-                                                                true ->
-                                                                    %% run validations
-                                                                    Ret = validate(Txn, Path, LayerData, LayerHashes, OldLedger),
-                                                                    maybe_log_duration(receipt_validation, StartV),
-                                                                    case Ret of
-                                                                        ok ->
-                                                                            {ok, Channels};
-                                                                        {error, _}=E -> E
-                                                                    end
+                                                                {error, _}=E -> E
                                                             end;
                                                         _ ->
                                                             %% We are not on poc v9, just do old behavior
@@ -1212,23 +1234,31 @@ get_channels(Txn, Chain) ->
     Secret = ?MODULE:secret(Txn),
     PathLength = length(Path),
 
-    %% Retry by walking the chain and attempt to find the last challenge block
     OnionKeyHash = ?MODULE:onion_key_hash(Txn),
     {ok, Head} = blockchain:head_block(Chain),
-    RequestFilter = fun(T) ->
-                            blockchain_txn:type(T) == blockchain_txn_poc_request_v1 andalso
-                            blockchain_txn_poc_request_v1:onion_key_hash(T) == OnionKeyHash
-                    end,
 
-    BlockHash = blockchain:fold_chain(fun(Block, undefined) ->
-                                              case blockchain_utils:find_txn(Block, RequestFilter) of
-                                                  [_T] ->
-                                                      blockchain_block:hash_block(Block);
-                                                  _ ->
-                                                      undefined
-                                              end;
-                                         (_, _Hash) -> return
-                                      end, undefined, Head, Chain),
+    BlockHash = case blockchain:config(?poc_version, blockchain:ledger(Chain)) of
+        {ok, POCVer} when POCVer >= 10 ->
+            ?MODULE:block_hash(Txn);
+        _ ->
+            %% Retry by walking the chain and attempt to find the last challenge block
+            %% Note that this does not scale at all and should not be used
+            RequestFilter = fun(T) ->
+                                    blockchain_txn:type(T) == blockchain_txn_poc_request_v1 andalso
+                                    blockchain_txn_poc_request_v1:onion_key_hash(T) == OnionKeyHash
+                            end,
+
+            blockchain:fold_chain(fun(Block, undefined) ->
+                                                      case blockchain_utils:find_txn(Block, RequestFilter) of
+                                                          [_T] ->
+                                                              blockchain_block:hash_block(Block);
+                                                          _ ->
+                                                              undefined
+                                                      end;
+                                                 (_, _Hash) -> return
+                                              end, undefined, Head, Chain)
+    end,
+
     case BlockHash of
         undefined ->
             {error, request_block_hash_not_found};

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -798,7 +798,7 @@ validate_var(?poc_challenge_interval, Value) ->
     validate_int(Value, "poc_challenge_interval", 10, 1440, false);
 validate_var(?poc_version, Value) ->
     case Value of
-        N when is_integer(N), N >= 1,  N =< 9 ->
+        N when is_integer(N), N >= 1,  N =< 10 ->
             ok;
         _ ->
             throw({error, {invalid_poc_version, Value}})


### PR DESCRIPTION
I'm only adding this as a suggestion since we are using this in some simulations which (for now) does not actually use the chain at all instead solely relying on the ledger. Having a `get_channels/1` fun will be useful once we add the request block hash to poc receipts.