### PR TITLE
Add support for payment-v2 memo field

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -272,6 +272,8 @@
 -define(max_payments, max_payments).
 %% Var to switch off legacy payment txn
 -define(deprecate_payment_v1, deprecate_payment_v1).
+%% Enable payment-v2 memos
+-define(allow_payment_v2_memos, allow_payment_v2_memos).
 
 %% Set this var to false to disable zero amount txns (payment_v1, payment_v2, htlc_create)
 -define(allow_zero_amount, allow_zero_amount).

--- a/rebar.config
+++ b/rebar.config
@@ -39,7 +39,7 @@
     {erlang_stats, ".*", {git, "https://github.com/helium/erlang-stats.git", {branch, "master"}}},
     {e2qc, ".*", {git, "https://github.com/helium/e2qc", {branch, "master"}}},
     {vincenty, ".*", {git, "https://github.com/helium/vincenty", {branch, "master"}}},
-    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "master"}}},
+    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "rg/payment-v2-memos"}}},
     {merkerl, ".*", {git, "https://github.com/helium/merkerl.git", {branch, "master"}}},
     {xxhash, {git, "https://github.com/pierreis/erlang-xxhash", {branch, "master"}}},
     {exor_filter, ".*", {git, "https://github.com/mpope9/exor_filter", {branch, "master"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -39,7 +39,7 @@
     {erlang_stats, ".*", {git, "https://github.com/helium/erlang-stats.git", {branch, "master"}}},
     {e2qc, ".*", {git, "https://github.com/helium/e2qc", {branch, "master"}}},
     {vincenty, ".*", {git, "https://github.com/helium/vincenty", {branch, "master"}}},
-    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "rg/payment-v2-memos"}}},
+    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "master"}}},
     {merkerl, ".*", {git, "https://github.com/helium/merkerl.git", {branch, "master"}}},
     {xxhash, {git, "https://github.com/pierreis/erlang-xxhash", {branch, "master"}}},
     {exor_filter, ".*", {git, "https://github.com/mpope9/exor_filter", {branch, "master"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -41,7 +41,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"456591707ec9061776819ffba45de4940acae956"}},
+       {ref,"7f1deaf412f3c062263f52e4f6b994ff8a3157f3"}},
   0},
  {<<"inert">>,{pkg,<<"inert">>,<<"1.0.1">>},2},
  {<<"inet_cidr">>,{pkg,<<"erl_cidr">>,<<"1.0.2">>},2},

--- a/rebar.lock
+++ b/rebar.lock
@@ -41,7 +41,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"7f1deaf412f3c062263f52e4f6b994ff8a3157f3"}},
+       {ref,"b55d801643a2b8df1bc366a2a074f29b97a75526"}},
   0},
  {<<"inert">>,{pkg,<<"inert">>,<<"1.0.1">>},2},
  {<<"inet_cidr">>,{pkg,<<"erl_cidr">>,<<"1.0.2">>},2},

--- a/rebar.lock
+++ b/rebar.lock
@@ -41,7 +41,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"b55d801643a2b8df1bc366a2a074f29b97a75526"}},
+       {ref,"4a4f44e98b2973d71aa8a2ebb34196ded320acfb"}},
   0},
  {<<"inert">>,{pkg,<<"inert">>,<<"1.0.1">>},2},
  {<<"inet_cidr">>,{pkg,<<"erl_cidr">>,<<"1.0.2">>},2},

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -953,6 +953,13 @@ validate_var(?deprecate_payment_v1, Value) ->
         _ -> throw({error, {invalid_deprecate_payment_v1, Value}})
     end;
 
+validate_var(?allow_payment_v2_memos, Value) ->
+    case Value of
+        true -> ok;
+        false -> ok;
+        _ -> throw({error, {invalid_allow_payment_v2_memos, Value}})
+    end;
+
 validate_var(?allow_zero_amount, Value) ->
     case Value of
         true -> ok;

--- a/src/transactions/v2/blockchain_payment_v2.erl
+++ b/src/transactions/v2/blockchain_payment_v2.erl
@@ -15,6 +15,7 @@
          payee/1,
          amount/1,
          memo/1, memo/2,
+         is_valid_memo/1,
          print/1,
          to_json/2
         ]).
@@ -62,6 +63,16 @@ memo(Payment) ->
 -spec memo(Payment :: payment(), Memo :: non_neg_integer()) -> payment().
 memo(Payment, Memo) ->
     Payment#payment_pb{memo=Memo}.
