### PR TITLE
Filter downed packet streams

### DIFF
--- a/src/state_channel/blockchain_state_channels_client.erl
+++ b/src/state_channel/blockchain_state_channels_client.erl
@@ -307,13 +307,19 @@ handle_info({blockchain_event, {add_block, BlockHash, _Syncing, Ledger}},
                                            end
                                    end, [], SCs),
     {noreply, State#state{pending_closes=lists:usort(PendingCloses ++ ClosingChannels ++ ExpiringChannels)}};
-handle_info({'DOWN', _Ref, process, Pid, _}, #state{streams=Streams}=State) ->
+handle_info({'DOWN', _Ref, process, Pid, _}, #state{streams=Streams, packets=Packets}=State) ->
     FilteredStreams = maps:filter(fun(_Name, {unverified, Stream}) ->
                                           Stream /= Pid;
                                      (_Name, Stream) ->
                                           Stream /= Pid
                                   end, Streams),
-    {noreply, State#state{streams=FilteredStreams}};
+
+    %% Keep the streams which don't have downed pid, given we're monitoring correctly
+    FilteredPackets = maps:filter(fun(StreamPid, _PacketQueue) ->
+                                          StreamPid /= Pid
+                                  end, Packets),
+
+    {noreply, State#state{streams=FilteredStreams, packets=FilteredPackets}};
 handle_info(_Msg, State) ->
     lager:warning("rcvd unknown info msg: ~p", [_Msg]),
     {noreply, State}.

--- a/src/state_channel/blockchain_state_channels_client.erl
+++ b/src/state_channel/blockchain_state_channels_client.erl
@@ -212,6 +212,7 @@ handle_info({dial_success, AddressOrOUI, Stream}, #state{chain=undefined}=State)
     %% NOTE: We don't keep the packets we were waiting on as we lost the chain, maybe we should?
     NewState = case find_stream(AddressOrOUI, State) of
                    undefined ->
+                       erlang:monitor(process, Stream),
                        add_stream(AddressOrOUI, Stream, State);
                    _ ->
                        State


### PR DESCRIPTION
I've altered `find_stream` in the state channel client to `find_alive_stream`; this should return `undefined` when the stream has died for any reason and it went unhandled in the client. This should also allow `handle_packet` to add packet to the waiting queue instead of trying to send an offer over a dead stream.

Open to any suggestions. Also, wondering if we should also invoke `delete_stream` if the stream process isn't alive?