### PR TITLE
Add timeout for outbound dials

### DIFF
--- a/src/state_channel/blockchain_state_channels_client.erl
+++ b/src/state_channel/blockchain_state_channels_client.erl
@@ -552,7 +552,7 @@ dial(Swarm, Address) when is_list(Address) ->
                       ok;
                   {'DOWN', R, process, P, _Reason} ->
                       Self ! {dial_fail, Address, _Reason}
-              after 30000 ->
+              after application:get_env(blockchain, sc_packet_dial_timeout, 30000) ->
                       erlang:exit(P, kill),
                       Self ! {dial_fail, Address, timeout}
               end
@@ -595,7 +595,7 @@ dial(Swarm, Route) ->
                       ok;
                   {'DOWN', R, process, P, _Reason} ->
                       Self ! {dial_fail, OUI, failed}
-              after 30000 ->
+              after application:get_env(blockchain, sc_packet_dial_timeout, 30000) ->
                       erlang:exit(P, kill),
                       Self ! {dial_fail, OUI, timeout}
               end

--- a/src/state_channel/blockchain_state_channels_client.erl
+++ b/src/state_channel/blockchain_state_channels_client.erl
@@ -552,6 +552,9 @@ dial(Swarm, Address) when is_list(Address) ->
                       ok;
                   {'DOWN', R, process, P, _Reason} ->
                       Self ! {dial_fail, Address, _Reason}
+              after 30000 ->
+                      erlang:exit(P, kill),
+                      Self ! {dial_fail, Address, timeout}
               end
       end),
     ok;
@@ -592,6 +595,9 @@ dial(Swarm, Route) ->
                       ok;
                   {'DOWN', R, process, P, _Reason} ->
                       Self ! {dial_fail, OUI, failed}
+              after 30000 ->
+                      erlang:exit(P, kill),
+                      Self ! {dial_fail, OUI, timeout}
               end
       end),
     ok.


### PR DESCRIPTION
On my local system I noticed that the sc client state would keep packets in the waiting queue forever if for some reason the outbound dial to one of the router(s) was either unverified or stuck; this should clear it after 30s. It's debatable whether we should be dropping them but if you can't succeed in 30s there's not much to do there.