### PR TITLE
Bump proto to pull in regional additions

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -41,7 +41,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"e022ae15c3153d597d16f8a967d27599d57d32f5"}},
+       {ref,"69a6452a682bf2e1e2f20cdde15368459c50166a"}},
   0},
  {<<"inert">>,{pkg,<<"inert">>,<<"1.0.2">>},2},
  {<<"inet_cidr">>,{pkg,<<"erl_cidr">>,<<"1.0.2">>},2},


### PR DESCRIPTION
This PR bumps proto to include:

https://github.com/helium/proto/pull/81
https://github.com/helium/proto/pull/77