### PR TITLE
Introduce poc_per_hop_max_witnesses chain variable

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -253,6 +253,8 @@
 -define(poc_good_bucket_high, poc_good_bucket_high).
 %% Maximum allowed h3 grid cells for a potential next hop
 -define(poc_max_hop_cells, poc_max_hop_cells).
+%% Maximum allow witnesses per hop
+-define(poc_per_hop_max_witnesses, poc_per_hop_max_witnesses).
 
 %% ------------------------------------------------------------------
 %%

--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -41,7 +41,8 @@
     min_rcv_sig/1, min_rcv_sig/2,
     index_of/2,
 
-    verify_multisig/3
+    verify_multisig/3,
+    poc_per_hop_max_witnesses/1
 ]).
 
 -ifdef(TEST).
@@ -53,6 +54,7 @@
 -define(FREQUENCY, 915).
 -define(TRANSMIT_POWER, 28).
 -define(MAX_ANTENNA_GAIN, 6).
+-define(POC_PER_HOP_MAX_WITNESSES, 5).
 
 -type zone_map() :: #{h3:index() => gateway_score_map()}.
 -type gateway_score_map() :: #{libp2p_crypto:pubkey_bin() => {blockchain_ledger_gateway_v2:gateway(), float()}}.
@@ -451,6 +453,16 @@ count_votes(Artifact, MultiKeys, [Proof | Proofs], Acc) ->
             count_votes(Artifact, lists:delete(GoodKey, MultiKeys),
                         Proofs, Acc + 1)
     end.
+
+-spec poc_per_hop_max_witnesses(Ledger :: blockchain_ledger_v1:ledger()) -> pos_integer().
+poc_per_hop_max_witnesses(Ledger) ->
+    case blockchain:config(?poc_per_hop_max_witnesses, Ledger) of
+        {ok, N} -> N;
+        _ ->
+            %% Defaulted to 5 to preserve backward compatability
+            ?POC_PER_HOP_MAX_WITNESSES
+    end.
+
 
 %% majority(N) ->
 %%     N div 2 + 1.

--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -955,7 +955,8 @@ validate(Txn, Path, LayerData, LayerHashes, OldLedger) ->
                                                    true ->
                                                        %% ok the receipt looks good, check the witnesses
                                                        Witnesses = blockchain_poc_path_element_v1:witnesses(Elem),
-                                                       case erlang:length(Witnesses) > 5 of
+                                                       PerHopMaxWitnesses = blockchain_utils:poc_per_hop_max_witnesses(OldLedger),
+                                                       case erlang:length(Witnesses) > PerHopMaxWitnesses of
                                                            true ->
                                                                {error, too_many_witnesses};
                                                            false ->

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -860,13 +860,7 @@ validate_var(?poc_centrality_wt, Value) ->
 validate_var(?poc_max_hop_cells, Value) ->
     validate_int(Value, "poc_max_hop_cells", 100, 4000, false);
 validate_var(?poc_per_hop_max_witnesses, Value) ->
-    case Value of
-        N when is_integer(N), N >= 5,  N =< 20 ->
-            ok;
-        _ ->
-            %% Defaulted to 5
-            5
-    end;
+    validate_int(Value, "poc_per_hop_max_witnesses", 5, 50, false);
 
 %% score vars
 validate_var(?alpha_decay, Value) ->

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -859,6 +859,14 @@ validate_var(?poc_centrality_wt, Value) ->
     validate_float(Value, "poc_centrality_wt", 0.0, 1.0);
 validate_var(?poc_max_hop_cells, Value) ->
     validate_int(Value, "poc_max_hop_cells", 100, 4000, false);
+validate_var(?poc_per_hop_max_witnesses, Value) ->
+    case Value of
+        N when is_integer(N), N >= 5,  N =< 20 ->
+            ok;
+        _ ->
+            %% Defaulted to 5
+            5
+    end;
 
 %% score vars
 validate_var(?alpha_decay, Value) ->


### PR DESCRIPTION
This adds validation for introducing a new chain variable `poc_per_hop_max_witnesses`. Currently this is defaulted to `5` miner side, but we'd like to be able to change via chain var in preparation for improvements to the proof-of-coverage mechanism.