### PR TITLE
Codify implicit sorting of oracle submissions before txn close & fix …

### DIFF
--- a/src/handlers/blockchain_sync_handler.erl
+++ b/src/handlers/blockchain_sync_handler.erl
@@ -115,6 +115,7 @@ handle_data(client, Data0, #state{blockchain=Chain, path=Path}=State) ->
         ok ->
             {noreply, State, blockchain_sync_handler_pb:encode_msg(#blockchain_sync_req_pb{msg={response, true}})};
         _Error ->
+            lager:info("Error adding blocks ~p", [_Error]),
             %% TODO: maybe dial for sync again?
             {stop, normal, State, blockchain_sync_handler_pb:encode_msg(#blockchain_sync_req_pb{msg={response, false}})}
     end;

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -109,8 +109,9 @@
     {blockchain_txn_payment_v2, 19},
     {blockchain_txn_state_channel_open_v1, 20},
     {blockchain_txn_update_gateway_oui_v1, 21},
-    {blockchain_txn_state_channel_close_v1, 22},
-    {blockchain_txn_transfer_hotspot_v1, 23}
+    {blockchain_txn_price_oracle_v1, 22},
+    {blockchain_txn_state_channel_close_v1, 23},
+    {blockchain_txn_transfer_hotspot_v1, 24}
 ]).
 
 block_delay() ->
@@ -636,7 +637,7 @@ type_order(Txn) ->
     Type = type(Txn),
     case lists:keyfind(Type, 1, ?ORDER) of
         {Type, Index} -> Index;
-        false -> erlang:length(?ORDER)
+        false -> erlang:length(?ORDER) + 1
     end.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
…issue

The implicit txn ordering behaviour if a transaction did not have a
defined sort order can cause instability in the sort order when a new
transaction is added, because the undefined sort order was the same as
the last sort order. This could lead to the transaction without a
defined sort order sorting before the transaction with a defined sort
order (because of the other sort dimensions like nonces, etc).This means
that adding another transaction to the end of the sort order list would
cause the transaction with the implicit sort order to definitely sort
after the transaction it may have sorted before earlier, invalidating
the block.

This change establishes a definitive sort order for the oracle price
report txn to mirror the implicit sort order before the addition of the
hotspot transfer function. Additionally it makes the undefined sort
order one past the maximum to prevent this bug recurring and it add a
log message to the sync_handler to make this failure clearer.

This *may* expose other implicit sort ordering bugs, so a thorough
resync (or at least ordering check of txns in blocks) is recommended.