### PR TITLE
Extend PoC validation

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -149,6 +149,9 @@
 %% during targeting
 -define(poc_witness_consideration_limit, poc_witness_consideration_limit).
 
+%% Maximum number of times hotspot A is allowed to witness some other hotspot B
+-define(poc_witnessing_max, poc_witnessing_max).
+
 %%%
 %%% score vars
 %%%

--- a/rebar.config
+++ b/rebar.config
@@ -68,6 +68,7 @@
 
 {profiles, [
     {test, [
+        {erl_opts, [nowarn_export_all]},
         {deps, [{meck, "0.8.12"}]}
     ]},
     {eqc, [

--- a/src/ledger/v1/blockchain_ledger_gateway_v2.erl
+++ b/src/ledger/v1/blockchain_ledger_gateway_v2.erl
@@ -26,6 +26,7 @@
     has_witness/2,
     clear_witnesses/1,
     remove_witness/2,
+    lookup_witness_count/2,
     witnesses/1,
     witnesses_plain/1,
     witness_hist/1, witness_recent_time/1, witness_first_time/1,
@@ -483,6 +484,16 @@ has_witness(#gateway_v2{witnesses=Witnesses}, WitnessAddr) ->
         _ -> true
     end.
 
+-spec lookup_witness_count(gateway(), libp2p_crypto:pubkey_bin()) -> undefined | non_neg_integer().
+lookup_witness_count(#gateway_v2{witnesses=Witnesses}, WitnessAddr) ->
+    case lists:keyfind(WitnessAddr, 1, Witnesses) of
+        false ->
+            %% no witness found
+            undefined;
+        {_, Witness} ->
+            witness_count(Witness)
+    end.
+
 -spec witnesses(gateway()) -> #{libp2p_crypto:pubkey_bin() => gateway_witness()}.
 witnesses(Gateway) ->
     maps:from_list(Gateway#gateway_v2.witnesses).
@@ -494,6 +505,10 @@ witnesses_plain(Gateway) ->
 -spec witness_hist(gateway_witness()) -> erlang:error(no_histogram) | histogram().
 witness_hist(Witness) ->
     maps:from_list(Witness#witness.hist).
+
+-spec witness_count(gateway_witness()) -> undefined | non_neg_integer().
+witness_count(Witness) ->
+    Witness#witness.count.
 
 -spec witness_recent_time(gateway_witness()) -> undefined | non_neg_integer().
 witness_recent_time(Witness) ->

--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -41,6 +41,7 @@
 ]).
 
 -ifdef(TEST).
+-export([check_witness_allowed_count/3]).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -873,6 +873,8 @@ validate_var(?poc_v4_randomness_wt, Value) ->
     validate_float(Value, "poc_v4_randomness_wt", 0.0, 1.0);
 validate_var(?poc_v5_target_prob_randomness_wt, Value) ->
     validate_float(Value, "poc_v5_target_prob_randomness_wt", 0.0, 1.0);
+validate_var(?poc_witnessing_max, Value) ->
+    validate_int(Value, "poc_witnessing_max", 1, 50, false);
 validate_var(?poc_typo_fixes, Value) ->
     case Value of
         true -> ok;

--- a/test/blockchain_witness_SUITE.erl
+++ b/test/blockchain_witness_SUITE.erl
@@ -1,0 +1,126 @@
+-module(blockchain_witness_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-include("blockchain_vars.hrl").
+
+-export([
+    all/0,
+    init_per_testcase/2,
+    end_per_testcase/2,
+    init_per_suite/1,
+    end_per_suite/1
+]).
+
+-export([
+    with_vars_max_witnessing_test/1,
+    without_vars_max_witnessing_test/1
+]).
+
+-define(POC_WITNESSING_MAX, 5).
+%% WITNESS has seen BEACONER more than 5 times in the pinned ledger
+-define(BEACONER, "11UAmz1HPHKbNXE5Wd5un5Koe6TLS4Qdn13ChXFhw4NBgWF2ehX").
+-define(WITNESS, "112A3u9QpjQmzfk5WPLCCDUoME3hsPRWTGUuWooxXbw8KsxAHJDL").
+
+all() ->
+    [
+        with_vars_max_witnessing_test,
+        without_vars_max_witnessing_test
+    ].
+
+%%--------------------------------------------------------------------
+%% TEST SUITE SETUP
+%%--------------------------------------------------------------------
+init_per_suite(Config) ->
+    LedgerURL = "https://blockchain-core.s3-us-west-1.amazonaws.com/ledger-687973.tar.gz",
+    Ledger = blockchain_ct_utils:download_ledger(LedgerURL),
+    [{ledger, Ledger} | Config].
+
+%%--------------------------------------------------------------------
+%% TEST CASE SETUP
+%%--------------------------------------------------------------------
+init_per_testcase(TestCase, Config) ->
+    Ledger0 = ?config(ledger, Config),
+
+    ExtraVars =
+        case TestCase of
+            without_vars_max_witnessing_test -> #{};
+            with_vars_max_witnessing_test -> poc_max_witnessing_var()
+        end,
+
+    Ledger = blockchain_ct_utils:apply_extra_vars(ExtraVars, Ledger0),
+
+    Ledger1 = blockchain_ledger_v1:new_context(Ledger),
+    blockchain:bootstrap_h3dex(Ledger1),
+    blockchain_ledger_v1:commit_context(Ledger1),
+    blockchain_ledger_v1:compact(Ledger),
+
+    %% Check that the pinned ledger is at the height we expect it to be
+    {ok, 687973} = blockchain_ledger_v1:current_height(Ledger),
+
+    [
+        {ledger, Ledger},
+        {beaconer_pubkey_bin, libp2p_crypto:b58_to_bin(?BEACONER)},
+        {witness_pubkey_bin, libp2p_crypto:b58_to_bin(?WITNESS)}
+        | Config
+    ].
+
+%%--------------------------------------------------------------------
+%% TEST CASE TEARDOWN
+%%--------------------------------------------------------------------
+end_per_testcase(_, Config) ->
+    Ledger0 = ?config(ledger, Config),
+    Ledger = blockchain_ct_utils:remove_var(poc_witnessing_max, Ledger0),
+    [{ledger, Ledger} | Config].
+
+%%--------------------------------------------------------------------
+%% TEST SUITE TEARDOWN
+%%--------------------------------------------------------------------
+end_per_suite(_Config) ->
+    %% destroy the downloaded ledger
+    blockchain_ct_utils:destroy_ledger(),
+    ok.
+
+%%--------------------------------------------------------------------
+%% TEST CASES
+%%--------------------------------------------------------------------
+
+with_vars_max_witnessing_test(Config) ->
+    Ledger = ?config(ledger, Config),
+    WitnessPubkeyBin = ?config(witness_pubkey_bin, Config),
+    BeaconerPubkeyBin = ?config(beaconer_pubkey_bin, Config),
+    {ok, ?POC_WITNESSING_MAX} = blockchain:config(?poc_witnessing_max, Ledger),
+    {ok, BeaconGW} = blockchain_gateway_cache:get(BeaconerPubkeyBin, Ledger),
+
+    %% As the vars are set, it's expected that this check returns false
+    false = blockchain_txn_poc_receipts_v1:check_witness_allowed_count(
+        BeaconGW,
+        WitnessPubkeyBin,
+        Ledger
+    ),
+
+    ok.
+
+without_vars_max_witnessing_test(Config) ->
+    Ledger = ?config(ledger, Config),
+    WitnessPubkeyBin = ?config(witness_pubkey_bin, Config),
+    BeaconerPubkeyBin = ?config(beaconer_pubkey_bin, Config),
+    {error, not_found} = blockchain:config(?poc_witnessing_max, Ledger),
+    {ok, BeaconGW} = blockchain_gateway_cache:get(BeaconerPubkeyBin, Ledger),
+
+    %% The var is not set, this should return true
+    true = blockchain_txn_poc_receipts_v1:check_witness_allowed_count(
+        BeaconGW,
+        WitnessPubkeyBin,
+        Ledger
+    ),
+
+    ok.
+
+%%--------------------------------------------------------------------
+%% CHAIN VARIABLES
+%%--------------------------------------------------------------------
+
+poc_max_witnessing_var() ->
+    #{poc_witnessing_max => ?POC_WITNESSING_MAX}.


### PR DESCRIPTION
The goal here is to extend PoC validation by utilizing witness_count that are captured in the gateway ledger record.

#### TODO:
- [x] Introduce a new chain variable (`poc_witnessing_max`)
- [x] Extend poc validation to filter witnesses who have reached `poc_witnessing_max`
~~- [ ] Maybe allow poc_version to go higher than `10`, propose 50 and do the extra validation with `poc_version=11` + `max_witness_count`~~