### PR TITLE
datarate list fixups

### DIFF
--- a/include/blockchain_json.hrl
+++ b/include/blockchain_json.hrl
@@ -9,3 +9,4 @@
 -define (MAYBE_B58(B), blockchain_json:maybe_b58((B))).
 -define (MAYBE_B64(B), blockchain_json:maybe_b64((B))).
 -define (MAYBE_H3(B), blockchain_json:maybe_h3((B))).
+-define (MAYBE_LIST_TO_BINARY(L), blockchain_json:maybe_list_to_binary((L))).

--- a/src/blockchain_json.erl
+++ b/src/blockchain_json.erl
@@ -20,7 +20,8 @@
          maybe_fn/2,
          maybe_b64/1,
          maybe_b58/1,
-         maybe_h3/1
+         maybe_h3/1,
+         maybe_list_to_binary/1
         ]).
 
 %%
@@ -58,3 +59,11 @@ maybe_b58(V) ->
 -spec maybe_h3(undefined | h3:h3index()) -> undefined | binary().
 maybe_h3(V) ->
     maybe_fn(fun(I) -> list_to_binary(h3:to_string(I)) end, V).
+
+-spec maybe_list_to_binary(undefined | list()) -> undefined | binary().
+maybe_list_to_binary(V) ->
+    maybe_fn(fun ([]) -> undefined;
+                 (I) when is_list(I) -> list_to_binary(I);
+                 (<<>>) -> undefined;
+                 (I) when is_binary(I) -> I
+             end, V).

--- a/src/transactions/v1/blockchain_poc_receipt_v1.erl
+++ b/src/transactions/v1/blockchain_poc_receipt_v1.erl
@@ -127,7 +127,7 @@ snr(Receipt) ->
 frequency(Receipt) ->
     Receipt#blockchain_poc_receipt_v1_pb.frequency.
 
--spec datarate(Receipt :: poc_receipt()) -> binary().
+-spec datarate(Receipt :: poc_receipt()) -> list().
 datarate(Receipt) ->
     Receipt#blockchain_poc_receipt_v1_pb.datarate.
 
@@ -177,7 +177,7 @@ to_json(Receipt, _Opts) ->
       snr => ?MAYBE_UNDEFINED(snr(Receipt)),
       frequency => ?MAYBE_UNDEFINED(frequency(Receipt)),
       channel => ?MAYBE_UNDEFINED(channel(Receipt)),
-      datarate => ?MAYBE_UNDEFINED(datarate(Receipt))
+      datarate => ?MAYBE_UNDEFINED(?MAYBE_LIST_TO_BINARY(datarate(Receipt)))
      }.
 
 %% ------------------------------------------------------------------

--- a/src/transactions/v1/blockchain_poc_witness_v1.erl
+++ b/src/transactions/v1/blockchain_poc_witness_v1.erl
@@ -115,7 +115,7 @@ frequency(Witness) ->
 channel(Witness) ->
     Witness#blockchain_poc_witness_v1_pb.channel.
 
--spec datarate(Witness :: poc_witness()) -> binary().
+-spec datarate(Witness :: poc_witness()) -> list().
 datarate(Witness) ->
     Witness#blockchain_poc_witness_v1_pb.datarate.
 
@@ -160,7 +160,7 @@ to_json(Witness, Opts) ->
              snr => ?MAYBE_UNDEFINED(snr(Witness)),
              frequency => ?MAYBE_UNDEFINED(frequency(Witness)),
              channel => ?MAYBE_UNDEFINED(channel(Witness)),
-             datarate => ?MAYBE_UNDEFINED(datarate(Witness))
+             datarate => ?MAYBE_UNDEFINED(?MAYBE_LIST_TO_BINARY(datarate(Witness)))
             },
     case lists:keyfind(is_valid, 1, Opts) of
         false -> Base;
@@ -219,10 +219,10 @@ encode_decode_test() ->
     ?assertEqual({witness, Witness}, blockchain_poc_response_v1:decode(blockchain_poc_response_v1:encode(Witness))).
 
 to_json_test() ->
-    Witness = new(<<"gateway">>, 1, 12, <<"hash">>),
+    Witness = new(<<"gateway">>, 1, 12, <<"hash">>, 9.8, 915.2, 8, "SF12BW500"),
     Json = to_json(Witness, []),
     ?assert(lists:all(fun(K) -> maps:is_key(K, Json) end,
-                      [gateway, timestamp, signal, packet_hash])).
+                      [gateway, timestamp, signal, packet_hash, datarate])).
 
 new2_test() ->
     Witness = #blockchain_poc_witness_v1_pb{


### PR DESCRIPTION
datarate in receipt and witness record is a _string_ not a binary. This fixes the to_json use for data rate to convert the data rate string to a binary