### PR TITLE
Optimization for searching for poc_requests

### DIFF
--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -1369,8 +1369,8 @@ get_channels(Txn, Chain) ->
                                     blockchain_txn:type(T) == blockchain_txn_poc_request_v1 andalso
                                     blockchain_txn_poc_request_v1:onion_key_hash(T) == OnionKeyHash
                             end,
-
-            {ok, Head} = blockchain:head_block(Chain),
+            {ok, CurrentHeight} = blockchain_ledger_v1:current_height(blockchain:ledger(Chain)),
+            {ok, Head} = blockchain:get_block(CurrentHeight, Chain),
             blockchain:fold_chain(fun(Block, undefined) ->
                                                       case blockchain_utils:find_txn(Block, RequestFilter) of
                                                           [_T] ->


### PR DESCRIPTION
In get_channels we were using `blockhain:head_block` to start looking for poc_requests for a given onion hash.

This works for normal setups but when a blockchain.db is available that has many more blocks than the current ledger height, a _huge_ perfomance hit is incurred by searching from a much later block back to the current one before going back in height to actually fine the poc_request within a few blocks.

I believe this change is  completely backwards compatible