### PR TITLE
Implement blockchain GC for older snapshots and blocks

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -1946,7 +1946,7 @@ add_bin_snapshot(BinSnap, Height, Hash, #blockchain{db=DB, dir=Dir, snapshots=Sn
 
 rocksdb_gc(BytesToDrop, #blockchain{db=DB, heights=HeightsCF}=Blockchain) ->
     {ok, Height} = blockchain:height(Blockchain),
-    CutoffHeight = max(2, Height - 100000),
+    CutoffHeight = max(2, Height - application:get_env(blockchain, blocks_to_protect_from_gc, 10000)),
     %% start at 2 here so we don't GC the genesis block
     {ok, Itr} = rocksdb:iterator(DB, HeightsCF, [{iterate_lower_bound, <<2:64/integer-unsigned-big>>}, {iterate_upper_bound, <<CutoffHeight:64/integer-unsigned-big>>}]),
     do_rocksdb_gc(BytesToDrop, Itr, Blockchain,  rocksdb:iterator_move(Itr, first)).

--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -2164,7 +2164,7 @@ load(Dir, Mode) ->
                             lager:notice("System requested we free ~b bytes of disk space"),
                             Pid = spawn(fun() -> rocksdb_gc(BytesToGC, Blockchain) end),
                             lager:info("Starting rocksdb gc on pid ~p", [Pid]),
-                            ok = blockchain_worker:monitor_rocksdb_gc(Pid);
+                            ok = blockchain_worker:monitor_rocksdb_gc(Pid)
                     catch _:_ ->
                               ok
                     end

--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -2177,7 +2177,7 @@ load(Dir, Mode) ->
                 ValString ->
                     try list_to_integer(ValString, 10) of
                         BytesToGC ->
-                            lager:notice("System requested we free ~b bytes of disk space"),
+                            lager:notice("System requested we free ~b bytes of disk space", [BytesToGC]),
                             Pid = spawn(fun() -> rocksdb_gc(BytesToGC, Blockchain) end),
                             lager:info("Starting rocksdb gc on pid ~p", [Pid]),
                             ok = blockchain_worker:monitor_rocksdb_gc(Pid)

--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -1956,7 +1956,7 @@ do_rocksdb_gc(_Bytes, _Itr, _Blockchain, {error, _}) ->
 do_rocksdb_gc(Bytes, _Itr, _Blockchain, _Res) when Bytes < 1 ->
     ok;
 do_rocksdb_gc(Bytes, Itr, #blockchain{dir=Dir, db=DB, heights=HeightsCF, blocks=BlocksCF, snapshots=SnapshotsCF}=Blockchain, {ok, <<IntHeight:64/integer-unsigned-big>>=Height, Hash}) ->
-    lager:info("GCing block at height ~p", [IntHeight]),
+    lager:info("GCing block at height ~p, ~b bytes remain", [IntHeight, Bytes]),
     BytesRemoved0 = case rocksdb:get(DB, BlocksCF, Hash, []) of
                         {ok, Block} -> byte_size(Block);
                         _ -> 0

--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -590,7 +590,7 @@ handle_cast({snapshot_sync, Hash, Height}, State) ->
 handle_cast({async_reset, _Height}, State) ->
     lager:info("got async_reset at height ~p, ignoring", [_Height]),
     {noreply, State};
-handle_cast([monitor_rocksdb_gc, Pid}, State) ->
+handle_cast({monitor_rocksdb_gc, Pid}, State) ->
     MRef = monitor(process, Pid),
     {noreply, State#state{rocksdb_gc_mref = MRef}};
 
@@ -686,7 +686,7 @@ handle_info({'DOWN', RocksGCRef, process, RocksGCPid, Reason},
         Reason ->
             lager:error("rocksdb_gc pid ~p crashed because ~p", [RocksGCPid, Reason])
     end,
-    {noreply, State#{rocksdb_gc_mref = undefined}};
+    {noreply, State#state{rocksdb_gc_mref = undefined}};
 
 handle_info({blockchain_event, {new_chain, NC}}, State) ->
     {noreply, State#state{blockchain = NC}};

--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -54,7 +54,9 @@
     grab_snapshot/2,
 
     add_commit_hook/3, add_commit_hook/4,
-    remove_commit_hook/1
+    remove_commit_hook/1,
+
+    monitor_rocksdb_gc/1
 ]).
 
 %% ------------------------------------------------------------------
@@ -99,6 +101,7 @@
          absorb_retries = 3 :: pos_integer(),
          resync_info :: undefined | {pid(), reference()},
          resync_retries = 3 :: pos_integer(),
+         rocksdb_gc_mref :: undefined | reference(),
          mode :: snapshot | normal | reset
         }).
 
@@ -269,6 +272,9 @@ add_commit_hook(CF, HookIncFun, HookEndFun, Pred) ->
 
 remove_commit_hook(RefOrAtom) ->
     gen_server:call(?SERVER, {remove_commit_hook, RefOrAtom}).
+
+monitor_rocksdb_gc(Pid) ->
+    gen_server:cast(?SERVER, {monitor_rocksdb_gc, Pid}).
 
 signed_metadata_fun() ->
     %% cache the chain handle in the peerbook processes' dictionary
@@ -584,6 +590,9 @@ handle_cast({snapshot_sync, Hash, Height}, State) ->
 handle_cast({async_reset, _Height}, State) ->
     lager:info("got async_reset at height ~p, ignoring", [_Height]),
     {noreply, State};
+handle_cast([monitor_rocksdb_gc, Pid}, State) ->
+    MRef = monitor(process, Pid),
+    {noreply, State#state{rocksdb_gc_mref = MRef}};
 
 handle_cast(_Msg, State) ->
     lager:warning("rcvd unknown cast msg: ~p", [_Msg]),
@@ -667,6 +676,17 @@ handle_info({'DOWN', ResyncRef, process, ResyncPid, Reason},
             %% ran out of retries
             {stop, Reason, State}
     end;
+handle_info({'DOWN', RocksGCRef, process, RocksGCPid, Reason},
+            #state{rocksdb_gc_mref = RocksGCRef} = State) ->
+    case Reason of
+        normal ->
+            lager:info("rocksdb_gc process completed normally");
+        shutdown ->
+            ok;
+        Reason ->
+            lager:error("rocksdb_gc pid ~p crashed because ~p", [RocksGCPid, Reason])
+    end,
+    {noreply, State#{rocksdb_gc_mref = undefined}};
 
 handle_info({blockchain_event, {new_chain, NC}}, State) ->
     {noreply, State#state{blockchain = NC}};


### PR DESCRIPTION
Because disks are not infinite, we want to occasionally remove some
older blocks and snapshots so we don't fill the disk entirely. This
change adds an environment variable, BLOCKCHAIN_GC_BYTES that allows the
system to signal to the blockchain it needs to reclaim some space.

If this environment variable is set, the blockchain will kick off a
background process that, starting at the oldest blocks, will delete
blocks and snapshots at that height until it has deleted at least as
many bytes as was requested. Note that this will temporarily increase
disk usage because compaction will need to happen before rocksdb can
actually reclaim space.

When using this feature it's probably important that you remove *more*
than is your threshold for triggering GC. For example if you want to GC
when the disk is 80% full, you should probably tell the blockchain to
delete enough bytes to get you back to 75% so you have some hystersis.

The last 100k of blocks and snapshots are protected from GC.