### PR TITLE
Attempt to download snaps from S3; fallback to p2p

### DIFF
--- a/src/blockchain.app.src
+++ b/src/blockchain.app.src
@@ -10,6 +10,7 @@
         compiler,
         crypto,
         ssl,
+        inets,
         lager,
         ranch,
         libp2p,

--- a/src/blockchain_sup.erl
+++ b/src/blockchain_sup.erl
@@ -63,6 +63,10 @@ init(Args) ->
     application:ensure_all_started(lager),
     application:ensure_all_started(clique),
     application:ensure_all_started(throttle),
+    %% start http client and ssl here
+    %% currently used for s3 snapshot download
+    ssl:start(),
+    inets:start(httpc, [{profile, blockchain}]),
     ok = blockchain_cli_registry:register_cli(),
     lager:info("~p init with ~p", [?MODULE, Args]),
     GroupMgrArgs =

--- a/src/cli/blockchain_cli_snapshot.erl
+++ b/src/cli/blockchain_cli_snapshot.erl
@@ -23,6 +23,7 @@ register_all_usage() ->
                   [
                    snapshot_take_usage(),
                    snapshot_load_usage(),
+                   snapshot_grab_usage(),
                    snapshot_diff_usage(),
                    snapshot_info_usage(),
                    snapshot_list_usage(),
@@ -36,6 +37,7 @@ register_all_cmds() ->
                   [
                    snapshot_take_cmd(),
                    snapshot_load_cmd(),
+                   snapshot_grab_cmd(),
                    snapshot_diff_cmd(),
                    snapshot_info_cmd(),
                    snapshot_list_cmd(),
@@ -50,6 +52,7 @@ snapshot_usage() ->
      ["blockchain snapshot commands\n\n",
       "  snapshot take   - Take a snapshot at the current ledger height.\n",
       "  snapshot load   - Load a snapshot from a file.\n"
+      "  snapshot grab   - Attempt to grab a snapshot from a connected peer.\n"
       "  snapshot diff   - Load two snapshots from files and find changes.\n"
       "  snapshot info   - Show information about a snapshot in a file.\n"
       "  snapshot list   - Show information about the last 5 snapshots.\n"
@@ -99,7 +102,7 @@ snapshot_load_cmd() ->
 snapshot_load_usage() ->
     [["snapshot", "load"],
      ["blockchain snapshot load <filename>\n\n",
-      "  Take a ledger snapshot at the current height and write it to filename\n"]
+      "  Load a snapshot from filename\n"]
     ].
 
 snapshot_load(["snapshot", "load", Filename], [], []) ->
@@ -116,6 +119,31 @@ snapshot_load(Filename) ->
 
     ok = blockchain_worker:install_snapshot(Hash, Snapshot),
     ok.
+
+snapshot_grab_usage() ->
+    [["snapshot", "grab"],
+     ["blockchain snapshot grab <Height> <Hash> <Filename>\n\n",
+      "  Grab a snapshot at specified height and hex encoded snapshot hash from a connected peer\n",
+      "  Use curl or wget to pull snapshots from a URL\n"]
+    ].
+
+snapshot_grab_cmd() ->
+    [
+     [["snapshot", "grab", '*', '*', '*' ], [], [], fun snapshot_grab/5]
+    ].
+
+snapshot_grab("snapshot", "grab", HeightStr, HashStr, Filename) ->
+    try
+        Height = list_to_integer(HeightStr),
+        Hash = hex_to_binary(HashStr),
+        {ok, Snapshot} = blockchain_worker:grab_snapshot(Height, Hash),
+        file:write_file(Filename, Snapshot)
+    catch
+        _Type:Error ->
+            [clique_status:text(io_lib:format("failed: ~p", [Error]))]
+    end;
+snapshot_grab(_, _, _, _, _) ->
+    usage.
 
 snapshot_diff_cmd() ->
     [
@@ -157,8 +185,11 @@ snapshot_info_usage() ->
 snapshot_info(["snapshot", "info", Filename], [], []) ->
     {ok, BinSnap} = file:read_file(Filename),
     {ok, Snap} = blockchain_ledger_snapshot_v1:deserialize(BinSnap),
-    [clique_status:text(io_lib:format("Height ~p\nHash ~p\n", [blockchain_ledger_snapshot_v1:height(Snap),
-                                                              blockchain_ledger_snapshot_v1:hash(Snap)]))];
+    [clique_status:text(io_lib:format("Height ~p\nHash ~p (~p)\n",
+                                      [blockchain_ledger_snapshot_v1:height(Snap),
+                                       blockchain_ledger_snapshot_v1:hash(Snap),
+                                       binary_to_hex(blockchain_ledger_snapshot_v1:hash(Snap))]
+                                     ))];
 snapshot_info(_, _, _) ->
     usage.
 
@@ -180,7 +211,27 @@ snapshot_list(["snapshot", "list"], [], []) ->
     case Snapshots of
         undefined -> ok;
         _ ->
-            [ clique_status:text(io_lib:format("Height ~p\nHash ~p\nHave ~p\n", [Height, Hash, element(1, blockchain:get_snapshot(Hash, Chain)) == ok])) || {Height, _, Hash} <- Snapshots ]
+            [ clique_status:text(io_lib:format("Height ~p\nHash ~p (~p)\nHave ~p\n",
+                                               [Height, Hash, binary_to_hex(Hash),
+                                                element(1, blockchain:get_snapshot(Hash, Chain)) == ok])) || {Height, _, Hash} <- Snapshots ]
     end;
 snapshot_list(_, _, _) ->
     usage.
+
+binary_to_hex(Binary) ->
+    << <<(hex(H)),(hex(L))>> || <<H:4,L:4>> <= Binary >>.
+
+hex(C) when C < 10 -> $0 + C;
+hex(C) -> $a + C - 10.
+
+hex_to_binary(Hex) when is_list(Hex) ->
+    hexstr_to_bin(Hex, []).
+
+hexstr_to_bin([], Acc) ->
+    list_to_binary(lists:reverse(Acc));
+hexstr_to_bin([X,Y|T], Acc) ->
+    {ok, [V], []} = io_lib:fread("~16u", [X,Y]),
+    hexstr_to_bin(T, [V | Acc]);
+hexstr_to_bin([X|T], Acc) ->
+    {ok, [V], []} = io_lib:fread("~16u", lists:flatten([X,"0"])),
+    hexstr_to_bin(T, [V | Acc]).


### PR DESCRIPTION
Problem to solve: Locally reproduced snapshots are more difficult to find in the network. Since snapshot data comes from peer nodes, peer nodes without snapshots make bootstrapping a blockchain from a "blessed" snapshot quite difficult, especially for brand new hotspots who may be stuck at block 1, looking for a peer that can't help.

Solution: Attempt to download a snapshot file from S3 and install it. If that fails, fall back to the current code path. Additionally, expose a CLI interface to attempt to grab a snapshot from the p2p code path and save it to a specified file.