### PR TITLE
Fix for loading a snapshot with an aux ledger

### DIFF
--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -412,7 +412,7 @@ import(Chain, SHA, #{version := v6}=Snapshot) ->
     case blockchain_ledger_v1:has_aux(Ledger0) of
         true ->
             load_into_ledger(Snapshot, Ledger0, aux),
-            load_blocks(blockchain_ledger_v1:mode(aux, Ledger0), Chain, Snapshot);
+            load_blocks(blockchain_ledger_v1:mode(aux_load, Ledger0), Chain, Snapshot);
         false ->
             ok
     end,

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -331,7 +331,7 @@
 -define(BITS_25, 33554431). %% biggest unsigned number in 25 bits
 -define(DEFAULT_ORACLE_PRICE, 0).
 
--type mode() :: active | delayed | aux.
+-type mode() :: active | delayed | aux | aux_load.
 -type ledger() :: #ledger_v1{}.
 -type sub_ledger() :: #sub_ledger_v1{}.
 -type aux_ledger() :: #aux_ledger_v1{}.
@@ -530,7 +530,7 @@ bootstrap_aux(Path, Ledger) ->
             end
     end.
 
--spec mode(ledger()) -> active | delayed | aux.
+-spec mode(ledger()) -> mode().
 mode(Ledger) ->
     Ledger#ledger_v1.mode.
 
@@ -538,7 +538,7 @@ mode(Ledger) ->
 has_aux(Ledger) ->
     Ledger#ledger_v1.aux /= undefined.
 
--spec mode(active | delayed | aux, ledger()) -> ledger().
+-spec mode(mode(), ledger()) -> ledger().
 mode(aux, #ledger_v1{aux=undefined}) ->
     error(no_aux_ledger);
 mode(Mode, Ledger) ->
@@ -919,7 +919,7 @@ subledger(Ledger = #ledger_v1{mode=Mode}) ->
     case Mode of
         active -> Ledger#ledger_v1.active;
         delayed -> Ledger#ledger_v1.delayed;
-        aux -> Ledger#ledger_v1.aux#aux_ledger_v1.aux
+        T when T == aux; T == aux_load -> Ledger#ledger_v1.aux#aux_ledger_v1.aux
     end.
 
 -spec subledger(ledger(), sub_ledger()) -> ledger().
@@ -927,7 +927,7 @@ subledger(Ledger = #ledger_v1{mode=Mode}, NewSubLedger) ->
     case Mode of
         active -> Ledger#ledger_v1{active=NewSubLedger};
         delayed -> Ledger#ledger_v1{delayed=NewSubLedger};
-        aux -> Ledger#ledger_v1{aux=Ledger#ledger_v1.aux#aux_ledger_v1{aux=NewSubLedger}}
+        T when T == aux; T == aux_load -> Ledger#ledger_v1{aux=Ledger#ledger_v1.aux#aux_ledger_v1{aux=NewSubLedger}}
     end.
 
 -spec db(ledger()) -> rocksdb:db_handle().
@@ -935,7 +935,7 @@ db(Ledger = #ledger_v1{mode=Mode}) ->
     case Mode of
         active -> Ledger#ledger_v1.db;
         delayed -> Ledger#ledger_v1.db;
-        aux -> Ledger#ledger_v1.aux#aux_ledger_v1.db
+        T when T == aux; T == aux_load -> Ledger#ledger_v1.aux#aux_ledger_v1.db
     end.
 
 

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -650,9 +650,10 @@ context_cache(Ledger) ->
 new_snapshot(#ledger_v1{db=DB,
                         snapshot=undefined,
                         snapshots=Cache,
-                        mode=active,
+                        mode=Mode,
                         active=#sub_ledger_v1{cache=undefined},
-                        delayed=#sub_ledger_v1{cache=undefined}}=Ledger) ->
+                        delayed=#sub_ledger_v1{cache=undefined}}=Ledger)
+  when Mode == active; Mode == aux_load ->
     {ok, Height} = current_height(Ledger),
     Me = self(),
     Old = {Height, {pending, Me}},

--- a/src/transactions/v2/blockchain_txn_rewards_v2.erl
+++ b/src/transactions/v2/blockchain_txn_rewards_v2.erl
@@ -206,7 +206,7 @@ calculate_rewards(Start, End, Chain) ->
         Ledger :: blockchain_ledger_v1:ledger(),
         Chain :: blockchain:blockchain()) -> {error, any()} | {ok, rewards()}.
 calculate_rewards_(Start, End, Ledger, Chain) ->
-    {ok, Results} = calculate_rewards_metadata(Start, End, Chain),
+    {ok, Results} = calculate_rewards_metadata(Start, End, blockchain:ledger(Ledger, Chain)),
     try
         {ok, prepare_rewards_v2_txns(Results, Ledger)}
     catch


### PR DESCRIPTION
Adds an `aux_load` mode which is only used for loading a snapshot to the aux ledger