### PR TITLE
Bump to cross-compilable H3

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -37,7 +37,7 @@
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
  {<<"h3">>,
   {git,"https://github.com/helium/erlang-h3.git",
-       {ref,"8541da45596549e36bdbf82dcb77f19c8608e9d4"}},
+       {ref,"cdc3a10fb5ad79e1ba01893bebcd28d6944851f1"}},
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",


### PR DESCRIPTION
We've been avoiding bumping H3 for a while because it wasn't cross-compilable. That was fixed in https://github.com/helium/erlang-h3/pull/25