### PR TITLE
Only do ledger_at if necessary

### DIFF
--- a/src/transactions/v2/blockchain_txn_rewards_v2.erl
+++ b/src/transactions/v2/blockchain_txn_rewards_v2.erl
@@ -1278,7 +1278,7 @@ share_of_dc_rewards(Key, Vars=#{dc_remainder := DCRemainder}) ->
 maybe_ledger_at(End, Chain) ->
     Ledger = blockchain:ledger(Chain),
     case blockchain_ledger_v1:current_height(Ledger) of
-        {ok, Height} when Height == End ->
+        {ok, Height} when Height == End + 1 ->
             {ok, Ledger};
         _ ->
             blockchain:ledger_at(End, Chain)

--- a/src/transactions/v2/blockchain_txn_rewards_v2.erl
+++ b/src/transactions/v2/blockchain_txn_rewards_v2.erl
@@ -1277,12 +1277,14 @@ share_of_dc_rewards(Key, Vars=#{dc_remainder := DCRemainder}) ->
     {error, any()}.
 maybe_ledger_at(End, Chain) ->
     Ledger = blockchain:ledger(Chain),
-    case blockchain_ledger_v1:current_height(Ledger) of
-        {ok, Height} when Height == End + 1 ->
+
+    case blockchain_ledger_v1:has_aux(Ledger) of
+        true ->
             {ok, Ledger};
-        _ ->
+        false ->
             blockchain:ledger_at(End, Chain)
     end.
+
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests


### PR DESCRIPTION
When calculating rewards_v2, only invoke `ledger_at` if necessary. Expectation is that this would also fix aux ledger invocations.

TODO:
- [ ] Manual testing