### PR TITLE
Expose tagged_witnesses to use with ETL

### DIFF
--- a/src/transactions/v1/blockchain_poc_path_element_v1.erl
+++ b/src/transactions/v1/blockchain_poc_path_element_v1.erl
@@ -91,13 +91,16 @@ to_json(Elem, Opts) ->
             {valid_receipt, _} -> [{is_valid, true}]
         end,
     Witnesses =
-        case lists:keyfind(valid_witnesses, 1, Opts) of
+        case lists:keyfind(tagged_witnesses, 1, Opts) of
             false ->
                 [{W, []} || W <- witnesses(Elem)];
-            {valid_witnesses, ValidWitnesses} ->
-                lists:map(fun(W) ->
-                                  {W, [{is_valid, lists:member(W, ValidWitnesses)}]}
-                          end, witnesses(Elem))
+            {tagged_witnesses, TaggedWitnesses} ->
+                lists:map(fun
+                              ({true, _, W}) ->
+                                  {W, [{is_valid, true}]};
+                              ({false, InvalidReason, W}) ->
+                                  {W, [{is_valid, false}, {invalid_reason, InvalidReason}]}
+                          end, TaggedWitnesses)
         end,
     #{
       challengee => ?BIN_TO_B58(challengee(Elem)),

--- a/src/transactions/v1/blockchain_poc_witness_v1.erl
+++ b/src/transactions/v1/blockchain_poc_witness_v1.erl
@@ -152,7 +152,7 @@ print(#blockchain_poc_witness_v1_pb{
 
 -spec to_json(poc_witness(), blockchain_json:opts()) -> blockchain_json:json_object().
 to_json(Witness, Opts) ->
-    Base = #{
+    Base0 = #{
              gateway => ?BIN_TO_B58(gateway(Witness)),
              timestamp => timestamp(Witness),
              signal => signal(Witness),
@@ -162,9 +162,13 @@ to_json(Witness, Opts) ->
              channel => ?MAYBE_UNDEFINED(channel(Witness)),
              datarate => ?MAYBE_UNDEFINED(?MAYBE_LIST_TO_BINARY(datarate(Witness)))
             },
-    case lists:keyfind(is_valid, 1, Opts) of
+    Base = case lists:keyfind(is_valid, 1, Opts) of
+               false -> Base0;
+               {is_valid, Valid} -> Base0#{ is_valid => Valid }
+           end,
+    case lists:keyfind(invalid_reason, 1, Opts) of
         false -> Base;
-        {is_valid, Valid} -> Base#{ is_valid => Valid }
+        {invalid_reason, InvalidReason} -> Base#{ invalid_reason => InvalidReason }
     end.
 
 


### PR DESCRIPTION
Didn't really want to mess around with `valid_witnesses` because it requires changing critical logic in _several_ other places. Instead wrote a separate function `tagged_witnesses` which does NOT filter witnesses instead just adds a boolean and a reason tag to each witness and passed it down to the `to_json` function for both poc receipt txn and poc path element.

Unfortunately this introduces some code duplication but I think we can live with it (assuming that this indeed works)