### PR TITLE
ignore some static in the fingerprinting

### DIFF
--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -540,8 +540,8 @@ raw_fingerprint(#ledger_v1{mode = Mode} = Ledger, Extended) ->
            state_channels = SCsCF,
            subnets = SubnetsCF
           } = SubLedger,
-        %% NB: keep in sync with upgrades macro in blockchain.erl
-        Filter = ?BC_UPGRADE_NAMES,
+        %% NB: remove multi_keys when they go live
+        Filter = ?BC_UPGRADE_NAMES ++ [<<"transaction_fee">>, <<"multi_keys">>],
         DefaultHash0 =
             cache_fold(
               Ledger, DefaultCF,


### PR DESCRIPTION
Due to some sloppiness in the snapshot upgrade process, some ledger default column families have picked up different unused and underused values over time.  This has led to some large but unimportant fingerprint drift as many snapshot-installed nodes have come onto the chain.  This ignores some of these issues so we can focus on cases where there is real, substantial drift.