+
+-spec is_valid_memo(Payment :: payment()) -> boolean().
+is_valid_memo(#payment_pb{memo = Memo}) ->
+    try
+        Bin = binary:encode_unsigned(Memo, big),
+        bit_size(Bin) =< 64
+    catch _:_ ->
+            %% we can't do this, invalid
+            false
+    end.
 
 print(undefined) ->
     <<"type=payment undefined">>;

--- a/src/transactions/v2/blockchain_payment_v2.erl
+++ b/src/transactions/v2/blockchain_payment_v2.erl
@@ -72,7 +72,8 @@ print(#payment_pb{payee=Payee, amount=Amount, memo=Memo}) ->
 to_json(Payment, _Opts) ->
     #{
       payee => ?BIN_TO_B58(payee(Payment)),
-      amount => amount(Payment)
+      amount => amount(Payment),
+      memo => ?MAYBE_UNDEFINED(memo(Payment))
      }.
 
 %% ------------------------------------------------------------------

--- a/src/transactions/v2/blockchain_payment_v2.erl
+++ b/src/transactions/v2/blockchain_payment_v2.erl
@@ -11,9 +11,10 @@
 -include_lib("helium_proto/include/blockchain_txn_payment_v2_pb.hrl").
 
 -export([
-         new/2,
+         new/2, new/3,
          payee/1,
          amount/1,
+         memo/1, memo/2,
          print/1,
          to_json/2
         ]).
@@ -32,7 +33,18 @@
 new(Payee, Amount) ->
     #payment_pb{
        payee=Payee,
-       amount=Amount
+       amount=Amount,
+       memo=0
+      }.
+
+-spec new(Payee :: libp2p_crypto:pubkey_bin(),
+          Amount :: non_neg_integer(),
+          Memo :: non_neg_integer()) -> payment().
+new(Payee, Amount, Memo) ->
+    #payment_pb{
+       payee=Payee,
+       amount=Amount,
+       memo=Memo
       }.
 
 -spec payee(Payment :: payment()) -> libp2p_crypto:pubkey_bin().
@@ -43,10 +55,18 @@ payee(Payment) ->
 amount(Payment) ->
     Payment#payment_pb.amount.
 
+-spec memo(Payment :: payment()) -> undefined | non_neg_integer().
+memo(Payment) ->
+    Payment#payment_pb.memo.
+
+-spec memo(Payment :: payment(), Memo :: non_neg_integer()) -> payment().
+memo(Payment, Memo) ->
+    Payment#payment_pb{memo=Memo}.
+
 print(undefined) ->
     <<"type=payment undefined">>;
-print(#payment_pb{payee=Payee, amount=Amount}) ->
-    io_lib:format("type=payment payee: ~p amount: ~p", [?TO_B58(Payee), Amount]).
+print(#payment_pb{payee=Payee, amount=Amount, memo=Memo}) ->
+    io_lib:format("type=payment payee: ~p amount: ~p, memo: ~p", [?TO_B58(Payee), Amount, Memo]).
 
 -spec to_json(payment(), blockchain_json:opts()) -> blockchain_json:json_object().
 to_json(Payment, _Opts) ->

--- a/src/transactions/v2/blockchain_txn_payment_v2.erl
+++ b/src/transactions/v2/blockchain_txn_payment_v2.erl
@@ -274,7 +274,7 @@ memo_check(Txn, Ledger) ->
             %% old behavior before var, allow only if memo=0 (default)
             case has_default_memos(Payments) of
                 true -> ok;
-                false -> {error, non_default_memo_before_memo_allowance}
+                false -> {error, invalid_memo_before_var}
             end
     end.
 
@@ -317,7 +317,8 @@ has_valid_memos(Payments) ->
 has_default_memos(Payments) ->
     lists:all(
         fun(Payment) ->
-            0 == blockchain_payment_v2:memo(Payment)
+            0 == blockchain_payment_v2:memo(Payment) orelse
+                undefined == blockchain_payment_v2:memo(Payment)
         end,
         Payments
     ).

--- a/src/transactions/v2/blockchain_txn_payment_v2.erl
+++ b/src/transactions/v2/blockchain_txn_payment_v2.erl
@@ -305,10 +305,15 @@ has_non_zero_amounts(Payments) ->
 has_valid_memos(Payments) ->
     lists:all(
         fun(Payment) ->
-            ok ==
-                blockchain_txn:validate_fields([
-                    {{memo, blockchain_payment_v2:memo(Payment)}, {is_integer, 0}}
-                ])
+                %% check that the memo field is valid
+                FieldCheck = blockchain_txn:validate_fields([ {{memo, blockchain_payment_v2:memo(Payment)}, {is_integer, 0}} ]),
+                case FieldCheck of
+                    ok ->
+                        %% check that the memo field is within limits
+                        blockchain_payment_v2:is_valid_memo(Payment);
+                    _ ->
+                        false
+                end
         end,
         Payments
     ).

--- a/test/blockchain_payment_v2_SUITE.erl
+++ b/test/blockchain_payment_v2_SUITE.erl
@@ -492,7 +492,7 @@ invalid_memo_not_set_test(Config) ->
     %% which does validations, this will suffice for now
     %% NOTE: SignedTx being in the second pos implies it's invalid
     {[], [{SignedTx, InvalidReason}]} = blockchain_txn:validate([SignedTx], Chain),
-    ?assertEqual(non_default_memo_before_memo_allowance, InvalidReason),
+    ?assertEqual(invalid_memo_before_var, InvalidReason),
     ok.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
Enables support for specifying a uint64 memo for a payment-v2.

Notes:
- Introduces `allow_payment_v2_memos` boolean chain variable
- If the var is not set, existing payment-v2s will have memo=0 as default
- If the var is set, as long as the memo lies between 0 - 2^64 it will be considered valid
- Add some test cases to verify said logic
- Update and refactor payment-v2 txn validation

TODO:
- [x] Switch proto to master once [proto#72](https://github.com/helium/proto/pull/72) lands.