### PR TITLE
Allow for testnet keys

### DIFF
--- a/eqc/path_eqc.erl
+++ b/eqc/path_eqc.erl
@@ -208,7 +208,7 @@ generate_keys(N, Type) ->
       fun(_, Acc) ->
               #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(Type),
               SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
-              [{libp2p_crypto:pubkey_to_bin(PubKey), {PubKey, PrivKey, SigFun}}|Acc]
+              [{blockchain_utils:pubkey_to_bin(PubKey), {PubKey, PrivKey, SigFun}}|Acc]
       end,
       [],
       lists:seq(1, N)).

--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -82,6 +82,11 @@
 -define(predicate_callback_mod, predicate_callback_mod). %% Currently set to: miner
 -define(predicate_callback_fun, predicate_callback_fun). %% Currently set to: version
 
+%% The network this blockchain operations on. This variable is used to initialize
+%%  the chain to mainnet or testnet. The chain defaults to mainnet unless
+%% this variable is set to something else (i.e. testnet)
+-define(network, network).
+
 %%%
 %%% miner vars
 %%%

--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -1800,7 +1800,7 @@ add_gateway_txn(OwnerB58, PayerB58, Fee, StakingFee) ->
                 _ -> libp2p_crypto:b58_to_bin(PayerB58)
             end,
     {ok, PubKey, SigFun, _ECDHFun} =  blockchain_swarm:keys(),
-    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+    PubKeyBin = blockchain_utils:pubkey_to_bin(PubKey),
     Txn0 = blockchain_txn_add_gateway_v1:new(Owner, PubKeyBin, Payer),
     Txn = blockchain_txn_add_gateway_v1:staking_fee(blockchain_txn_add_gateway_v1:fee(Txn0, Fee), StakingFee),
     SignedTxn = blockchain_txn_add_gateway_v1:sign_request(Txn, SigFun),
@@ -1810,7 +1810,7 @@ add_gateway_txn(OwnerB58, PayerB58, Fee, StakingFee) ->
 %% the gateway, and the given owner and payer
 %%
 %% NOTE: This is an alternative add_gateway creation that calculates the fee and
-%% staking fee from the current live blockchain. 
+%% staking fee from the current live blockchain.
 -spec add_gateway_txn(OwnerB58::string(),
                       PayerB58::string() | undefined) -> {ok, binary()}.
 add_gateway_txn(OwnerB58, PayerB58) ->
@@ -1822,7 +1822,7 @@ add_gateway_txn(OwnerB58, PayerB58) ->
             end,
     Chain = blockchain_worker:blockchain(),
     {ok, PubKey, SigFun, _ECDHFun} =  blockchain_swarm:keys(),
-    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+    PubKeyBin = blockchain_utils:pubkey_to_bin(PubKey),
     Txn0 = blockchain_txn_add_gateway_v1:new(Owner, PubKeyBin, Payer),
     StakingFee = blockchain_txn_add_gateway_v1:calculate_staking_fee(Txn0, Chain),
     Txn1 = blockchain_txn_add_gateway_v1:staking_fee(Txn0, StakingFee),
@@ -1857,7 +1857,7 @@ assert_loc_txn(H3String, OwnerB58, PayerB58, Nonce, StakingFee, Fee) ->
                 _ -> libp2p_crypto:b58_to_bin(PayerB58)
             end,
     {ok, PubKey, SigFun, _ECDHFun} =  blockchain_swarm:keys(),
-    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+    PubKeyBin = blockchain_utils:pubkey_to_bin(PubKey),
     Txn0 = blockchain_txn_assert_location_v1:new(PubKeyBin, Owner, Payer, H3Index, Nonce),
     Txn = blockchain_txn_assert_location_v1:staking_fee(blockchain_txn_assert_location_v1:fee(Txn0, Fee), StakingFee),
     SignedTxn = blockchain_txn_assert_location_v1:sign_request(Txn, SigFun),
@@ -1882,7 +1882,7 @@ assert_loc_txn(H3String, OwnerB58, PayerB58, Nonce) ->
                 _ -> libp2p_crypto:b58_to_bin(PayerB58)
             end,
     {ok, PubKey, SigFun, _ECDHFun} =  blockchain_swarm:keys(),
-    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+    PubKeyBin = blockchain_utils:pubkey_to_bin(PubKey),
     Chain = blockchain_worker:blockchain(),
     Txn0 = blockchain_txn_assert_location_v1:new(PubKeyBin, Owner, Payer, H3Index, Nonce),
     StakingFee = blockchain_txn_assert_location_v1:calculate_staking_fee(Txn0, Chain),
@@ -2372,7 +2372,7 @@ blocks_test_() ->
              {ok, Pid} = blockchain_lock:start_link(),
 
              #{secret := Priv, public := Pub} = libp2p_crypto:generate_keys(ecc_compact),
-             BinPub = libp2p_crypto:pubkey_to_bin(Pub),
+             BinPub = blockchain_utils:pubkey_to_bin(Pub),
 
              Vars = #{chain_vars_version => 2},
              Txn = blockchain_txn_vars_v1:new(Vars, 1, #{master_key => BinPub}),
@@ -2447,7 +2447,7 @@ get_block_test_() ->
              {ok, Pid} = blockchain_lock:start_link(),
 
              #{secret := Priv, public := Pub} = libp2p_crypto:generate_keys(ecc_compact),
-             BinPub = libp2p_crypto:pubkey_to_bin(Pub),
+             BinPub = blockchain_utils:pubkey_to_bin(Pub),
 
              Vars = #{chain_vars_version => 2},
              Txn = blockchain_txn_vars_v1:new(Vars, 1, #{master_key => BinPub}),

--- a/src/blockchain_block_v1.erl
+++ b/src/blockchain_block_v1.erl
@@ -295,7 +295,7 @@ verify_normal_signatures(Artifact, ConsensusMembers, Signatures, Threshold) ->
           fun({Addr, Sig}) ->
                   case
                       lists:member(Addr, ConsensusMembers)
-                      andalso libp2p_crypto:verify(Artifact, Sig, libp2p_crypto:bin_to_pubkey(Addr))
+                      andalso libp2p_crypto:verify(Artifact, Sig, blockchain_utils:bin_to_pubkey(Addr))
                   of
                       true -> {Addr, Sig};
                       false ->
@@ -334,7 +334,7 @@ verify_rescue_signature(EncodedBlock, RescueSigs, Keys) when is_list(Keys) ->
             false
     end;
 verify_rescue_signature(EncodedBlock, RescueSig, Key) ->
-    case libp2p_crypto:verify(EncodedBlock, RescueSig, libp2p_crypto:bin_to_pubkey(Key)) of
+    case libp2p_crypto:verify(EncodedBlock, RescueSig, blockchain_utils:bin_to_pubkey(Key)) of
         true ->
             {true, RescueSig, true};
         false ->
@@ -503,7 +503,7 @@ generate_keys(N) ->
         fun(_, Acc) ->
             #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
             SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
-            [{libp2p_crypto:pubkey_to_bin(PubKey), {PubKey, PrivKey, SigFun}}|Acc]
+            [{blockchain_utils:pubkey_to_bin(PubKey), {PubKey, PrivKey, SigFun}}|Acc]
         end,
         [],
         lists:seq(1, N)

--- a/src/cli/blockchain_cli_ledger.erl
+++ b/src/cli/blockchain_cli_ledger.erl
@@ -191,7 +191,7 @@ ledger_fold(Verbose) ->
       Ledger).
 
 format_ledger_gateway_entry({GatewayAddr, Gateway}, Ledger, Verbose) ->
-    {ok, Name} = erl_angry_purple_tiger:animal_name(libp2p_crypto:pubkey_to_b58(libp2p_crypto:bin_to_pubkey(GatewayAddr))),
+    {ok, Name} = erl_angry_purple_tiger:animal_name(libp2p_crypto:pubkey_to_b58(blockchain_utils:bin_to_pubkey(GatewayAddr))),
     [{gateway_address, libp2p_crypto:pubkey_bin_to_p2p(GatewayAddr)},
      {name, Name} |
      blockchain_ledger_gateway_v2:print(GatewayAddr, Gateway, Ledger, Verbose)].

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -35,6 +35,8 @@
     vars/3,
     config/2,  % no version with default, use the set value or fail
 
+    network/1,
+
     vars_nonce/1, vars_nonce/2,
     save_threshold_txn/2,
 
@@ -271,7 +273,7 @@ new(Dir) ->
      SubnetsCF, SCsCF, H3DexCF, GwDenormCF, DelayedDefaultCF, DelayedAGwsCF, DelayedEntriesCF,
      DelayedDCEntriesCF, DelayedHTLCsCF, DelayedPoCsCF, DelayedSecuritiesCF,
      DelayedRoutingCF, DelayedSubnetsCF, DelayedSCsCF, DelayedH3DexCF, DelayedGwDenormCF] = CFs,
-    #ledger_v1{
+    Ledger = #ledger_v1{
         dir=Dir,
         db=DB,
         mode=active,
@@ -304,7 +306,10 @@ new(Dir) ->
             state_channels=DelayedSCsCF,
             h3dex=DelayedH3DexCF
         }
-    }.
+    },
+    {ok, Network} = network(Ledger),
+    blockchain_utils:set_network(Network),
+    Ledger.
 
 -spec mode(ledger()) -> active | delayed.
 mode(Ledger) ->
@@ -953,6 +958,13 @@ config(ConfigName, Ledger) ->
             {error, not_found};
         Error ->
             Error
+    end.
+
+network(Ledger) ->
+    case config(?network, Ledger) of
+        {ok, Network} -> {ok, Network};
+        {error, not_found} -> {ok, mainnet};
+        Error -> Error
     end.
 
 vars_nonce(Ledger) ->

