### PR TITLE
Fix crash when there's only one price

### DIFF
--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -1956,6 +1956,7 @@ select_prices_by_time(Start, End, Entry, Acc) ->
         true -> Acc
     end.
 
+median([P]) -> P; %% if there's only 1 entry, use it
 median(L) ->
     Sorted = lists:sort(L),
     Len = length(L),


### PR DESCRIPTION
Problem to solve: During bringing up testnet, we found that the oracle crashes if there's only one price estimate in the list of prices to consider when recalculating the median price.

Solution: If we have a list of one element, return the element.