### PR TITLE
Implement a DC to HNT scaling factor when paying rewards in 1:1 mode

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -307,6 +307,8 @@
 -define(sc_causality_fix, sc_causality_fix).
 %% Block interval to try to GC state channels
 -define(sc_gc_interval, sc_gc_interval).
+%% When rewarding DCs 1:1 in HNT, a scaling factor to reduce the scope for arbitrage
+-define(sc_dc_to_hnt_scaling_factor, sc_dc_to_hnt_scaling_factor).
 
 
 %% ------------------------------------------------------------------

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -981,7 +981,8 @@ validate_var(?sc_causality_fix, Value) ->
     validate_int(Value, "sc_causality_fix", 1, 1, false);
 validate_var(?sc_gc_interval, Value) ->
     validate_int(Value, "sc_gc_interval", 10, 100, false);
-
+validate_var(?sc_dc_to_hnt_scaling_factor, Value) ->
+    validate_float(Value, "sc_dc_to_hnt_scaling_factor", 0.5, 1.5);
 
 %% txn snapshot vars
 validate_var(?snapshot_version, Value) ->


### PR DESCRIPTION
Currently there exists an arbitrage opportunity when the value at which
you burned HNT into DC is lower than the value you spend it. This PR
adds a scaling factor (which was originally proposed in HIP 10 but later
removed) so that arbitrage amounts under some percentage can be
prevented. For example, if this value was set to 0.9 there would have to
be a greater than 10% spread between the value of HNT at burn time and
the value of HNT at spend time to be able to make a profit. Naturally
this does not close long-term arbitrage holes but it prevents
front-running the oracle price in all but the most extreme adjustment
periods.