### PR TITLE
speed up ledger cli

### DIFF
--- a/src/cli/blockchain_cli_ledger.erl
+++ b/src/cli/blockchain_cli_ledger.erl
@@ -183,9 +183,9 @@ ledger_fold(Verbose) ->
     Ledger = get_ledger(),
     blockchain_ledger_v1:cf_fold(
       active_gateways,
-      fun({_Addr, BinGw}, Acc) ->
+      fun({Addr, BinGw}, Acc) ->
               Gw = blockchain_ledger_gateway_v2:deserialize(BinGw),
-              [format_ledger_gateway_entry(Gw, Ledger, Verbose) | Acc]
+              [format_ledger_gateway_entry({Addr, Gw}, Ledger, Verbose) | Acc]
       end,
       [],
       Ledger).

--- a/src/ledger/v1/blockchain_ledger_gateway_v2.erl
+++ b/src/ledger/v1/blockchain_ledger_gateway_v2.erl
@@ -306,21 +306,21 @@ print(Address, Gateway, Ledger, Verbose) ->
         fun(undefined) -> "undefined";
            (I) -> Height - I
         end,
-    {NewAlpha, NewBeta, Score} = score(Address, Gateway, Height, Ledger),
     Scoring =
         case Verbose of
             true ->
-                [
-                 {alpha, alpha(Gateway)},
-                 {new_alpha, NewAlpha},
-                 {beta, beta(Gateway)},
-                 {new_beta, NewBeta},
-                 {delta, Height - delta(Gateway)}
+                {NewAlpha, NewBeta, Score} = score(Address, Gateway, Height, Ledger),
+                [ 
+                  {score, Score},
+                  {alpha, alpha(Gateway)},
+                  {new_alpha, NewAlpha},
+                  {beta, beta(Gateway)},
+                  {new_beta, NewBeta},
+                  {delta, Height - delta(Gateway)}
                 ];
             _ -> []
         end,
     [
-     {score, Score},
      {owner_address, libp2p_crypto:pubkey_bin_to_p2p(owner_address(Gateway))},
      {location, UndefinedHandleFunc(location(Gateway))},
      {last_poc_challenge, PocUndef(last_poc_challenge(Gateway))},


### PR DESCRIPTION
the command `miner ledger gateways` was doing a lot of extraneous work and keeping a lot of extra stuff in memory when preparing the command for printing.   this PR trims extraneous work and does fewer conversions, producing the formatted entries directly.  