### PR TITLE
Wire up stake_release_height in txn and ledger

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -436,6 +436,7 @@
 -define(validator_liveness_interval, validator_liveness_interval).  % blocks
 -define(validator_liveness_grace_period, validator_liveness_grace_period).  % blocks
 -define(stake_withdrawl_cooldown, stake_withdrawl_cooldown). % blocks
+-define(stake_withdrawl_max, stake_withdrawal_max). % blocks
 %% -define(maximum_overstake, maximum_overstake). % float multiple of min stake
 
 -define(penalty_history_limit, penalty_history_limit). % blocks

--- a/rebar.lock
+++ b/rebar.lock
@@ -41,7 +41,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"456591707ec9061776819ffba45de4940acae956"}},
+       {ref,"85a5d31353446c8a60880798466a7f45a2aa4d5f"}},
   0},
  {<<"inert">>,{pkg,<<"inert">>,<<"1.0.1">>},2},
  {<<"inet_cidr">>,{pkg,<<"erl_cidr">>,<<"1.0.2">>},2},

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1160,6 +1160,8 @@ validate_var(?validator_liveness_grace_period, Value) ->
 validate_var(?stake_withdrawl_cooldown, Value) ->
     %% maybe set this in the test
     validate_int(Value, "stake_withdrawl_cooldown", 5, 1000000, false);
+validate_var(?stake_withdrawl_max, Value) ->
+    validate_int(Value, "stake_withdrawl_max", 500, 10000, false);
 
 validate_var(?dkg_penalty, Value) ->
     validate_float(Value, "dkg_penalty", 0.0, 5.0);


### PR DESCRIPTION
Problem to solve: We want owners to explicitly agree to a defined stake release height when unstaking, since stakes in a cooldown state are unable to earn new HNT or transfer HNT.  This PR implements that.

Addresses helium/miner#736

See also helium/proto#74