### PR TITLE
hip 17 merge cleanup

### DIFF
--- a/src/blockchain_hex.erl
+++ b/src/blockchain_hex.erl
@@ -15,7 +15,7 @@
 -define(DENSITY_MEMO_TBL, '__blockchain_hex_density_memoization_tbl').
 -define(ETS_OPTS, [named_table, public]).
 
--type density_map() :: #{h3:h3_index() => pos_integer()}.
+-type density_map() :: #{h3:h3_index() => non_neg_integer()}.
 -type densities() :: {UnclippedDensities :: density_map(), ClippedDensities :: density_map()}.
 -type var_map() :: #{0..12 => map()}.
 -type locations() :: #{h3:h3_index() => [libp2p_crypto:pubkey_bin(), ...]}.

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -314,6 +314,7 @@ import(Chain, SHA,
          oui_counter := OUICounter,
 
          hexes := Hexes,
+         h3dex := H3dex,
 
          state_channels := StateChannels,
 
@@ -369,6 +370,7 @@ import(Chain, SHA,
                  ok = blockchain_ledger_v1:set_oui_counter(OUICounter, Ledger),
 
                  ok = blockchain_ledger_v1:load_hexes(Hexes, Ledger),
+                 ok = blockchain_ledger_v1:load_h3dex(H3dex, Ledger),
 
                  ok = blockchain_ledger_v1:load_state_channels(StateChannels, Ledger),
 
@@ -1216,6 +1218,8 @@ diff(A, B) ->
                                   {ADiffs, BDiffs} ->
                                       [{Field, [Height || {Height, _Hash} <- ADiffs], [Height || {Height, _Hash} <- BDiffs]} | Acc]
                               end;
+                          h3dex ->
+                              [{Field, length(AI), length(BI)} | Acc];
                           _ ->
                               [Field | Acc]
                       end

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -3582,15 +3582,9 @@ load_hexes(Hexes0, Ledger) ->
     end.
 
 snapshot_h3dex(Ledger) ->
-    H3CF = h3dex_cf(Ledger),
     lists:sort(
       maps:to_list(
-        cache_fold(
-          Ledger, H3CF,
-          fun({Loc, GWs}, Acc) ->
-                  maps:put(<<Loc:64/unsigned-integer-big>>, binary_to_term(GWs), Acc)
-          end, #{},
-          []))).
+        get_h3dex(Ledger))).
 
 load_h3dex(H3DexList, Ledger) ->
     set_h3dex(maps:from_list(H3DexList), Ledger).

--- a/test/blockchain_reward_perf_SUITE.erl
+++ b/test/blockchain_reward_perf_SUITE.erl
@@ -89,7 +89,7 @@ end_per_testcase(_TestCase, _Config) ->
     ok.
 
 all() ->
-    [].
+    [reward_perf_test].
 
 reward_perf_test(Config) ->
     Chain = ?config(chain, Config),
@@ -124,7 +124,7 @@ reward_perf_test(Config) ->
           end),
     ct:pal("hip 17 calc took: ~p ms", [Time3 div 1000]),
 
-    error(print),
+    %% error(print),
     ok.
 
 

--- a/test/blockchain_snapshot_SUITE.erl
+++ b/test/blockchain_snapshot_SUITE.erl
@@ -47,6 +47,14 @@ end_per_testcase(_, _Config) ->
 %%--------------------------------------------------------------------
 basic_test(_Config) ->
     Ledger = ledger(),
+    case blockchain_ledger_v1:get_h3dex(Ledger) of
+        #{} ->
+            LedgerBoot = blockchain_ledger_v1:new_context(Ledger),
+            blockchain:bootstrap_h3dex(LedgerBoot),
+            blockchain_ledger_v1:commit_context(LedgerBoot);
+        _ -> ok
+    end,
+
     {ok, Snapshot} = blockchain_ledger_snapshot_v1:snapshot(Ledger, []),
 
     %% make a dir for the loaded snapshot


### PR DESCRIPTION
during the confusion of the release it appears that a few things got missed out:

- we weren't dialyzer clean
- snapshots got broken by a merge
- filtering for 0 population hexes got rebases away somehow.

This PR should fix all of those.