### PR TITLE
Add is_valid entries for poc_receipts/witnesses

### DIFF
--- a/src/transactions/v1/blockchain_poc_witness_v1.erl
+++ b/src/transactions/v1/blockchain_poc_witness_v1.erl
@@ -151,17 +151,22 @@ print(#blockchain_poc_witness_v1_pb{
                   ]).
 
 -spec to_json(poc_witness(), blockchain_json:opts()) -> blockchain_json:json_object().
-to_json(Witness, _Opts) ->
-    #{
-      gateway => ?BIN_TO_B58(gateway(Witness)),
-      timestamp => timestamp(Witness),
-      signal => signal(Witness),
-      packet_hash => ?BIN_TO_B64(packet_hash(Witness)),
-      snr => ?MAYBE_UNDEFINED(snr(Witness)),
-      frequency => ?MAYBE_UNDEFINED(frequency(Witness)),
-      channel => ?MAYBE_UNDEFINED(channel(Witness)),
-      datarate => ?MAYBE_UNDEFINED(datarate(Witness))
-     }.
+to_json(Witness, Opts) ->
+    Base = #{
+             gateway => ?BIN_TO_B58(gateway(Witness)),
+             timestamp => timestamp(Witness),
+             signal => signal(Witness),
+             packet_hash => ?BIN_TO_B64(packet_hash(Witness)),
+             snr => ?MAYBE_UNDEFINED(snr(Witness)),
+             frequency => ?MAYBE_UNDEFINED(frequency(Witness)),
+             channel => ?MAYBE_UNDEFINED(channel(Witness)),
+             datarate => ?MAYBE_UNDEFINED(datarate(Witness))
+            },
+    case lists:keyfind(is_valid, 1, Opts) of
+        false -> Base;
+        {is_valid, Valid} -> Base#{ is_valid => Valid }
+    end.
+
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -36,7 +36,7 @@
     poc_id/1,
     good_quality_witnesses/2,
     valid_witnesses/3,
-    get_channels/2, get_channels/1
+    get_channels/2
 ]).
 
 -ifdef(TEST).
@@ -668,9 +668,9 @@ good_quality_witnesses(Element, Ledger) ->
 
 %% Iterate over all poc_path elements and for each path element calls a given
 %% callback function with the valid witnesses and valid receipt.
-valid_path_elements_fold(Fun, Acc0, Txn, Ledger) ->
+valid_path_elements_fold(Fun, Acc0, Txn, Ledger, Chain) ->
     Path = ?MODULE:path(Txn),
-    {ok, Channels} = get_channels(Txn),
+    {ok, Channels} = get_channels(Txn, Chain),
     lists:foldl(fun({ElementPos, Element}, Acc) ->
                         {PreviousElement, ReceiptChannel, WitnessChannel} =
                             case ElementPos of
@@ -725,7 +725,7 @@ absorb(Txn, Chain) ->
                                                                   FR ->
                                                                       ok = blockchain_ledger_v1:insert_witnesses(Challengee, FilteredWitnesses ++ [FR], Ledger)
                                                               end
-                                                      end, ok, Txn, Ledger);
+                                                      end, ok, Txn, Ledger, Chain);
                     {ok, POCVersion} when POCVersion > 1 ->
                         %% Find upper and lower time bounds for this poc txn and use those to clamp
                         %% witness timestamps being inserted in the ledger
@@ -1017,25 +1017,26 @@ print_path(Path) ->
                           end,
                           Path), "\n\t").
 
--spec to_json(txn_poc_receipts(), blockchain_json:opts()) -> blockchain_json:json_object().
+-spec to_json(Txn :: txn_poc_receipts(),
+              Opts :: blockchain_json:opts()) -> blockchain_json:json_object().
 to_json(Txn, Opts) ->
     PathElems =
-        case lists:keyfind(ledger, 1, Opts) of
-            false ->
-                [{Elem, []} || Elem <- path(Txn)];
-            {ledger, Ledger} ->
-                case blockchain:config(?poc_version, Ledger) of
-                    {error, not_found} ->
-                        %% Older poc version, don't add validity
-                        [{Elem, []} || Elem <- path(Txn)];
-                    {ok, POCVersion} when POCVersion >= 9 ->
-                        valid_path_elements_fold(fun(Elem, {ValidWitnesses, ValidReceipt}, Acc) ->
-                                                         ElemOpts = [{valid_witnesses, ValidWitnesses},
-                                                                     {valid_receipt, ValidReceipt}],
-                                                         [{Elem, ElemOpts} | Acc]
-                                                 end, [], Txn, Ledger)
-                end
-        end,
+    case {lists:keyfind(ledger, 1, Opts), lists:keyfind(chain, 1, Opts)} of
+        {{ledger, Ledger}, {chain, Chain}} ->
+            case blockchain:config(?poc_version, Ledger) of
+                {ok, POCVersion} when POCVersion >= 10 ->
+                    valid_path_elements_fold(fun(Elem, {ValidWitnesses, ValidReceipt}, Acc) ->
+                                                     ElemOpts = [{valid_witnesses, ValidWitnesses},
+                                                                 {valid_receipt, ValidReceipt}],
+                                                     [{Elem, ElemOpts} | Acc]
+                                             end, [], Txn, Ledger, Chain);
+                _ ->
+                    %% Older poc version, don't add validity
+                    [{Elem, []} || Elem <- path(Txn)]
+            end;
+        {_, _} ->
+            [{Elem, []} || Elem <- path(Txn)]
+    end,
     #{
       type => <<"poc_receipts_v1">>,
       hash => ?BIN_TO_B64(hash(Txn)),
@@ -1296,38 +1297,6 @@ get_channels(Txn, Chain) ->
                                           IntData rem 8
                                   end, LayerData1),
             {ok, Channels1}
-    end.
-
-%%--------------------------------------------------------------------
-%% @doc
-%%
-%% This will only work poc-v10 onwards, but no check is made for
-%% that in this function.
-%%
-%% Furthermore, this is exposed so that `to_json` function for poc_receipt and
-%% poc_witness can use it.
-%%
-%% @end
-%%--------------------------------------------------------------------
--spec get_channels(Txn :: txn_poc_receipts()) -> {ok, [non_neg_integer()]} | {error, any()}.
-get_channels(Txn) ->
-    Challenger = ?MODULE:challenger(Txn),
-    Path = ?MODULE:path(Txn),
-    Secret = ?MODULE:secret(Txn),
-    PathLength = length(Path),
-    case ?MODULE:request_block_hash(Txn) of
-        <<>> ->
-            {error, request_block_hash_not_found};
-        undefined ->
-            {error, request_block_hash_not_found};
-        BH ->
-            Entropy = <<Secret/binary, BH/binary, Challenger/binary>>,
-            [_ | LayerData1] = blockchain_txn_poc_receipts_v1:create_secret_hash(Entropy, PathLength+1),
-            Channels = lists:map(fun(Layer) ->
-                                         <<IntData:16/integer-unsigned-little>> = Layer,
-                                         IntData rem 8
-                                 end, LayerData1),
-            {ok, Channels}
     end.
 
 %% ------------------------------------------------------------------


### PR DESCRIPTION
Passing in a ledger to txn_receipts_v1:to_json options will have the resulting json include is_valid entries for the receipts and witnesses. 