### PR TITLE
Dont insert self witnesses with poc-v11

### DIFF
--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -737,7 +737,7 @@ absorb(Txn, Chain) ->
                     {error, not_found} ->
                         %% Older poc version, don't add witnesses
                         ok;
-                    {ok, POCVersion} when POCVersion >= 10 ->
+                    {ok, POCVersion} when POCVersion >= 11 ->
                         %% Add filtered witnesses and remove self-witnessing with poc-v10
                         ok = valid_path_elements_fold(fun(Element, {FilteredWitnesses, FilteredReceipt}, _) ->
                                                               Challengee = blockchain_poc_path_element_v1:challengee(Element),

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -830,7 +830,7 @@ validate_var(?poc_challenge_interval, Value) ->
     validate_int(Value, "poc_challenge_interval", 10, 1440, false);
 validate_var(?poc_version, Value) ->
     case Value of
-        N when is_integer(N), N >= 1,  N =< 10 ->
+        N when is_integer(N), N >= 1,  N =< 20 ->
             ok;
         _ ->
             throw({error, {invalid_poc_version, Value}})


### PR DESCRIPTION
This extends witness filtering to not insert a challengee as a witness of itself. We've seen that happening on rare occasions. This change is guarded behind `poc_version` chain var which would have to be incremented to 11 for this to take effect.

Note that the witness gc would remove any self witness records from the ledger, this does not address that.