### PR TITLE
add extra not_found handler in leger_v1:current_height

### DIFF
--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -618,6 +618,8 @@ current_height(Ledger) ->
             {ok, Height};
         not_found ->
             {ok, 0};
+        {error, not_found} ->
+            {ok, 0};
         Error ->
             Error
     end.


### PR DESCRIPTION
It looks like rocksdb can return an {error, not_found} which is separate from the not_found error that is also returnable. 

I _think_ this addresses the problem where a fresh etl sync breaks as soon as the ledger tries to pick up the first block. Which results in the following stack trace: 

```
2020-10-31 20:11:44.666 [info] <0.1353.0>@blockchain:resync_fun:2128 absorbing block 2
2020-10-31 20:11:44.666 [info] <0.1353.0>@blockchain_txn:validate:233 valid: [], invalid: []
2020-10-31 20:11:44.668 [warning] <0.1353.0>@blockchain:run_gc_hooks:2244 hooks failed error {badmatch,{error,not_found}}
    blockchain:resync_fun/3 line 2123
    lists:foreach/2 line 1338
    blockchain:'-resync_fun/3-fun-10-'/2 line 2133
    blockchain_txn:unvalidated_absorb_and_commit/4 line 370
    blockchain:'-resync_fun/3-fun-7-'/2 line 2126
    blockchain:run_gc_hooks/2 line 2238
    blockchain_ledger_v1:maybe_gc_scs/1 line 1533
error:{badmatch,{error,not_found}}
2020-10-31 20:11:44.669 [warning] <0.1225.0>@blockchain_worker:handle_info:560 Resync process exited with reason {{badmatch,{error,gc_hooks_failed}},[{blockchain,'-resync_fun/3-fun-7-',2,[{file,"/home/ubuntu/blockchain-etl/_build/default/lib/blockchain/src/blockchain.erl"},{line,2126}]},{blockchain_txn,unvalidated_absorb_and_commit,4,[{file,"/home/ubuntu/blockchain-etl/_build/default/lib/blockchain/src/transactions/blockchain_txn.erl"},{line,370}]},{blockchain,'-resync_fun/3-fun-10-',2,[{file,"/home/ubuntu/blockchain-etl/_build/default/lib/blockchain/src/blockchain.erl"},{line,2133}]},{lists,foreach,2,[{file,"lists.erl"},{line,1338}]},{blockchain,resync_fun,3,[{file,"/home/ubuntu/blockchain-etl/_build/default/lib/blockchain/src/blockchain.erl"},{line,2123}]}]}, retrying 3 more times
```