--- a/src/poc/blockchain_poc_packet.erl
+++ b/src/poc/blockchain_poc_packet.erl
@@ -54,7 +54,7 @@
 %% If the decryption fails, return `error'.
 -spec decrypt(Packet :: binary(), ECDHFun :: libp2p_crypto:ecdh_fun(), BlockHash :: binary(), Ledger :: blockchain_ledger_v1:ledger()) -> error | {Payload :: binary(), NextLayer :: binary()}.
 decrypt(<<IV0:16/integer-unsigned-little, OnionCompactKey:33/binary, Tag:4/binary, CipherText/binary>>, ECDHFun, BlockHash, Ledger) ->
-    try libp2p_crypto:bin_to_pubkey(OnionCompactKey) of
+    try blockchain_utils:bin_to_pubkey(OnionCompactKey) of
         PubKey ->
             SecretKey = ECDHFun(PubKey),
             IV = <<0:80/integer, IV0:16/integer-unsigned-little>>,
@@ -85,7 +85,7 @@ decrypt(<<IV0:16/integer-unsigned-little, OnionCompactKey:33/binary, Tag:4/binar
             Ledger :: blockchain_ledger_v1:ledger()) -> {OuterLayer :: binary(), Layers :: [binary()]}.
 build(#{secret := OnionPrivKey, public := OnionPubKey}, IV, PubKeysAndData, BlockHash, Ledger) ->
     ECDHFun = libp2p_crypto:mk_ecdh_fun(OnionPrivKey),
-    OnionCompactKey = libp2p_crypto:pubkey_to_bin(OnionPubKey),
+    OnionCompactKey = blockchain_utils:pubkey_to_bin(OnionPubKey),
     N = length(PubKeysAndData),
 
     {Keys, Data} = lists:unzip(PubKeysAndData),
@@ -306,7 +306,7 @@ encrypt_decrypt_single_layer(Ledger) ->
     ?assertEqual(SecretKey1, SecretKey2),
     {<<"abc">>, Remainder1} = decrypt(OuterPacket, libp2p_crypto:mk_ecdh_fun(PrivKey1), BlockHash, Ledger),
     ?assert(lists:all(fun(E) -> E == error end, [ decrypt(OuterPacket, libp2p_crypto:mk_ecdh_fun(PK), BlockHash, Ledger) || PK <- PrivKeys -- [PrivKey1]])),
-    OnionCompactKey = libp2p_crypto:pubkey_to_bin(PubOnionKey),
+    OnionCompactKey = blockchain_utils:pubkey_to_bin(PubOnionKey),
     %ExpectedIV = IV+1,
     <<_IV:16/integer-unsigned-little, OnionCompactKey:33/binary, _Rest/binary>> = Remainder1,
     %% check all packets are the same length
@@ -346,7 +346,7 @@ encrypt_decrypt_double_layer(Ledger) ->
     ?assertEqual(SecretKey1, SecretKey2),
     {<<"abc">>, Remainder1} = decrypt(OuterPacket, libp2p_crypto:mk_ecdh_fun(PrivKey1), BlockHash, Ledger),
     ?assert(lists:all(fun(E) -> E == error end, [ decrypt(OuterPacket, libp2p_crypto:mk_ecdh_fun(PK), BlockHash, Ledger) || PK <- PrivKeys -- [PrivKey1]])),
-    OnionCompactKey = libp2p_crypto:pubkey_to_bin(PubOnionKey),
+    OnionCompactKey = blockchain_utils:pubkey_to_bin(PubOnionKey),
     %ExpectedIV = IV+1,
     <<_IV:16/integer-unsigned-little, OnionCompactKey:33/binary, _Rest/binary>> = Remainder1,
     {<<"def">>, Remainder2} = decrypt(Remainder1, libp2p_crypto:mk_ecdh_fun(PrivKey2), BlockHash, Ledger),
@@ -394,7 +394,7 @@ encrypt_decrypt(Ledger) ->
     ?assertEqual(SecretKey1, SecretKey2),
     {<<"abc">>, Remainder1} = decrypt(OuterPacket, libp2p_crypto:mk_ecdh_fun(PrivKey1), BlockHash, Ledger),
     ?assert(lists:all(fun(E) -> E == error end, [ decrypt(OuterPacket, libp2p_crypto:mk_ecdh_fun(PK), BlockHash, Ledger) || PK <- PrivKeys -- [PrivKey1]])),
-    OnionCompactKey = libp2p_crypto:pubkey_to_bin(PubOnionKey),
+    OnionCompactKey = blockchain_utils:pubkey_to_bin(PubOnionKey),
     %ExpectedIV = IV+1,
     <<_IV:16/integer-unsigned-little, OnionCompactKey:33/binary, _Rest/binary>> = Remainder1,
     {<<"def">>, Remainder2} = decrypt(Remainder1, libp2p_crypto:mk_ecdh_fun(PrivKey2), BlockHash, Ledger),

--- a/src/state_channel/v1/blockchain_state_channel_offer_v1.erl
+++ b/src/state_channel/v1/blockchain_state_channel_offer_v1.erl
@@ -89,7 +89,7 @@ validate(Offer) ->
     EncodedOffer = ?MODULE:encode(BaseOffer),
     Signature = ?MODULE:signature(Offer),
     PubKeyBin = ?MODULE:hotspot(Offer),
-    PubKey = libp2p_crypto:bin_to_pubkey(PubKeyBin),
+    PubKey = blockchain_utils:bin_to_pubkey(PubKeyBin),
     case libp2p_crypto:verify(EncodedOffer, Signature, PubKey) of
         false -> {error, bad_signature};
         true -> true

--- a/src/state_channel/v1/blockchain_state_channel_packet_v1.erl
+++ b/src/state_channel/v1/blockchain_state_channel_packet_v1.erl
@@ -58,7 +58,7 @@ validate(Packet, Offer) ->
     EncodedPacket = ?MODULE:encode(BasePacket),
     Signature = ?MODULE:signature(Packet),
     PubKeyBin = ?MODULE:hotspot(Packet),
-    PubKey = libp2p_crypto:bin_to_pubkey(PubKeyBin),
+    PubKey = blockchain_utils:bin_to_pubkey(PubKeyBin),
     case libp2p_crypto:verify(EncodedPacket, Signature, PubKey) of
         false -> {error, bad_signature};
         true ->
@@ -120,7 +120,7 @@ sign_test() ->
 
 validate_test() ->
     #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+    PubKeyBin = blockchain_utils:pubkey_to_bin(PubKey),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     P = blockchain_helium_packet_v1:new({devaddr, 1234}, <<"hello">>),
     Packet0 = new(P, PubKeyBin, 'US915'),

--- a/src/state_channel/v1/blockchain_state_channel_summary_v1.erl
+++ b/src/state_channel/v1/blockchain_state_channel_summary_v1.erl
@@ -72,7 +72,7 @@ update(NumDCs, NumPackets, Summary) ->
     Summary#blockchain_state_channel_summary_v1_pb{num_dcs=NumDCs, num_packets=NumPackets}.
 
 validate(Summary) ->
-    try libp2p_crypto:bin_to_pubkey(client_pubkeybin(Summary)) of
+    try blockchain_utils:bin_to_pubkey(client_pubkeybin(Summary)) of
         _ ->
             case num_dcs(Summary) >= num_packets(Summary) of
                 true ->

--- a/src/state_channel/v1/blockchain_state_channel_v1.erl
+++ b/src/state_channel/v1/blockchain_state_channel_v1.erl
@@ -230,7 +230,7 @@ validate(SC) ->
     EncodedSC = ?MODULE:encode(BaseSC),
     Signature = ?MODULE:signature(SC),
     Owner = ?MODULE:owner(SC),
-    PubKey = libp2p_crypto:bin_to_pubkey(Owner),
+    PubKey = blockchain_utils:bin_to_pubkey(Owner),
     case libp2p_crypto:verify(EncodedSC, Signature, PubKey) of
         false -> {error, bad_signature};
         true -> validate_summaries(summaries(SC))
@@ -252,7 +252,7 @@ quick_validate(SC, PubkeyBin) ->
     EncodedSC = ?MODULE:encode(BaseSC),
     Signature = ?MODULE:signature(SC),
     Owner = ?MODULE:owner(SC),
-    PubKey = libp2p_crypto:bin_to_pubkey(Owner),
+    PubKey = blockchain_utils:bin_to_pubkey(Owner),
     case libp2p_crypto:verify(EncodedSC, Signature, PubKey) of
         false -> {error, bad_signature};
         true ->
@@ -603,7 +603,7 @@ nonce_test() ->
 
 summaries_test() ->
     #{public := PubKey} = libp2p_crypto:generate_keys(ecc_compact),
-    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+    PubKeyBin = blockchain_utils:pubkey_to_bin(PubKey),
     SC = new(<<"1">>, <<"owner">>, 0),
     ?assertEqual([], summaries(SC)),
     Summary = blockchain_state_channel_summary_v1:new(PubKeyBin),
@@ -614,13 +614,13 @@ summaries_test() ->
 
 summaries_not_found_test() ->
     #{public := PubKey} = libp2p_crypto:generate_keys(ecc_compact),
-    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+    PubKeyBin = blockchain_utils:pubkey_to_bin(PubKey),
     SC = new(<<"1">>, <<"owner">>, 0),
     ?assertEqual({error, not_found}, get_summary(PubKeyBin, SC)).
 
 update_summaries_test() ->
     #{public := PubKey} = libp2p_crypto:generate_keys(ecc_compact),
-    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+    PubKeyBin = blockchain_utils:pubkey_to_bin(PubKey),
     SC = new(<<"1">>, <<"owner">>, 0),
     io:format("Summaries0: ~p~n", [summaries(SC)]),
     ?assertEqual([], summaries(SC)),
@@ -653,9 +653,9 @@ normalize_test() ->
     InitDCs = 20,
     SC = new(<<"1">>, <<"owner">>, InitDCs),
     #{public := PubKey1} = libp2p_crypto:generate_keys(ecc_compact),
-    PubKeyBin1 = libp2p_crypto:pubkey_to_bin(PubKey1),
+    PubKeyBin1 = blockchain_utils:pubkey_to_bin(PubKey1),
     #{public := PubKey2} = libp2p_crypto:generate_keys(ecc_compact),
-    PubKeyBin2 = libp2p_crypto:pubkey_to_bin(PubKey2),
+    PubKeyBin2 = blockchain_utils:pubkey_to_bin(PubKey2),
     Summary1 = blockchain_state_channel_summary_v1:num_packets(30, blockchain_state_channel_summary_v1:num_dcs(30, blockchain_state_channel_summary_v1:new(PubKeyBin1))),
     Summary2 = blockchain_state_channel_summary_v1:num_packets(40, blockchain_state_channel_summary_v1:num_dcs(40, blockchain_state_channel_summary_v1:new(PubKeyBin2))),
     SC1 = summaries([Summary1, Summary2], SC),
@@ -675,9 +675,9 @@ encode_decode_test() ->
     SC0 = new(<<"1">>, <<"owner">>, 0),
     ?assertEqual(SC0, decode(encode(SC0))),
     #{public := PubKey0} = libp2p_crypto:generate_keys(ecc_compact),
-    PubKeyBin0 = libp2p_crypto:pubkey_to_bin(PubKey0),
+    PubKeyBin0 = blockchain_utils:pubkey_to_bin(PubKey0),
     #{public := PubKey1} = libp2p_crypto:generate_keys(ecc_compact),
-    PubKeyBin1 = libp2p_crypto:pubkey_to_bin(PubKey1),
+    PubKeyBin1 = blockchain_utils:pubkey_to_bin(PubKey1),
     Summary0 = blockchain_state_channel_summary_v1:new(PubKeyBin0),
     Summary1 = blockchain_state_channel_summary_v1:new(PubKeyBin1),
     SC1 = summaries([Summary1, Summary0], SC0),
@@ -687,9 +687,9 @@ encode_decode_test() ->
 
 causality_test() ->
     #{public := PubKey} = libp2p_crypto:generate_keys(ecc_compact),
-    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+    PubKeyBin = blockchain_utils:pubkey_to_bin(PubKey),
     #{public := PubKey1} = libp2p_crypto:generate_keys(ecc_compact),
-    PubKeyBin1 = libp2p_crypto:pubkey_to_bin(PubKey1),
+    PubKeyBin1 = blockchain_utils:pubkey_to_bin(PubKey1),
     Summary1 = blockchain_state_channel_summary_v1:num_packets(2, blockchain_state_channel_summary_v1:num_dcs(2, blockchain_state_channel_summary_v1:new(PubKeyBin))),
     Summary2 = blockchain_state_channel_summary_v1:num_packets(4, blockchain_state_channel_summary_v1:num_dcs(4, blockchain_state_channel_summary_v1:new(PubKeyBin))),
     Summary3 = blockchain_state_channel_summary_v1:num_packets(1, blockchain_state_channel_summary_v1:num_dcs(1, blockchain_state_channel_summary_v1:new(PubKeyBin1))),

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -605,7 +605,7 @@ validate_fields([{{Name, Field}, {binary, Min, Max}}|Tail]) when is_binary(Field
             {error, {field_wrong_size, {Name, {Min, Max}, byte_size(Field)}}}
     end;
 validate_fields([{{Name, Field}, {address, libp2p}}|Tail]) when is_binary(Field) ->
-    try libp2p_crypto:bin_to_pubkey(Field) of
+    try blockchain_utils:bin_to_pubkey(Field) of
         _ ->
             validate_fields(Tail)
     catch
@@ -916,11 +916,11 @@ depends_on(ThisTxn, CachedTxns) ->
 
 depends_on_test() ->
     #{secret := PrivKey1, public := PubKey1} = libp2p_crypto:generate_keys(ecc_compact),
-    Payer = libp2p_crypto:pubkey_to_bin(PubKey1),
+    Payer = blockchain_utils:pubkey_to_bin(PubKey1),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey1),
 
     #{secret := _PrivKey2, public := PubKey2} = libp2p_crypto:generate_keys(ecc_compact),
-    Recipient = libp2p_crypto:pubkey_to_bin(PubKey2),
+    Recipient = blockchain_utils:pubkey_to_bin(PubKey2),
     Txns = lists:map(fun(Nonce) ->
                       case rand:uniform(2) of
                           1 ->
@@ -987,14 +987,14 @@ nonce_check(Txns) ->
 gen_pubkeys(Count) ->
     lists:foldl(fun(_, Acc) ->
                         #{secret := _, public := PubKey} = libp2p_crypto:generate_keys(ecc_compact),
-                        Addr = libp2p_crypto:pubkey_to_bin(PubKey),
+                        Addr = blockchain_utils:pubkey_to_bin(PubKey),
                         [Addr | Acc]
                 end, [], lists:seq(1, Count)).
 
 gen_payers(Count) ->
     lists:foldl(fun(_, Acc) ->
                         #{secret := PrivKey, public := PubKey} = libp2p_crypto:generate_keys(ecc_compact),
-                        PubkeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+                        PubkeyBin = blockchain_utils:pubkey_to_bin(PubKey),
                         SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
                         [{PubkeyBin, SigFun} | Acc]
                 end, [], lists:seq(1, Count)).
@@ -1034,10 +1034,10 @@ txn_fees_payment_v2_test() ->
 txn_fees_add_gateway_v1_test() ->
     [{Payer, PayerSigFun}] = gen_payers(1),
     #{public := GWPubKey, secret := GWPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    GWPubkeyBin = libp2p_crypto:pubkey_to_bin(GWPubKey),
+    GWPubkeyBin = blockchain_utils:pubkey_to_bin(GWPubKey),
     GWSigFun = libp2p_crypto:mk_sig_fun(GWPrivKey),
     #{public := OwnerPubKey, secret := OwnerPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    OwnerPubkeyBin = libp2p_crypto:pubkey_to_bin(OwnerPubKey),
+    OwnerPubkeyBin = blockchain_utils:pubkey_to_bin(OwnerPubKey),
     OwnerSigFun = libp2p_crypto:mk_sig_fun(OwnerPrivKey),
 
     %% create new txn, and confirm expected txn and staking fee
@@ -1066,10 +1066,10 @@ txn_fees_add_gateway_v1_test() ->
 txn_fees_assert_location_v1_test() ->
     [{Payer, PayerSigFun}] = gen_payers(1),
     #{public := GWPubKey, secret := GWPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    GWPubkeyBin = libp2p_crypto:pubkey_to_bin(GWPubKey),
+    GWPubkeyBin = blockchain_utils:pubkey_to_bin(GWPubKey),
     GWSigFun = libp2p_crypto:mk_sig_fun(GWPrivKey),
     #{public := OwnerPubKey, secret := OwnerPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    OwnerPubkeyBin = libp2p_crypto:pubkey_to_bin(OwnerPubKey),
+    OwnerPubkeyBin = blockchain_utils:pubkey_to_bin(OwnerPubKey),
     OwnerSigFun = libp2p_crypto:mk_sig_fun(OwnerPrivKey),
 
     %% create new txn, and confirm expected txn and staking fee
@@ -1130,7 +1130,7 @@ txn_fees_oui_test() ->
     OUI = 1,
     [{Payer, PayerSigFun}] = gen_payers(1),
     #{public := OwnerPubKey, secret := OwnerPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    OwnerPubkeyBin = libp2p_crypto:pubkey_to_bin(OwnerPubKey),
+    OwnerPubkeyBin = blockchain_utils:pubkey_to_bin(OwnerPubKey),
     OwnerSigFun = libp2p_crypto:mk_sig_fun(OwnerPrivKey),
     {Filter, _} = xor16:to_bin(xor16:new([], fun xxhash:hash64/1)),
 

--- a/src/transactions/v1/blockchain_poc_receipt_v1.erl
+++ b/src/transactions/v1/blockchain_poc_receipt_v1.erl
@@ -143,7 +143,7 @@ sign(Receipt, SigFun) ->
 
 -spec is_valid(Receipt :: poc_receipt()) -> boolean().
 is_valid(Receipt=#blockchain_poc_receipt_v1_pb{gateway=Gateway, signature=Signature}) ->
-    PubKey = libp2p_crypto:bin_to_pubkey(Gateway),
+    PubKey = blockchain_utils:bin_to_pubkey(Gateway),
     BaseReceipt = Receipt#blockchain_poc_receipt_v1_pb{signature = <<>>},
     EncodedReceipt = blockchain_txn_poc_receipts_v1_pb:encode_msg(BaseReceipt),
     libp2p_crypto:verify(EncodedReceipt, Signature, PubKey).
@@ -222,7 +222,7 @@ signature_test() ->
 
 sign_test() ->
     #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    Gateway = libp2p_crypto:pubkey_to_bin(PubKey),
+    Gateway = blockchain_utils:pubkey_to_bin(PubKey),
     Receipt0 = new(Gateway, 1, 12, <<"data">>, p2p),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     Receipt1 = sign(Receipt0, SigFun),

--- a/src/transactions/v1/blockchain_poc_witness_v1.erl
+++ b/src/transactions/v1/blockchain_poc_witness_v1.erl
@@ -131,7 +131,7 @@ sign(Witness, SigFun) ->
 
 -spec is_valid(Witness :: poc_witness()) -> boolean().
 is_valid(Witness=#blockchain_poc_witness_v1_pb{gateway=Gateway, signature=Signature}) ->
-    PubKey = libp2p_crypto:bin_to_pubkey(Gateway),
+    PubKey = blockchain_utils:bin_to_pubkey(Gateway),
     BaseWitness = Witness#blockchain_poc_witness_v1_pb{signature = <<>>},
     EncodedWitness = blockchain_txn_poc_receipts_v1_pb:encode_msg(BaseWitness),
     libp2p_crypto:verify(EncodedWitness, Signature, PubKey).
@@ -209,7 +209,7 @@ signature_test() ->
 
 sign_test() ->
     #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    Gateway = libp2p_crypto:pubkey_to_bin(PubKey),
+    Gateway = blockchain_utils:pubkey_to_bin(PubKey),
     Witness0 = new(Gateway, 1, 12, <<"hash">>),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     Witness1 = sign(Witness0, SigFun),

--- a/src/transactions/v1/blockchain_txn_add_gateway_v1.erl
+++ b/src/transactions/v1/blockchain_txn_add_gateway_v1.erl
@@ -246,7 +246,7 @@ is_valid_gateway(#blockchain_txn_add_gateway_v1_pb{gateway=PubKeyBin,
                                                    gateway_signature= <<>>,
                                                    payer_signature= <<>>},
     EncodedTxn = blockchain_txn_add_gateway_v1_pb:encode_msg(BaseTxn),
-    PubKey = libp2p_crypto:bin_to_pubkey(PubKeyBin),
+    PubKey = blockchain_utils:bin_to_pubkey(PubKeyBin),
     libp2p_crypto:verify(EncodedTxn, Signature, PubKey).
 
 %%--------------------------------------------------------------------
@@ -260,7 +260,7 @@ is_valid_owner(#blockchain_txn_add_gateway_v1_pb{owner=PubKeyBin,
                                                    gateway_signature= <<>>,
                                                    payer_signature= <<>>},
     EncodedTxn = blockchain_txn_add_gateway_v1_pb:encode_msg(BaseTxn),
-    PubKey = libp2p_crypto:bin_to_pubkey(PubKeyBin),
+    PubKey = blockchain_utils:bin_to_pubkey(PubKeyBin),
     libp2p_crypto:verify(EncodedTxn, Signature, PubKey).
 
 %%--------------------------------------------------------------------
@@ -280,7 +280,7 @@ is_valid_payer(#blockchain_txn_add_gateway_v1_pb{payer=PubKeyBin,
                                                     gateway_signature= <<>>,
                                                     payer_signature= <<>>},
     EncodedTxn = blockchain_txn_add_gateway_v1_pb:encode_msg(BaseTxn),
-    PubKey = libp2p_crypto:bin_to_pubkey(PubKeyBin),
+    PubKey = blockchain_utils:bin_to_pubkey(PubKeyBin),
     libp2p_crypto:verify(EncodedTxn, Signature, PubKey).
 
 -spec is_valid_staking_key(txn_add_gateway(), blockchain_ledger_v1:ledger())-> boolean().
@@ -396,7 +396,7 @@ missing_payer_signature_new() ->
         gateway= <<"gateway_address">>,
         owner_signature= <<>>,
         gateway_signature = <<>>,
-        payer= libp2p_crypto:pubkey_to_bin(PubKey),
+        payer= blockchain_utils:pubkey_to_bin(PubKey),
         payer_signature = <<>>,
         staking_fee = 1,
         fee = 1

--- a/src/transactions/v1/blockchain_txn_assert_location_v1.erl
+++ b/src/transactions/v1/blockchain_txn_assert_location_v1.erl
@@ -240,7 +240,7 @@ is_valid_gateway(#blockchain_txn_assert_location_v1_pb{gateway=PubKeyBin,
                                                        gateway_signature= <<>>,
                                                        payer_signature= <<>>},
     EncodedTxn = blockchain_txn_assert_location_v1_pb:encode_msg(BaseTxn),
-    PubKey = libp2p_crypto:bin_to_pubkey(PubKeyBin),
+    PubKey = blockchain_utils:bin_to_pubkey(PubKeyBin),
     libp2p_crypto:verify(EncodedTxn, Signature, PubKey).
 
 %%--------------------------------------------------------------------
@@ -254,7 +254,7 @@ is_valid_owner(#blockchain_txn_assert_location_v1_pb{owner=PubKeyBin,
                                                        gateway_signature= <<>>,
                                                        payer_signature= <<>>},
     EncodedTxn = blockchain_txn_assert_location_v1_pb:encode_msg(BaseTxn),
-    PubKey = libp2p_crypto:bin_to_pubkey(PubKeyBin),
+    PubKey = blockchain_utils:bin_to_pubkey(PubKeyBin),
     libp2p_crypto:verify(EncodedTxn, Signature, PubKey).
 
 -spec is_valid_location(txn_assert_location(), pos_integer()) -> boolean().
@@ -280,7 +280,7 @@ is_valid_payer(#blockchain_txn_assert_location_v1_pb{payer=PubKeyBin,
                                                        gateway_signature= <<>>,
                                                        payer_signature= <<>>},
     EncodedTxn = blockchain_txn_assert_location_v1_pb:encode_msg(BaseTxn),
-    PubKey = libp2p_crypto:bin_to_pubkey(PubKeyBin),
+    PubKey = blockchain_utils:bin_to_pubkey(PubKeyBin),
     libp2p_crypto:verify(EncodedTxn, Signature, PubKey).
 
 %%--------------------------------------------------------------------
@@ -512,7 +512,7 @@ missing_payer_signature_new() ->
     #blockchain_txn_assert_location_v1_pb{
        gateway= <<"gateway_address">>,
        owner= <<"owner_address">>,
-       payer= libp2p_crypto:pubkey_to_bin(PubKey),
+       payer= blockchain_utils:pubkey_to_bin(PubKey),
        payer_signature = <<>>,
        gateway_signature= <<>>,
        owner_signature= << >>,

--- a/src/transactions/v1/blockchain_txn_consensus_group_v1.erl
+++ b/src/transactions/v1/blockchain_txn_consensus_group_v1.erl
@@ -257,7 +257,7 @@ verify_proof(Proof, Members, Hash, Delay, OldLedger) ->
             case lists:all(fun({Addr, Sig}) ->
                                    lists:member(Addr, Members) andalso
                                        libp2p_crypto:verify(Artifact, Sig,
-                                                            libp2p_crypto:bin_to_pubkey(Addr))
+                                                            blockchain_utils:bin_to_pubkey(Addr))
 
                            end, Proof) andalso
                 lists:all(fun(M) ->

--- a/src/transactions/v1/blockchain_txn_create_htlc_v1.erl
+++ b/src/transactions/v1/blockchain_txn_create_htlc_v1.erl
@@ -147,7 +147,7 @@ is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Payer = ?MODULE:payer(Txn),
     Signature = ?MODULE:signature(Txn),
-    PubKey = libp2p_crypto:bin_to_pubkey(Payer),
+    PubKey = blockchain_utils:bin_to_pubkey(Payer),
     BaseTxn = Txn#blockchain_txn_create_htlc_v1_pb{signature = <<>>},
     EncodedTxn = blockchain_txn_create_htlc_v1_pb:encode_msg(BaseTxn),
     FieldValidation = case blockchain:config(?txn_field_validation_version, Ledger) of
@@ -370,7 +370,7 @@ is_valid_with_extended_validation_test() ->
 
     #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
-    Payer = libp2p_crypto:pubkey_to_bin(PubKey),
+    Payer = blockchain_utils:pubkey_to_bin(PubKey),
     Tx = sign(new(Payer, <<"payee">>, <<"address">>, crypto:strong_rand_bytes(32), 0, 666, 1), SigFun),
     ?assertEqual({error, {invalid_address, payee}}, is_valid(Tx, Chain)),
 
@@ -378,7 +378,7 @@ is_valid_with_extended_validation_test() ->
     ?assertEqual({error, {invalid_address, payee}}, is_valid(Tx1, Chain)),
 
     #{public := PayeePubkey, secret := _PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    ValidPayee = libp2p_crypto:pubkey_to_bin(PayeePubkey),
+    ValidPayee = blockchain_utils:pubkey_to_bin(PayeePubkey),
     Tx2 = sign(new(Payer, ValidPayee, ValidPayee, crypto:strong_rand_bytes(32), 0, 666, 1), SigFun),
     %% This check can be improved but whatever (it fails on fee)
     ?assertNotEqual({error, {invalid_address, payee}}, is_valid(Tx2, Chain)),

--- a/src/transactions/v1/blockchain_txn_oui_v1.erl
+++ b/src/transactions/v1/blockchain_txn_oui_v1.erl
@@ -161,7 +161,7 @@ is_valid_owner(#blockchain_txn_oui_v1_pb{owner=PubKeyBin,
                                          owner_signature=Signature}=Txn) ->
     BaseTxn = Txn#blockchain_txn_oui_v1_pb{owner_signature= <<>>, payer_signature= <<>>},
     EncodedTxn = blockchain_txn_oui_v1_pb:encode_msg(BaseTxn),
-    PubKey = libp2p_crypto:bin_to_pubkey(PubKeyBin),
+    PubKey = blockchain_utils:bin_to_pubkey(PubKeyBin),
     libp2p_crypto:verify(EncodedTxn, Signature, PubKey).
 
 -spec is_valid_payer(txn_oui()) -> boolean().
@@ -175,7 +175,7 @@ is_valid_payer(#blockchain_txn_oui_v1_pb{payer=PubKeyBin,
                                          payer_signature=Signature}=Txn) ->
     BaseTxn = Txn#blockchain_txn_oui_v1_pb{owner_signature= <<>>, payer_signature= <<>>},
     EncodedTxn = blockchain_txn_oui_v1_pb:encode_msg(BaseTxn),
-    PubKey = libp2p_crypto:bin_to_pubkey(PubKeyBin),
+    PubKey = blockchain_utils:bin_to_pubkey(PubKeyBin),
     libp2p_crypto:verify(EncodedTxn, Signature, PubKey).
 
 -spec is_valid(txn_oui(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
@@ -413,7 +413,7 @@ missing_payer_signature_new() ->
        oui = 1,
        owner= <<"owner">>,
        addresses = [?KEY1],
-       payer= libp2p_crypto:pubkey_to_bin(PubKey),
+       payer= blockchain_utils:pubkey_to_bin(PubKey),
        payer_signature= <<>>,
        staking_fee=?LEGACY_STAKING_FEE,
        fee=?LEGACY_TXN_FEE,

--- a/src/transactions/v1/blockchain_txn_payment_v1.erl
+++ b/src/transactions/v1/blockchain_txn_payment_v1.erl
@@ -118,7 +118,7 @@ is_valid(Txn, Chain) ->
     Payer = ?MODULE:payer(Txn),
     Payee = ?MODULE:payee(Txn),
     Signature = ?MODULE:signature(Txn),
-    PubKey = libp2p_crypto:bin_to_pubkey(Payer),
+    PubKey = blockchain_utils:bin_to_pubkey(Payer),
     BaseTxn = Txn#blockchain_txn_payment_v1_pb{signature = <<>>},
     EncodedTxn = blockchain_txn_payment_v1_pb:encode_msg(BaseTxn),
     case blockchain:config(?deprecate_payment_v1, Ledger) of
@@ -291,7 +291,7 @@ is_valid_with_extended_validation_test() ->
 
     #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
-    Payer = libp2p_crypto:pubkey_to_bin(PubKey),
+    Payer = blockchain_utils:pubkey_to_bin(PubKey),
     Tx = sign(new(Payer, <<"payee">>, 666, 1), SigFun),
     ?assertEqual({error, {invalid_address, payee}}, is_valid(Tx, Chain)),
 
@@ -299,7 +299,7 @@ is_valid_with_extended_validation_test() ->
     ?assertEqual({error, {invalid_address, payee}}, is_valid(Tx1, Chain)),
 
     #{public := PayeePubkey, secret := _PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    ValidPayee = libp2p_crypto:pubkey_to_bin(PayeePubkey),
+    ValidPayee = blockchain_utils:pubkey_to_bin(PayeePubkey),
     Tx2 = sign(new(Payer, ValidPayee, 666, 1), SigFun),
     %% This check can be improved but whatever (it fails on fee)
     ?assertNotEqual({error, {invalid_address, payee}}, is_valid(Tx2, Chain)),

--- a/src/transactions/v1/blockchain_txn_poc_request_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_request_v1.erl
@@ -143,7 +143,7 @@ is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Challenger = ?MODULE:challenger(Txn),
     ChallengerSignature = ?MODULE:signature(Txn),
-    PubKey = libp2p_crypto:bin_to_pubkey(Challenger),
+    PubKey = blockchain_utils:bin_to_pubkey(Challenger),
     BaseTxn = Txn#blockchain_txn_poc_request_v1_pb{signature = <<>>},
     EncodedTxn = blockchain_txn_poc_request_v1_pb:encode_msg(BaseTxn),
 

--- a/src/transactions/v1/blockchain_txn_price_oracle_v1.erl
+++ b/src/transactions/v1/blockchain_txn_price_oracle_v1.erl
@@ -151,7 +151,7 @@ is_valid(Txn, Chain) ->
     Price = ?MODULE:price(Txn),
     Signature = ?MODULE:signature(Txn),
     RawTxnPK = ?MODULE:public_key(Txn),
-    TxnPK = libp2p_crypto:bin_to_pubkey(RawTxnPK),
+    TxnPK = blockchain_utils:bin_to_pubkey(RawTxnPK),
     BlockHeight = ?MODULE:block_height(Txn),
     {ok, LedgerHeight} = blockchain_ledger_v1:current_height(Ledger),
     BaseTxn = Txn#blockchain_txn_price_oracle_v1_pb{signature = <<>>},

--- a/src/transactions/v1/blockchain_txn_redeem_htlc_v1.erl
+++ b/src/transactions/v1/blockchain_txn_redeem_htlc_v1.erl
@@ -114,7 +114,7 @@ is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Redeemer = ?MODULE:payee(Txn),
     Signature = ?MODULE:signature(Txn),
-    PubKey = libp2p_crypto:bin_to_pubkey(Redeemer),
+    PubKey = blockchain_utils:bin_to_pubkey(Redeemer),
     BaseTxn = Txn#blockchain_txn_redeem_htlc_v1_pb{signature = <<>>},
     EncodedTxn = blockchain_txn_redeem_htlc_v1_pb:encode_msg(BaseTxn),
     FieldValidation = case blockchain:config(?txn_field_validation_version, Ledger) of
@@ -298,7 +298,7 @@ is_valid_with_extended_validation_test_() ->
 
              #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
              SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
-             Payee = libp2p_crypto:pubkey_to_bin(PubKey),
+             Payee = blockchain_utils:pubkey_to_bin(PubKey),
 
              %% We don't check for {invalid_address, payee} because that blows up on line#117
              %% regardless (that's a pubkey check)
@@ -308,7 +308,7 @@ is_valid_with_extended_validation_test_() ->
              ?assertEqual({error, {invalid_address, address}}, is_valid(Tx1, Chain)),
 
              #{public := PubKey2, secret := _PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-             Address = libp2p_crypto:pubkey_to_bin(PubKey2),
+             Address = blockchain_utils:pubkey_to_bin(PubKey2),
 
              %% valid payee, valid address
              Tx2 = sign(new(Payee, Address, crypto:strong_rand_bytes(32)), SigFun),

--- a/src/transactions/v1/blockchain_txn_routing_v1.erl
+++ b/src/transactions/v1/blockchain_txn_routing_v1.erl
@@ -210,7 +210,7 @@ is_valid(Txn, Chain) ->
                             {error, {bad_nonce, {routing, Nonce, LedgerNonce}}};
                         true ->
                             Signature = ?MODULE:signature(Txn),
-                            PubKey = libp2p_crypto:bin_to_pubkey(Owner),
+                            PubKey = blockchain_utils:bin_to_pubkey(Owner),
                             BaseTxn = Txn#blockchain_txn_routing_v1_pb{signature = <<>>},
                             EncodedTxn = blockchain_txn_routing_v1_pb:encode_msg(BaseTxn),
 

--- a/src/transactions/v1/blockchain_txn_security_exchange_v1.erl
+++ b/src/transactions/v1/blockchain_txn_security_exchange_v1.erl
@@ -179,7 +179,7 @@ is_valid(Txn, Chain) ->
     Payee = ?MODULE:payee(Txn),
     TxnFee = ?MODULE:fee(Txn),
     Signature = ?MODULE:signature(Txn),
-    PubKey = libp2p_crypto:bin_to_pubkey(Payer),
+    PubKey = blockchain_utils:bin_to_pubkey(Payer),
     BaseTxn = Txn#blockchain_txn_security_exchange_v1_pb{signature = <<>>},
     EncodedTxn = blockchain_txn_security_exchange_v1_pb:encode_msg(BaseTxn),
     case blockchain_txn:validate_fields([{{payee, Payee}, {address, libp2p}}]) of

--- a/src/transactions/v1/blockchain_txn_state_channel_close_v1.erl
+++ b/src/transactions/v1/blockchain_txn_state_channel_close_v1.erl
@@ -128,7 +128,7 @@ is_valid(Txn, Chain) ->
     {ok, LedgerHeight} = blockchain_ledger_v1:current_height(Ledger),
     Closer = ?MODULE:closer(Txn),
     Signature = ?MODULE:signature(Txn),
-    PubKey = libp2p_crypto:bin_to_pubkey(Closer),
+    PubKey = blockchain_utils:bin_to_pubkey(Closer),
     BaseTxn = Txn#blockchain_txn_state_channel_close_v1_pb{signature = <<>>},
     EncodedTxn = blockchain_txn_state_channel_close_v1_pb:encode_msg(BaseTxn),
     SC = ?MODULE:state_channel(Txn),
@@ -393,7 +393,7 @@ signature_test() ->
 sign_test() ->
     #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
     SC = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>, 0),
-    Closer = libp2p_crypto:pubkey_to_bin(PubKey),
+    Closer = blockchain_utils:pubkey_to_bin(PubKey),
     Tx0 = new(SC, Closer),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     Tx1 = sign(Tx0, SigFun),

--- a/src/transactions/v1/blockchain_txn_state_channel_open_v1.erl
+++ b/src/transactions/v1/blockchain_txn_state_channel_open_v1.erl
@@ -129,7 +129,7 @@ calculate_fee(Txn, Ledger, DCPayloadSize, TxnFeeMultiplier, true) ->
 is_valid(Txn, Chain) ->
     Owner = ?MODULE:owner(Txn),
     Signature = ?MODULE:signature(Txn),
-    PubKey = libp2p_crypto:bin_to_pubkey(Owner),
+    PubKey = blockchain_utils:bin_to_pubkey(Owner),
     BaseTxn = Txn#blockchain_txn_state_channel_open_v1_pb{signature = <<>>},
     EncodedTxn = blockchain_txn_state_channel_open_v1_pb:encode_msg(BaseTxn),
     case libp2p_crypto:verify(EncodedTxn, Signature, PubKey) of

--- a/src/transactions/v1/blockchain_txn_token_burn_v1.erl
+++ b/src/transactions/v1/blockchain_txn_token_burn_v1.erl
@@ -138,7 +138,7 @@ is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Payer = ?MODULE:payer(Txn),
     Signature = ?MODULE:signature(Txn),
-    PubKey = libp2p_crypto:bin_to_pubkey(Payer),
+    PubKey = blockchain_utils:bin_to_pubkey(Payer),
     BaseTxn = Txn#blockchain_txn_token_burn_v1_pb{signature = <<>>},
     EncodedTxn = blockchain_txn_token_burn_v1_pb:encode_msg(BaseTxn),
     case blockchain_txn:validate_fields([{{payee, ?MODULE:payee(Txn)}, {address, libp2p}}]) of

--- a/src/transactions/v1/blockchain_txn_transfer_hotspot_v1.erl
+++ b/src/transactions/v1/blockchain_txn_transfer_hotspot_v1.erl
@@ -151,7 +151,7 @@ is_valid_seller(#blockchain_txn_transfer_hotspot_v1_pb{seller=Seller,
     BaseTxn = Txn#blockchain_txn_transfer_hotspot_v1_pb{buyer_signature= <<>>,
                                                         seller_signature= <<>>},
     EncodedTxn = blockchain_txn_transfer_hotspot_v1_pb:encode_msg(BaseTxn),
-    Pubkey = libp2p_crypto:bin_to_pubkey(Seller),
+    Pubkey = blockchain_utils:bin_to_pubkey(Seller),
     libp2p_crypto:verify(EncodedTxn, SellerSig, Pubkey).
 
 -spec is_valid_buyer(txn_transfer_hotspot()) -> boolean().
@@ -160,7 +160,7 @@ is_valid_buyer(#blockchain_txn_transfer_hotspot_v1_pb{buyer=Buyer,
     BaseTxn = Txn#blockchain_txn_transfer_hotspot_v1_pb{buyer_signature= <<>>,
                                                         seller_signature= <<>>},
     EncodedTxn = blockchain_txn_transfer_hotspot_v1_pb:encode_msg(BaseTxn),
-    Pubkey = libp2p_crypto:bin_to_pubkey(Buyer),
+    Pubkey = blockchain_utils:bin_to_pubkey(Buyer),
     libp2p_crypto:verify(EncodedTxn, BuyerSig, Pubkey).
 
 -spec is_valid(txn_transfer_hotspot(), blockchain:blockchain()) -> ok | {error, any()}.
@@ -345,14 +345,14 @@ fee_test() ->
 
 sign_seller_test() ->
     #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    Tx = new(<<"gateway">>, libp2p_crypto:pubkey_to_bin(PubKey), <<"buyer">>, 1),
+    Tx = new(<<"gateway">>, blockchain_utils:pubkey_to_bin(PubKey), <<"buyer">>, 1),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     Tx0 = sign(Tx, SigFun),
     ?assert(is_valid_seller(Tx0)).
 
 sign_buyer_test() ->
     #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    Tx = new(<<"gateway">>, <<"seller">>, libp2p_crypto:pubkey_to_bin(PubKey), 1),
+    Tx = new(<<"gateway">>, <<"seller">>, blockchain_utils:pubkey_to_bin(PubKey), 1),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     Tx0 = sign_buyer(Tx, SigFun),
     ?assert(is_valid_buyer(Tx0)).

--- a/src/transactions/v1/blockchain_txn_update_gateway_oui_v1.erl
+++ b/src/transactions/v1/blockchain_txn_update_gateway_oui_v1.erl
@@ -115,14 +115,14 @@ oui_owner_sign(Txn, SigFun) ->
 is_valid_gateway_owner(GatewayOwner, #blockchain_txn_update_gateway_oui_v1_pb{gateway_owner_signature=Signature}=Txn) ->
     BaseTxn = Txn#blockchain_txn_update_gateway_oui_v1_pb{gateway_owner_signature= <<>>, oui_owner_signature= <<>>},
     EncodedTxn = blockchain_txn_update_gateway_oui_v1_pb:encode_msg(BaseTxn),
-    PubKey = libp2p_crypto:bin_to_pubkey(GatewayOwner),
+    PubKey = blockchain_utils:bin_to_pubkey(GatewayOwner),
     libp2p_crypto:verify(EncodedTxn, Signature, PubKey).
 
 -spec is_valid_oui_owner(libp2p_crypto:pubkey_bin(), txn_update_gateway_oui()) -> boolean().
 is_valid_oui_owner(OUIOwner, #blockchain_txn_update_gateway_oui_v1_pb{oui_owner_signature=Signature}=Txn) ->
     BaseTxn = Txn#blockchain_txn_update_gateway_oui_v1_pb{gateway_owner_signature= <<>>, oui_owner_signature= <<>>},
     EncodedTxn = blockchain_txn_update_gateway_oui_v1_pb:encode_msg(BaseTxn),
-    PubKey = libp2p_crypto:bin_to_pubkey(OUIOwner),
+    PubKey = blockchain_utils:bin_to_pubkey(OUIOwner),
     libp2p_crypto:verify(EncodedTxn, Signature, PubKey).
 
 %%--------------------------------------------------------------------
@@ -287,7 +287,7 @@ oui_owner_signature_test() ->
 
 is_valid_gateway_owner_test() ->
     #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+    PubKeyBin = blockchain_utils:pubkey_to_bin(PubKey),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     Update0 = new(<<"gateway">>, 1, 0),
     Update1 = gateway_owner_sign(Update0, SigFun),
@@ -295,7 +295,7 @@ is_valid_gateway_owner_test() ->
 
 is_valid_oui_owner_test() ->
     #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+    PubKeyBin = blockchain_utils:pubkey_to_bin(PubKey),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     Update0 = new(<<"gateway">>, 1, 0),
     Update1 = oui_owner_sign(Update0, SigFun),

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -656,7 +656,7 @@ create_artifact(Txn) ->
 verify_key(_Artifact, _Key, <<>>) ->
     throw({error, no_proof});
 verify_key(Artifact, Key, Proof) ->
-    libp2p_crypto:verify(Artifact, Proof, libp2p_crypto:bin_to_pubkey(Key)).
+    libp2p_crypto:verify(Artifact, Proof, blockchain_utils:bin_to_pubkey(Key)).
 
 validate_int(Value, Name, Min, Max, InfOK) ->
     case is_integer(Value) of
@@ -693,7 +693,7 @@ validate_oracle_public_keys_format(Str) when is_binary(Str) ->
 validate_oracle_keys([]) -> ok;
 validate_oracle_keys([H|T]) ->
     try
-        _ = libp2p_crypto:bin_to_pubkey(H),
+        _ = blockchain_utils:bin_to_pubkey(H),
         validate_oracle_keys(T)
     catch
         _C:_E:_St ->
@@ -707,7 +707,7 @@ validate_staking_keys_format(Str) when is_binary(Str) ->
 validate_staking_keys([]) -> ok;
 validate_staking_keys([H|T]) ->
     try
-        _ = libp2p_crypto:bin_to_pubkey(H),
+        _ = blockchain_utils:bin_to_pubkey(H),
         validate_staking_keys(T)
     catch
         _C:_E:_St ->
@@ -754,6 +754,13 @@ validate_var(?witness_refresh_rand_n, Value) ->
     validate_int(Value, "witness_refresh_rand_n", 50, 1000, false);
 
 %% meta vars
+validate_var(?network, Value) ->
+    case Value of
+        mainnet -> ok;
+        testnet -> ok;
+        _ ->
+            throw({error, {invalid_network, Value}})
+    end;
 validate_var(?vars_commit_delay, Value) ->
     validate_int(Value, "vars_commit_delay", 1, 60, false);
 validate_var(?chain_vars_version, Value) ->
@@ -1190,7 +1197,7 @@ invalid_var(Var, Value) ->
 key_test() ->
     #{secret := Priv, public := Pub} =
         libp2p_crypto:generate_keys(ecc_compact),
-    BPub = libp2p_crypto:pubkey_to_bin(Pub),
+    BPub = blockchain_utils:pubkey_to_bin(Pub),
     Vars = #{a => 1,
              b => 2000,
              c => 2.5,
@@ -1211,7 +1218,7 @@ key_test() ->
 legacy_key_test() ->
     #{secret := Priv, public := Pub} =
         libp2p_crypto:generate_keys(ecc_compact),
-    BPub = libp2p_crypto:pubkey_to_bin(Pub),
+    BPub = blockchain_utils:pubkey_to_bin(Pub),
     Vars = #{a => 1,
              b => 2000,
              c => 2.5,
@@ -1226,7 +1233,7 @@ legacy_key_test() ->
 to_json_test() ->
     #{secret := _Priv, public := Pub} =
         libp2p_crypto:generate_keys(ecc_compact),
-    BPub = libp2p_crypto:pubkey_to_bin(Pub),
+    BPub = blockchain_utils:pubkey_to_bin(Pub),
     Vars = #{a => 1,
              b => 2000,
              c => 2.5,

--- a/src/transactions/v2/blockchain_txn_payment_v2.erl
+++ b/src/transactions/v2/blockchain_txn_payment_v2.erl
@@ -198,7 +198,7 @@ do_is_valid_checks(Txn, Chain, MaxPayments) ->
     Payer = ?MODULE:payer(Txn),
     Signature = ?MODULE:signature(Txn),
     Payments = ?MODULE:payments(Txn),
-    PubKey = libp2p_crypto:bin_to_pubkey(Payer),
+    PubKey = blockchain_utils:bin_to_pubkey(Payer),
     BaseTxn = Txn#blockchain_txn_payment_v2_pb{signature = <<>>},
     EncodedTxn = blockchain_txn_payment_v2_pb:encode_msg(BaseTxn),
 

--- a/test/blockchain_ct_utils.erl
+++ b/test/blockchain_ct_utils.erl
@@ -312,7 +312,7 @@ create_vars(Vars) ->
     Vars1 = raw_vars(Vars),
     ct:pal("vars ~p", [Vars1]),
 
-    BinPub = libp2p_crypto:pubkey_to_bin(Pub),
+    BinPub = blockchain_utils:pubkey_to_bin(Pub),
 
     Txn = blockchain_txn_vars_v1:new(Vars1, 2, #{master_key => BinPub}),
     Proof = blockchain_txn_vars_v1:create_proof(Priv, Txn),

--- a/test/blockchain_price_oracle_SUITE.erl
+++ b/test/blockchain_price_oracle_SUITE.erl
@@ -325,7 +325,7 @@ submit_bad_public_key(Config) ->
     ?assertMatch({error, {invalid_txns, _}}, test_utils:create_block(ConsensusMembers, [BadTxn])),
 
     %% check that a bad signature is invalid
-    RawTxn = blockchain_txn_price_oracle_v1:new( libp2p_crypto:pubkey_to_bin(maps:get(public, hd(OracleKeys))), 50, 50),
+    RawTxn = blockchain_txn_price_oracle_v1:new( blockchain_utils:pubkey_to_bin(maps:get(public, hd(OracleKeys))), 50, 50),
     SignFun = libp2p_crypto:mk_sig_fun(maps:get(secret, BadKey)),
     BadlySignedTxn = blockchain_txn_price_oracle_v1:sign(RawTxn, SignFun),
     ?assertMatch({error, {invalid_txns, _}}, test_utils:create_block(ConsensusMembers, [BadlySignedTxn])),
@@ -595,7 +595,7 @@ txn_fees_pay_with_dc(Config) ->
     %%
 
     #{public := GatewayPubKey, secret := GatewayPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    Gateway = libp2p_crypto:pubkey_to_bin(GatewayPubKey),
+    Gateway = blockchain_utils:pubkey_to_bin(GatewayPubKey),
     GatewaySigFun = libp2p_crypto:mk_sig_fun(GatewayPrivKey),
 
     %% base txn
@@ -724,7 +724,7 @@ txn_fees_pay_with_dc(Config) ->
     Hashlock = crypto:hash(sha256, <<"sharkfed">>),
     % Create a Payee
     #{public := PayeePubKey, secret := PayeePrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    Payee = libp2p_crypto:pubkey_to_bin(PayeePubKey),
+    Payee = blockchain_utils:pubkey_to_bin(PayeePubKey),
 
     %% base txn
     CreateHTLCTx0 = blockchain_txn_create_htlc_v1:new(Payer, Payee, HTLCAddress, Hashlock, 3, 2500, 2),
@@ -856,7 +856,7 @@ txn_fees_pay_with_dc(Config) ->
     %%
 
     #{public := RouterPubKey, secret := RouterPrivKey} = libp2p_crypto:generate_keys(ed25519),
-    RouterPubKeyBin = libp2p_crypto:pubkey_to_bin(RouterPubKey),
+    RouterPubKeyBin = blockchain_utils:pubkey_to_bin(RouterPubKey),
     RouterAddresses1 = [RouterPubKeyBin],
     RouterSigFun = libp2p_crypto:mk_sig_fun(RouterPrivKey),
 
@@ -1179,7 +1179,7 @@ staking_key_add_gateway(Config) ->
     %%
 
     #{public := StakingPub, secret := StakingPrivKey} = ?config(staking_key, Config),
-    Staker = libp2p_crypto:pubkey_to_bin(StakingPub),
+    Staker = blockchain_utils:pubkey_to_bin(StakingPub),
     StakerSigFun = libp2p_crypto:mk_sig_fun(StakingPrivKey),
     %% base txn
     PaymentTx0 = blockchain_txn_payment_v1:new(Payer, Staker, 2500 * ?BONES_PER_HNT, 1),
@@ -1209,11 +1209,11 @@ staking_key_add_gateway(Config) ->
     blockchain:add_block(PaymentBlock, Chain),
 
     #{public := GatewayPubKey, secret := GatewayPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    Gateway = libp2p_crypto:pubkey_to_bin(GatewayPubKey),
+    Gateway = blockchain_utils:pubkey_to_bin(GatewayPubKey),
     GatewaySigFun = libp2p_crypto:mk_sig_fun(GatewayPrivKey),
 
     #{public := OwnerPubKey, secret := OwnerPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    Owner = libp2p_crypto:pubkey_to_bin(OwnerPubKey),
+    Owner = blockchain_utils:pubkey_to_bin(OwnerPubKey),
     OwnerSigFun = libp2p_crypto:mk_sig_fun(OwnerPrivKey),
 
     %% base txn
@@ -1288,11 +1288,11 @@ make_oracle_txns(N, Keys, BlockHeight) ->
 
 make_and_sign_txn(#{public := PubKey, secret := SecretKey}, Price, BlockHeight) ->
     SignFun = libp2p_crypto:mk_sig_fun(SecretKey),
-    RawTxn = blockchain_txn_price_oracle_v1:new(libp2p_crypto:pubkey_to_bin(PubKey), Price, BlockHeight),
+    RawTxn = blockchain_txn_price_oracle_v1:new(blockchain_utils:pubkey_to_bin(PubKey), Price, BlockHeight),
     blockchain_txn_price_oracle_v1:sign(RawTxn, SignFun).
 
 prep_public_key(#{public := K}) ->
-    BinPK = libp2p_crypto:pubkey_to_bin(K),
+    BinPK = blockchain_utils:pubkey_to_bin(K),
     <<(byte_size(BinPK)):8/unsigned-integer, BinPK/binary>>.
 
 make_encoded_oracle_keys(Keys) ->

--- a/test/blockchain_simple_SUITE.erl
+++ b/test/blockchain_simple_SUITE.erl
@@ -349,10 +349,10 @@ htlc_payee_redeem_test(Config) ->
     Chain = ?config(chain, Config),
 
     % Create a Payer
-    Payer = libp2p_crypto:pubkey_to_bin(PubKey),
+    Payer = blockchain_utils:pubkey_to_bin(PubKey),
     % Create a Payee
     #{public := PayeePubKey, secret := PayeePrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    Payee = libp2p_crypto:pubkey_to_bin(PayeePubKey),
+    Payee = blockchain_utils:pubkey_to_bin(PayeePubKey),
     % Generate a random address
     HTLCAddress = crypto:strong_rand_bytes(33),
     % Create a Hashlock
@@ -425,7 +425,7 @@ htlc_payer_redeem_test(Config) ->
     Chain = ?config(chain, Config),
 
     % Create a Payer
-    Payer = libp2p_crypto:pubkey_to_bin(PubKey),
+    Payer = blockchain_utils:pubkey_to_bin(PubKey),
     % Generate a random address
     HTLCAddress = crypto:strong_rand_bytes(33),
     % Create a Hashlock
@@ -492,7 +492,7 @@ poc_request_test(Config) ->
     ConsensusMembers = ?config(consensus_members, Config),
     PubKey = ?config(pubkey, Config),
     PrivKey = ?config(privkey, Config),
-    Owner = libp2p_crypto:pubkey_to_bin(PubKey),
+    Owner = blockchain_utils:pubkey_to_bin(PubKey),
     Chain = ?config(chain, Config),
     Balance = ?config(balance, Config),
 
@@ -548,7 +548,7 @@ poc_request_test(Config) ->
 
     % Create a Gateway
     #{public := GatewayPubKey, secret := GatewayPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    Gateway = libp2p_crypto:pubkey_to_bin(GatewayPubKey),
+    Gateway = blockchain_utils:pubkey_to_bin(GatewayPubKey),
     GatewaySigFun = libp2p_crypto:mk_sig_fun(GatewayPrivKey),
 
 
@@ -587,7 +587,7 @@ poc_request_test(Config) ->
     Secret0 = libp2p_crypto:keys_to_bin(Keys0),
     #{public := OnionCompactKey0} = Keys0,
     SecretHash0 = crypto:hash(sha256, Secret0),
-    OnionKeyHash0 = crypto:hash(sha256, libp2p_crypto:pubkey_to_bin(OnionCompactKey0)),
+    OnionKeyHash0 = crypto:hash(sha256, blockchain_utils:pubkey_to_bin(OnionCompactKey0)),
     PoCReqTxn0 = blockchain_txn_poc_request_v1:new(Gateway, SecretHash0, OnionKeyHash0, blockchain_block:hash_block(Block2), 1),
     SignedPoCReqTxn0 = blockchain_txn_poc_request_v1:sign(PoCReqTxn0, GatewaySigFun),
     {ok, Block26} = test_utils:create_block(ConsensusMembers, [SignedPoCReqTxn0]),
@@ -636,7 +636,7 @@ poc_request_test(Config) ->
     Secret1 = libp2p_crypto:keys_to_bin(Keys1),
     #{public := OnionCompactKey1} = Keys1,
     SecretHash1 = crypto:hash(sha256, Secret1),
-    OnionKeyHash1 = crypto:hash(sha256, libp2p_crypto:pubkey_to_bin(OnionCompactKey1)),
+    OnionKeyHash1 = crypto:hash(sha256, blockchain_utils:pubkey_to_bin(OnionCompactKey1)),
     PoCReqTxn1 = blockchain_txn_poc_request_v1:new(Gateway, SecretHash1, OnionKeyHash1, blockchain_block:hash_block(Block62), 1),
     SignedPoCReqTxn1 = blockchain_txn_poc_request_v1:sign(PoCReqTxn1, GatewaySigFun),
     {ok, Block63} = test_utils:create_block(ConsensusMembers, [SignedPoCReqTxn1]),
@@ -732,7 +732,7 @@ export_test(Config) ->
 
     ?assertEqual({ok, OP}, blockchain_ledger_v1:current_oracle_price(Ledger)),
 
-    Owner = libp2p_crypto:pubkey_to_bin(PayerPubKey1),
+    Owner = blockchain_utils:pubkey_to_bin(PayerPubKey1),
     OwnerSigFun = libp2p_crypto:mk_sig_fun(PayerPrivKey1),
 
     % Step 2: Token burn txn should pass now
@@ -752,7 +752,7 @@ export_test(Config) ->
 
     % Create a Gateway
     #{public := GatewayPubKey, secret := GatewayPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    Gateway = libp2p_crypto:pubkey_to_bin(GatewayPubKey),
+    Gateway = blockchain_utils:pubkey_to_bin(GatewayPubKey),
     GatewaySigFun = libp2p_crypto:mk_sig_fun(GatewayPrivKey),
 
     % Add a Gateway
@@ -1030,7 +1030,7 @@ routing_test(Config) ->
     ?assertEqual({ok, Routing0}, blockchain_ledger_v1:find_routing(OUI1, Ledger)),
 
     #{public := NewPubKey, secret := _PrivKey} = libp2p_crypto:generate_keys(ed25519),
-    Addresses1 = [libp2p_crypto:pubkey_to_bin(NewPubKey)],
+    Addresses1 = [blockchain_utils:pubkey_to_bin(NewPubKey)],
     OUITxn2 = blockchain_txn_routing_v1:update_router_addresses(OUI1, Payer, Addresses1, 1),
     SignedOUITxn2 = blockchain_txn_routing_v1:sign(OUITxn2, SigFun),
     {ok, Block1} = test_utils:create_block(ConsensusMembers, [SignedOUITxn2]),
@@ -1174,7 +1174,7 @@ routing_test(Config) ->
 
     %% Negative test
     #{secret := NegPivKey, public := NegPubKey} = libp2p_crypto:generate_keys(ecc_compact),
-    NegPubKeyBin = libp2p_crypto:pubkey_to_bin(NegPubKey),
+    NegPubKeyBin = blockchain_utils:pubkey_to_bin(NegPubKey),
     NegSigFun = libp2p_crypto:mk_sig_fun(NegPivKey),
     {FilterZ, _} = xor16:to_bin(xor16:new([], fun xxhash:hash64/1)),
     OUITxn04 = blockchain_txn_routing_v1:new_xor(OUI2, NegPubKeyBin, FilterZ, 3),
@@ -1223,7 +1223,7 @@ max_subnet_test(Config) ->
     ?assertEqual({ok, Routing0}, blockchain_ledger_v1:find_routing(OUI1, Ledger)),
 
     #{public := NewPubKey, secret := _PrivKey} = libp2p_crypto:generate_keys(ed25519),
-    Addresses1 = [libp2p_crypto:pubkey_to_bin(NewPubKey)],
+    Addresses1 = [blockchain_utils:pubkey_to_bin(NewPubKey)],
     OUITxn2 = blockchain_txn_routing_v1:update_router_addresses(OUI1, Payer, Addresses1, 1),
     SignedOUITxn2 = blockchain_txn_routing_v1:sign(OUITxn2, SigFun),
     {ok, Block1} = test_utils:create_block(ConsensusMembers, [SignedOUITxn2]),
@@ -2061,7 +2061,7 @@ payer_test(Config) ->
 
 
     #{public := GatewayPubKey, secret := GatewayPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    Gateway = libp2p_crypto:pubkey_to_bin(GatewayPubKey),
+    Gateway = blockchain_utils:pubkey_to_bin(GatewayPubKey),
     GatewaySigFun = libp2p_crypto:mk_sig_fun(GatewayPrivKey),
 
     AddGatewayTx = blockchain_txn_add_gateway_v1:new(Owner, Gateway, Payer),
@@ -2130,7 +2130,7 @@ poc_sync_interval_test(Config) ->
     ConsensusMembers = ?config(consensus_members, Config),
     PubKey = ?config(pubkey, Config),
     PrivKey = ?config(privkey, Config),
-    Owner = libp2p_crypto:pubkey_to_bin(PubKey),
+    Owner = blockchain_utils:pubkey_to_bin(PubKey),
     Chain = ?config(chain, Config),
     Balance = ?config(balance, Config),
     Ledger = blockchain:ledger(Chain),
@@ -2292,10 +2292,10 @@ zero_amt_htlc_create_test(Config) ->
     Chain = ?config(chain, Config),
 
     % Create a Payer
-    Payer = libp2p_crypto:pubkey_to_bin(PubKey),
+    Payer = blockchain_utils:pubkey_to_bin(PubKey),
     % Create a Payee
     #{public := PayeePubKey, secret := _PayeePrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    Payee = libp2p_crypto:pubkey_to_bin(PayeePubKey),
+    Payee = blockchain_utils:pubkey_to_bin(PayeePubKey),
     % Generate a random address
     HTLCAddress = crypto:strong_rand_bytes(33),
     % Create a Hashlock
@@ -2315,10 +2315,10 @@ negative_amt_htlc_create_test(Config) ->
     Chain = ?config(chain, Config),
 
     % Create a Payer
-    Payer = libp2p_crypto:pubkey_to_bin(PubKey),
+    Payer = blockchain_utils:pubkey_to_bin(PubKey),
     % Create a Payee
     #{public := PayeePubKey, secret := _PayeePrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    Payee = libp2p_crypto:pubkey_to_bin(PayeePubKey),
+    Payee = blockchain_utils:pubkey_to_bin(PayeePubKey),
     % Generate a random address
     HTLCAddress = crypto:strong_rand_bytes(33),
     % Create a Hashlock
@@ -2369,7 +2369,7 @@ update_gateway_oui_test(Config) ->
 
     % Step 3: Create a Gateway and OUI
     #{public := GatewayPubKey, secret := GatewayPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    Gateway = libp2p_crypto:pubkey_to_bin(GatewayPubKey),
+    Gateway = blockchain_utils:pubkey_to_bin(GatewayPubKey),
     GatewaySigFun = libp2p_crypto:mk_sig_fun(GatewayPrivKey),
     AddGatewayTxn = blockchain_txn_add_gateway_v1:new(Owner, Gateway),
     SignedOwnerAddGatewayTxn = blockchain_txn_add_gateway_v1:sign(AddGatewayTxn, OwnerSigFun),
@@ -2548,7 +2548,7 @@ failed_txn_error_handling(Config) ->
     ConsensusMembers = ?config(consensus_members, Config),
     PubKey = ?config(pubkey, Config),
     PrivKey = ?config(privkey, Config),
-    Owner = libp2p_crypto:pubkey_to_bin(PubKey),
+    Owner = blockchain_utils:pubkey_to_bin(PubKey),
     Chain = ?config(chain, Config),
     Balance = ?config(balance, Config),
 
@@ -2610,7 +2610,7 @@ failed_txn_error_handling(Config) ->
 
     % Create a Gateway
     #{public := GatewayPubKey, secret := GatewayPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    Gateway = libp2p_crypto:pubkey_to_bin(GatewayPubKey),
+    Gateway = blockchain_utils:pubkey_to_bin(GatewayPubKey),
     GatewaySigFun = libp2p_crypto:mk_sig_fun(GatewayPrivKey),
 
     % Add a Gateway
@@ -2648,7 +2648,7 @@ failed_txn_error_handling(Config) ->
     Secret0 = libp2p_crypto:keys_to_bin(Keys0),
     #{public := OnionCompactKey0} = Keys0,
     SecretHash0 = crypto:hash(sha256, Secret0),
-    OnionKeyHash0 = crypto:hash(sha256, libp2p_crypto:pubkey_to_bin(OnionCompactKey0)),
+    OnionKeyHash0 = crypto:hash(sha256, blockchain_utils:pubkey_to_bin(OnionCompactKey0)),
     PoCReqTxn0 = blockchain_txn_poc_request_v1:new(Gateway, SecretHash0, OnionKeyHash0, blockchain_block:hash_block(Block2), 1),
     SignedPoCReqTxn0 = blockchain_txn_poc_request_v1:sign(PoCReqTxn0, GatewaySigFun),
 
@@ -2693,7 +2693,7 @@ failed_txn_error_handling(Config) ->
 
 create_gateway() ->
     #{public := GatewayPubKey, secret := GatewayPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
-    Gateway = libp2p_crypto:pubkey_to_bin(GatewayPubKey),
+    Gateway = blockchain_utils:pubkey_to_bin(GatewayPubKey),
     GatewaySigFun = libp2p_crypto:mk_sig_fun(GatewayPrivKey),
     {Gateway, GatewaySigFun}.
 
@@ -2727,6 +2727,6 @@ fake_poc_request(Gateway, GatewaySigFun, BlockHash) ->
     Secret0 = libp2p_crypto:keys_to_bin(Keys0),
     #{public := OnionCompactKey0} = Keys0,
     SecretHash0 = crypto:hash(sha256, Secret0),
-    OnionKeyHash0 = crypto:hash(sha256, libp2p_crypto:pubkey_to_bin(OnionCompactKey0)),
+    OnionKeyHash0 = crypto:hash(sha256, blockchain_utils:pubkey_to_bin(OnionCompactKey0)),
     PoCReqTxn0 = blockchain_txn_poc_request_v1:new(Gateway, SecretHash0, OnionKeyHash0, BlockHash, 1),
     blockchain_txn_poc_request_v1:sign(PoCReqTxn0, GatewaySigFun).

--- a/test/blockchain_state_channel_SUITE.erl
+++ b/test/blockchain_state_channel_SUITE.erl
@@ -1080,9 +1080,9 @@ unknown_owner_test(Config) ->
     RouterChain = ct_rpc:call(RouterNode, blockchain_worker, blockchain, []),
     RouterSwarm = ct_rpc:call(RouterNode, blockchain_swarm, swarm, []),
     {ok, RouterPubkey, RouterSigFun, _} = ct_rpc:call(RouterNode, blockchain_swarm, keys, []),
-    RouterPubkeyBin = libp2p_crypto:pubkey_to_bin(RouterPubkey),
+    RouterPubkeyBin = blockchain_utils:pubkey_to_bin(RouterPubkey),
     {ok, PayerPubkey, _, _} = ct_rpc:call(PayerNode, blockchain_swarm, keys, []),
-    PayerPubkeyBin = libp2p_crypto:pubkey_to_bin(PayerPubkey),
+    PayerPubkeyBin = blockchain_utils:pubkey_to_bin(PayerPubkey),
 
     %% Create OUI txn
     SignedOUITxn = create_oui_txn(1, RouterNode, [], 8),
@@ -1969,20 +1969,20 @@ get_consensus_members(Config, ConsensusAddrs) ->
 
 create_oui_txn(OUI, RouterNode, EUIs, SubnetSize) ->
     {ok, RouterPubkey, RouterSigFun, _} = ct_rpc:call(RouterNode, blockchain_swarm, keys, []),
-    RouterPubkeyBin = libp2p_crypto:pubkey_to_bin(RouterPubkey),
+    RouterPubkeyBin = blockchain_utils:pubkey_to_bin(RouterPubkey),
     {Filter, _} = xor16:to_bin(xor16:new([ <<DevEUI:64/integer-unsigned-little, AppEUI:64/integer-unsigned-little>> || {DevEUI, AppEUI} <- EUIs], fun xxhash:hash64/1)),
     OUITxn = blockchain_txn_oui_v1:new(OUI, RouterPubkeyBin, [RouterPubkeyBin], Filter, SubnetSize),
     blockchain_txn_oui_v1:sign(OUITxn, RouterSigFun).
 
 create_sc_open_txn(RouterNode, ID, Expiry, OUI, Nonce) ->
     {ok, RouterPubkey, RouterSigFun, _} = ct_rpc:call(RouterNode, blockchain_swarm, keys, []),
-    RouterPubkeyBin = libp2p_crypto:pubkey_to_bin(RouterPubkey),
+    RouterPubkeyBin = blockchain_utils:pubkey_to_bin(RouterPubkey),
     SCOpenTxn = blockchain_txn_state_channel_open_v1:new(ID, RouterPubkeyBin, Expiry, OUI, Nonce, 20),
     blockchain_txn_state_channel_open_v1:sign(SCOpenTxn, RouterSigFun).
 
 create_update_gateway_oui_txn(GatewayNode, OUI, Nonce, OwnerSigFun, RouterSigFun) ->
     {ok, GatewayPubkey, _, _} = ct_rpc:call(GatewayNode, blockchain_swarm, keys, []),
-    GatewayPubkeyBin = libp2p_crypto:pubkey_to_bin(GatewayPubkey),
+    GatewayPubkeyBin = blockchain_utils:pubkey_to_bin(GatewayPubkey),
     UpdateGatewayOUITxn = blockchain_txn_update_gateway_oui_v1:new(GatewayPubkeyBin, OUI, Nonce),
 
     STx0 = blockchain_txn_update_gateway_oui_v1:gateway_owner_sign(UpdateGatewayOUITxn, OwnerSigFun),

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -153,7 +153,7 @@ generate_plain_keys(N, Type) ->
     lists:foldl(
         fun(_, Acc) ->
             #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(Type),
-            [{libp2p_crypto:pubkey_to_bin(PubKey), PubKey, PrivKey}|Acc]
+            [{blockchain_utils:pubkey_to_bin(PubKey), PubKey, PrivKey}|Acc]
         end
         ,[]
         ,lists:seq(1, N)
@@ -167,7 +167,7 @@ generate_keys(N, Type) ->
         fun(_, Acc) ->
             #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(Type),
             SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
-            [{libp2p_crypto:pubkey_to_bin(PubKey), {PubKey, PrivKey, SigFun}}|Acc]
+            [{blockchain_utils:pubkey_to_bin(PubKey), {PubKey, PrivKey, SigFun}}|Acc]
         end
         ,[]
         ,lists:seq(1, N)


### PR DESCRIPTION
This replaces all uses of libp2p_crypto:bin_to_pubkey and pubkey_to_bin with a blockchain_utils intermediary which uses the chain network as defined by a chain variable (and cached in a persistent_term for speed)