### PR TITLE
Handle failed scale calc for ETL

### DIFF
--- a/src/blockchain_hex.erl
+++ b/src/blockchain_hex.erl
@@ -44,8 +44,14 @@ scale(Location, Ledger) ->
             case get_target_res(Ledger) of
                 {error, _}=E -> E;
                 {ok, TargetRes} ->
-                    S = scale(Location, VarMap, TargetRes, Ledger),
-                    {ok, S}
+                    try
+                        S = scale(Location, VarMap, TargetRes, Ledger),
+                        {ok, S}
+                    catch What:Why:ST ->
+                        {ok, CurHeight} = blockchain_ledger_v1:current_height(Ledger),
+                        lager:error("failed to calculate scale for location: ~p, ~p:~p:~p", [Location, What, Why, ST]),
+                        {error, {failed_scale_calc, Location, CurHeight}}
+                    end
             end
     end.
 


### PR DESCRIPTION
Fixes https://github.com/helium/blockchain-core/issues/717

This isn't an ideal fix but we already do a try/catch in the rewards txn when the scale/4 calculation fails. This just does it so that ETL can also continue to ingest blocks.