### PR TITLE
tweak elections some more

### DIFF
--- a/eqc/stake_txns_eqc.erl
+++ b/eqc/stake_txns_eqc.erl
@@ -153,7 +153,7 @@ val_vars() ->
       ?election_bba_penalty => 0.5,
       ?election_seen_penalty => 0.5,
       ?tenure_penalty => 0.5,
-      ?validator_penalty_probability_factor => 1.0,
+      ?validator_penalty_filter => 1.0,
       ?penalty_history_limit => 100,
       ?election_interval => 3
      }.

--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -448,7 +448,7 @@
 -define(validator_minimum_stake, validator_minimum_stake).  % bones
 -define(validator_liveness_interval, validator_liveness_interval).  % blocks
 -define(validator_liveness_grace_period, validator_liveness_grace_period).  % blocks
--define(validator_penalty_probability_factor, validator_penalty_probability_factor). % float
+-define(validator_penalty_filter, validator_penalty_filter). % float
 -define(stake_withdrawal_cooldown, stake_withdrawal_cooldown). % blocks
 -define(stake_withdrawal_max, stake_withdrawal_max). % blocks
 %% -define(maximum_overstake, maximum_overstake). % float multiple of min stake

--- a/src/blockchain_election.erl
+++ b/src/blockchain_election.erl
@@ -820,7 +820,7 @@ val_dedup(OldGroup0, Validators0, Ledger) ->
     %% filter liveness here
     {ok, HBInterval} = blockchain:config(?validator_liveness_interval, Ledger),
     {ok, HBGrace} = blockchain:config(?validator_liveness_grace_period, Ledger),
-    {ok, PenaltyFactor} = blockchain:config(?validator_penalty_probability_factor, Ledger),
+    {ok, PenaltyFilter} = blockchain:config(?validator_penalty_filter, Ledger),
 
     {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
 
@@ -853,15 +853,11 @@ val_dedup(OldGroup0, Validators0, Ledger) ->
                               true ->
                                   Acc;
                               _ ->
-                                  %% the penalty factor makes higher penalty
-                                  %% scores more lenient than the original
-                                  %% 1.0 value
-                                  case max(0.0, PenaltyFactor - Prob) of
+                                  case Prob >= PenaltyFilter of
                                       %% don't even consider until some of
                                       %% these failures have aged out
-                                      0.0 -> Acc;
-                                      NewProb ->
-                                          {Old, [Val#val_v1{prob = NewProb} | Candidates]}
+                                      true -> Acc;
+                                      false -> {Old, [Val | Candidates]}
                                   end
                           end
                   end

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1231,8 +1231,8 @@ validate_var(?dkg_penalty, Value) ->
     validate_float(Value, "dkg_penalty", 0.0, 5.0);
 validate_var(?tenure_penalty, Value) ->
     validate_float(Value, "tenure_penalty", 0.0, 5.0);
-validate_var(?validator_penalty_probability_factor, Value) ->
-    validate_float(Value, "validator_penalty_probability_factor", 0.0, 10.0);
+validate_var(?validator_penalty_filter, Value) ->
+    validate_float(Value, "validator_penalty_filter", 0.0, 10.0);
 validate_var(?penalty_history_limit, Value) ->
     %% low end is low for testing and an out if these become corrupted
     %% also low end cannot be 0


### PR DESCRIPTION
Two changes here:
- I misread @mrallen1's initial PR adding vars, and when I took a closer look at the filtering logic, I decided I didn't actually like it?  sorry.  I reverted to the initial behavior + a var.
- instead of making an offline node's probability of removal arbitrarily high, we just keep a list of offline nodes and yank them preferentially, in front of any removal selections.