### PR TITLE
Add sort order for routing_v1, token_burn_v1

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -784,7 +784,23 @@ can_add_block(Block, Blockchain) ->
                                             SortedTxns = lists:sort(fun blockchain_txn:sort/2, Txns),
                                             case Txns == SortedTxns of
                                                 false ->
-                                                    {error, wrong_txn_order};
+                                                    %% this double check is for just one block as
+                                                    %% far as we know; there was a bug with a few
+                                                    %% txns not being in the sorting order and they
+                                                    %% got in there wrong in that one block
+                                                    Filter =
+                                                        fun(T) ->
+                                                                blockchain_txn:type(T) /= blockchain_txn_state_channel_close_v1
+                                                        end,
+                                                    Txns2 = lists:filter(Filter, Txns),
+                                                    Sorted2 = lists:filter(Filter, SortedTxns),
+                                                    SortedTxns2 = lists:sort(fun blockchain_txn:sort/2, Sorted2),
+                                                    case Txns2 == SortedTxns2 of
+                                                        false ->
+                                                            {error, wrong_txn_order};
+                                                        true ->
+                                                            {true, IsRescue}
+                                                    end;
                                                 true ->
                                                     {true, IsRescue}
                                             end

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -113,11 +113,7 @@
     {blockchain_txn_price_oracle_v1, 23},
     {blockchain_txn_token_burn_v1, 24},
     {blockchain_txn_state_channel_close_v1, 25},
-    {blockchain_txn_transfer_hotspot_v1, 26},
-    %% UNUSED just added for completeness
-    {blockchain_txn_bundle_v1, 27},
-    %% UNUSED just added for completeness
-    {blockchain_txn_gen_price_oracle_v1, 28}
+    {blockchain_txn_transfer_hotspot_v1, 26}
 ]).
 
 block_delay() ->

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -104,14 +104,20 @@
     {blockchain_txn_add_gateway_v1, 14},
     {blockchain_txn_assert_location_v1, 15},
     {blockchain_txn_redeem_htlc_v1, 16},
-    {blockchain_txn_poc_request_v1, 17},
-    {blockchain_txn_poc_receipts_v1, 18},
-    {blockchain_txn_payment_v2, 19},
-    {blockchain_txn_state_channel_open_v1, 20},
-    {blockchain_txn_update_gateway_oui_v1, 21},
-    {blockchain_txn_price_oracle_v1, 22},
-    {blockchain_txn_state_channel_close_v1, 23},
-    {blockchain_txn_transfer_hotspot_v1, 24}
+    {blockchain_txn_routing_v1, 17},
+    {blockchain_txn_poc_request_v1, 18},
+    {blockchain_txn_poc_receipts_v1, 19},
+    {blockchain_txn_payment_v2, 20},
+    {blockchain_txn_state_channel_open_v1, 21},
+    {blockchain_txn_update_gateway_oui_v1, 22},
+    {blockchain_txn_price_oracle_v1, 23},
+    {blockchain_txn_token_burn_v1, 24},
+    {blockchain_txn_state_channel_close_v1, 25},
+    {blockchain_txn_transfer_hotspot_v1, 26},
+    %% UNUSED just added for completeness
+    {blockchain_txn_bundle_v1, 27},
+    %% UNUSED just added for completeness
+    {blockchain_txn_gen_price_oracle_v1, 28}
 ]).
 
 block_delay() ->


### PR DESCRIPTION
Also added txn_buncld and gen_price_oracle (both unused) to have the
complete list there.

routing_v1: blocks 552480, 550829, and  490139