### PR TITLE
fix bad snap binary tag

### DIFF
--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -182,7 +182,7 @@ serialize(Snapshot, BlocksP) ->
     BinSz = byte_size(Bin),
 
     %% do some simple framing with version, size, & snap
-    Snap = <<4, %% version
+    Snap = <<5, %% version
              BinSz:32/little-unsigned-integer, Bin/binary>>,
     {ok, Snap}.
 

--- a/test/blockchain_snapshot_SUITE.erl
+++ b/test/blockchain_snapshot_SUITE.erl
@@ -63,7 +63,8 @@ basic_test(_Config) ->
     NewDir = PrivDir ++ "/ledger2/",
     ok = filelib:ensure_dir(NewDir),
 
-    Size = byte_size(element(2, blockchain_ledger_snapshot_v1:serialize(Snapshot))),
+    {ok, BinSnap} = blockchain_ledger_snapshot_v1:serialize(Snapshot),
+    Size = byte_size(BinSnap),
     SHA = blockchain_ledger_snapshot_v1:hash(Snapshot),
     ct:pal("size ~p", [Size]),
 
@@ -75,7 +76,9 @@ basic_test(_Config) ->
 
     {ok, Chain} = blockchain:new(NewDir, GenesisBlock, blessed_snapshot, undefined),
 
-    {ok, Ledger1} = blockchain_ledger_snapshot_v1:import(Chain, SHA, Snapshot),
+    {ok, SnapshotA} = blockchain_ledger_snapshot_v1:deserialize(BinSnap),
+
+    {ok, Ledger1} = blockchain_ledger_snapshot_v1:import(Chain, SHA, SnapshotA),
     {ok, Snapshot1} = blockchain_ledger_snapshot_v1:snapshot(Ledger1, []),
 
     ?assertEqual([], blockchain_ledger_snapshot_v1:diff(Snapshot, Snapshot1)),


### PR DESCRIPTION
The snapshot binary tag wasn't updated so now new snaps are going down the wrong path for deserialization.

This PR fixes the tag and enhances the test so this cannot slip through again.