### PR TITLE
don't fetch a million blocks for their height

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -15,7 +15,7 @@
     ledger/0, ledger/1, ledger/2, ledger_at/2, ledger_at/3,
     dir/1,
 
-    blocks/1, get_block/2, get_raw_block/2, save_block/2,
+    blocks/1, get_block/2, get_block_hash/2, get_raw_block/2, save_block/2,
     has_block/2,
     find_first_block_after/2,
 
@@ -587,6 +587,16 @@ get_block(Height, #blockchain{db=DB, heights=HeightsCF}=Blockchain) ->
     case rocksdb:get(DB, HeightsCF, <<Height:64/integer-unsigned-big>>, []) of
        {ok, Hash} ->
            ?MODULE:get_block(Hash, Blockchain);
+        not_found ->
+            {error, not_found};
+        Error ->
+            Error
+    end.
+
+get_block_hash(Height, #blockchain{db=DB, heights=HeightsCF}) ->
+    case rocksdb:get(DB, HeightsCF, <<Height:64/integer-unsigned-big>>, []) of
+       {ok, Hash} ->
+            {ok, Hash};
         not_found ->
             {error, not_found};
         Error ->

--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -877,6 +877,8 @@ add_block_(Block, Blockchain, Syncing) ->
                     case blockchain_block_v1:snapshot_hash(Block) of
                         <<>> ->
                             ok;
+                        %% check the snap height as it's pointless to do this work for the snapshot
+                        %% we're currently in the process of loading
                         ConsensusHash when Height /= (SnapHeight - 1) ->
                             process_snapshot(ConsensusHash, MyAddress, Signers,
                                              Ledger, Height, Blockchain);

--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -872,12 +872,15 @@ add_block_(Block, Blockchain, Syncing) ->
                               _ -> absorb_and_commit
                           end,
                     Ledger = blockchain:ledger(Blockchain),
+                    %% 0 can never be true below
+                    SnapHeight = application:get_env(blockchain, blessed_snapshot_block_height, 0),
                     case blockchain_block_v1:snapshot_hash(Block) of
                         <<>> ->
                             ok;
-                        ConsensusHash ->
+                        ConsensusHash when Height /= (SnapHeight - 1) ->
                             process_snapshot(ConsensusHash, MyAddress, Signers,
-                                             Ledger, Height, Blockchain)
+                                             Ledger, Height, Blockchain);
+                        _ -> ok
                     end,
                     case blockchain_txn:Fun(Block, Blockchain, BeforeCommit, IsRescue) of
                         {error, Reason}=Error ->

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -442,6 +442,8 @@ import(Chain, SHA,
                  blockchain_ledger_v1:commit_context(Ledger)
              end
              || Mode <- [delayed, active]],
+            %% TODO: it might make more sense to do this block by block?  it will at least be
+            %% cheaper to do it that way.
             Ledger2 = blockchain_ledger_v1:new_context(Ledger0),
             Chain1 = blockchain:ledger(Ledger2, Chain),
             {ok, Curr2} = blockchain_ledger_v1:current_height(Ledger2),
@@ -464,8 +466,10 @@ import(Chain, SHA,
                                   end,
 
                               Ht = blockchain_block:height(Block),
+                              %% since hash and block are written at the same time, just getting the
+                              %% hash from the height is an acceptable presence check, and much cheaper
                               case blockchain:get_block_hash(Ht, Chain) of
-                                  {ok, _Block} ->
+                                  {ok, _Hash} ->
                                       %% already have it, don't need to store it again.
                                       ok;
                                   _ ->

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -464,7 +464,7 @@ import(Chain, SHA,
                                   end,
 
                               Ht = blockchain_block:height(Block),
-                              case blockchain:get_block(Ht, Chain) of
+                              case blockchain:get_block_hash(Ht, Chain) of
                                   {ok, _Block} ->
                                       %% already have it, don't need to store it again.
                                       ok;

--- a/src/state_channel/blockchain_state_channels_client.erl
+++ b/src/state_channel/blockchain_state_channels_client.erl
@@ -170,12 +170,9 @@ handle_cast({reject, Rejection, HandlerPid}, State) ->
                end,
     {noreply, NewState};
 handle_cast({gc_state_channels, SCIDs}, #state{pending_closes=P, db=DB, cf=CF}=State) ->
-    {ok, Batch} = rocksdb:batch(),
     lists:foreach(fun(SCID) ->
-                          rocksdb:batch_delete(Batch, CF, SCID)
+                          rocksdb:delete(DB, CF, SCID)
                   end, SCIDs),
-    ok = rocksdb:write_batch(DB, Batch, [{sync, true}]),
-    rocksdb:release_batch(Batch),
     {noreply, State#state{pending_closes=P -- SCIDs}};
 handle_cast(_Msg, State) ->
     lager:debug("unhandled receive: ~p", [_Msg]),


### PR DESCRIPTION
this PR both increases the pace of poc gc (trying to make them cheaper), and also fetches only the block hash for the relevant blocks from the disk, which should make the gc dramatically cheaper.

it also removes a large sync write from the state channel client which doesn't seem to be required.