### PR TITLE
don't allow any unsortable txn to validate

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -784,7 +784,23 @@ can_add_block(Block, Blockchain) ->
                                             SortedTxns = lists:sort(fun blockchain_txn:sort/2, Txns),
                                             case Txns == SortedTxns of
                                                 false ->
-                                                    {error, wrong_txn_order};
+                                                    %% this double check is for just one block as
+                                                    %% far as we know; there was a bug with a few
+                                                    %% txns not being in the sorting order and they
+                                                    %% got in there wrong in that one block
+                                                    Filter =
+                                                        fun(T) ->
+                                                                blockchain_txn:type(T) /= blockchain_txn_state_channel_close_v1
+                                                        end,
+                                                    Txns2 = lists:filter(Filter, Txns),
+                                                    Sorted2 = lists:filter(Filter, SortedTxns),
+                                                    SortedTxns2 = lists:sort(fun blockchain_txn:sort/2, Sorted2),
+                                                    case Txns2 == SortedTxns2 of
+                                                        false ->
+                                                            {error, wrong_txn_order};
+                                                        true ->
+                                                            {true, IsRescue}
+                                                    end;
                                                 true ->
                                                     {true, IsRescue}
                                             end


### PR DESCRIPTION
this will make sure that we don't allow anything not in the sort order to get onto the chain.