### PR TITLE
Ensure oracle prices are recalculated while absorbing snapshot

### DIFF
--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -388,7 +388,8 @@ import(Chain, SHA,
 
                                       ok = blockchain_ledger_v1:maybe_gc_scs(Chain1),
 
-                                      ok = blockchain_ledger_v1:refresh_gateway_witnesses(Hash, Ledger2);
+                                      ok = blockchain_ledger_v1:refresh_gateway_witnesses(Hash, Ledger2),
+                                      ok = blockchain_ledger_v1:maybe_recalc_price(Chain1, Ledger2);
                                   _ ->
                                       ok
                               end


### PR DESCRIPTION
because I never merged #462, we missed a place for oracle calculation, in snapshot loading.