### PR TITLE
WIP: Add new targeting module

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -360,5 +360,15 @@
 %%
 -define(data_aggregation_version, data_aggregation_version).
 
+%% ------------------------------------------------------------------
 %% Multi-key
 -define(use_multi_keys, use_multi_keys).
+
+
+%% ------------------------------------------------------------------
+%% POC Rate Limiting
+%%
+%% Number of times a hotspot is allowed to beacon in a day
+-define(poc_challenges_per_block, poc_challenges_per_block).
+%% Hotspot considered inactive if current_height - last_poc_challenge >= poc_consider_inactive
+-define(poc_consider_inactive, poc_consider_inactive).

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -245,7 +245,7 @@
                                     blockchain_ledger_state_channel_v1:state_channel()
                                     | blockchain_ledger_state_channel_v2:state_channel_v2()}.
 
--export_type([ledger/0]).
+-export_type([ledger/0, active_gateways/0]).
 
 -spec new(file:filename_all()) -> ledger().
 new(Dir) ->

--- a/src/poc/blockchain_poc_target_v4.erl
+++ b/src/poc/blockchain_poc_target_v4.erl
@@ -1,0 +1,82 @@
+%%%-----------------------------------------------------------------------------
+%%% @doc blockchain_poc_target_v4 implementation.
+%%%
+%%% Refer HIP-X: TBD
+%%%
+%%%-----------------------------------------------------------------------------
+-module(blockchain_poc_target_v4).
+
+-include("blockchain_utils.hrl").
+-include("blockchain_vars.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-export([poc_interval/1]).
+
+-spec poc_interval(Ledger :: blockchain_ledger_v1:ledger()) -> {ok, pos_integer()} |
+                                                               {error, any()}.
+poc_interval(Ledger) ->
+    N = maps:size(blockchain_ledger_v1:active_gateways(Ledger)),
+    %% TODO: maybe filter depending on
+    %% - location exists for hospot
+    %% - last_poc_challenge is not extremely stale (controlled by poc_consider_inactive)
+    %% - has not poc-ed in X number of blocks
+    Y = poc_challenges_per_block(Ledger),
+    floor(N div Y).
+
+-spec poc_challenges_per_block(Ledger :: blockchain_ledger_v1:ledger()) ->
+    undefined | pos_integer().
+poc_challenges_per_block(Ledger) ->
+    case blockchain:config(?poc_challenges_per_block, Ledger) of
+        {ok, K} -> K;
+        _ -> undefined
+    end.
+
+%% -spec block_time(Ledger :: blockchain_ledger_v1:ledger()) -> pos_integer().
+%% block_time(Ledger) ->
+%%     case blockchain:config(?block_time, Ledger) of
+%%         {ok, K} -> K;
+%%         _ -> undefined
+%%     end.
+
+%% -spec poc_consider_inactive(Ledger :: blockchain_ledger_v1:ledger()) -> undefined | pos_integer().
+%% poc_consider_inactive(Ledger) ->
+%%     case blockchain:config(?poc_consider_inactive, Ledger) of
+%%         {ok, K} -> K;
+%%         _ -> undefined
+%%     end.
+
+
+%% ------------------------------------------------------------------
+%% EUNIT Tests
+%% ------------------------------------------------------------------
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+basic_test() ->
+    %% poc_challenges_per_block
+    POCChallengesPerBlockRange = lists:reverse(lists:seq(70, 150, 20)),
+    NetworkSizeRange = lists:seq(10000, 110000, 1000),
+
+    Res = lists:foldl(fun(Size, Acc) ->
+                              Ans = lists:foldl(fun(Y, Acc2) ->
+                                                      maps:put(Y, floor(Size div Y), Acc2)
+                                              end, #{}, POCChallengesPerBlockRange),
+                              maps:put(Size, Ans, Acc)
+                      end, #{}, NetworkSizeRange),
+
+    io:format("Res: ~p~n", [Res]),
+
+    %% Check that when we hit 20K, 50K, 75K, 100K hotspots, the poc_interval goes up
+
+    POCInterval1 = maps:get(70, maps:get(20000, Res)),
+    POCInterval2 = maps:get(70, maps:get(20000, Res)),
+    POCInterval3 = maps:get(70, maps:get(20000, Res)),
+
+    ?assert(POCInterval3 > POCInterval2 > POCInterval1),
+
+    ok.
+
+-endif.

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1063,6 +1063,14 @@ validate_var(?use_multi_keys, Value) ->
         _ -> throw({error, {invalid_multi_keys, Value}})
     end;
 
+
+%% POC Rate limiting vars
+validate_var(?poc_challenges_per_block, Value) ->
+    validate_int(Value, "poc_challenges_per_block", 1, 200, false);
+validate_var(?poc_consider_inactive, Value) ->
+    validate_int(Value, "poc_consider_inactive", 1, 10, false);
+
+
 validate_var(Var, Value) ->
     %% something we don't understand, crash
     invalid_var(Var, Value).


### PR DESCRIPTION
This adds poc challenge rate limiting with logarithmic scaling on
network size. It's controlled using several newly introduced chain
variables.

This allows us to ensure consistent block times and gives us more
control on how many POCs we want to have per block as the network
continues to grow.

New variables:

- poc_beacons_per_day: Number of times a hotspot is allowed to beacon in a day
- poc_log_base: Step size to control logarithm scale base
- poc_rate_k: Extra control parameter as the network grows
- poc_consider_inactive: Hotspot considered inactive if (current_height - last_poc_challenge >= poc_consider_inactive)

There is also a corresponding eqc included here which tests how many
hotspots are getting targeted depending on the current ledger.