### PR TITLE
ensure nonce is checked as part of validations

### DIFF
--- a/src/transactions/blockchain_txn_mgr.erl
+++ b/src/transactions/blockchain_txn_mgr.erl
@@ -342,17 +342,29 @@ process_cached_txns(Chain, CurBlockHeight, SubmitF, _Sync, IsNewElection, NewGro
     %% validate the cached txns
     {ValidTransactions, InvalidTransactions} = blockchain_txn:validate(Txns, Chain),
     ok = lists:foreach(
-        fun({TxnKey, Txn, _TxnData} = CachedTxn) ->
+        fun({TxnKey, Txn, #txn_data{recv_block_height = RecvBlockHeight} = _TxnData} = CachedTxn) ->
             case {lists:keyfind(Txn, 1, InvalidTransactions), lists:member(Txn, ValidTransactions)} of
                 {false, false} ->
                     %% the txn is not in the valid nor the invalid list
                     %% this means the validations cannot decide as yet, such as is the case with a
                     %% bad or out of sequence nonce
-                    %% so in this scenario do nothing...
-                    %% we need to keep dialers open to ensure we receive responses from the CG members
-                    %% who may not yet have responded to any previous submit
-                    lager:debug("txn has undecided validations, leaving in cache: ~p", [blockchain_txn:hash(Txn)]),
-                    ok;
+                    %% in this scenario we give the txn N blocks for the validation to make a decision
+                    %% as to whether valid or invalid
+                    %% if that does not happen by N blocks we will assume the txn will never become valid
+                    %% this prevents an account becoming wedged such as would be the case if
+                    %% a payer account submits a bunch of txns where a lower nonce txn got lost or
+                    %% an issue with the speculative nonce
+                    %% it also helps to prevent txn mgr's cache from getting cluttered long term
+                    %% with txns which will never become valid or invalid
+                    TxnMaxBlockSpan = application:get_env(blockchain, txn_max_block_span, 15),
+                    case (CurBlockHeight - RecvBlockHeight) > TxnMaxBlockSpan of
+                        true ->
+                            lager:debug("txn has exceeded max block space, rejecting: ~p", [blockchain_txn:hash(Txn)]),
+                            process_invalid_txn(CachedTxn, {error, {invalid, undecided_timeout}});
+                        _ ->
+                            lager:debug("txn has undecided validations, leaving in cache: ~p", [blockchain_txn:hash(Txn)]),
+                            ok
+                    end;
                 {{Txn, InvalidReason}, true} ->
                     %% hmm we have a txn which is a member of the valid and the invalid list
                     %% this can only mean we have dup txns, like 2 payment txns submitted with same nonce and payload

--- a/src/transactions/v1/blockchain_txn_create_htlc_v1.erl
+++ b/src/transactions/v1/blockchain_txn_create_htlc_v1.erl
@@ -181,10 +181,10 @@ is_valid(Txn, Chain) ->
                                     Error0;
                                 {ok, Entry} ->
                                     TxnNonce = ?MODULE:nonce(Txn),
-                                    NextLedgerNonce = blockchain_ledger_entry_v1:nonce(Entry) +1,
-                                    case TxnNonce =:= NextLedgerNonce of
+                                    LedgerNonce = blockchain_ledger_entry_v1:nonce(Entry),
+                                    case TxnNonce =:= LedgerNonce + 1 of
                                         false ->
-                                            {error, {bad_nonce, {create_htlc, TxnNonce, NextLedgerNonce}}};
+                                            {error, {bad_nonce, {create_htlc, TxnNonce, LedgerNonce}}};
                                         true ->
                                             Amount = ?MODULE:amount(Txn),
                                             TxnFee = ?MODULE:fee(Txn),

--- a/src/transactions/v1/blockchain_txn_payment_v1.erl
+++ b/src/transactions/v1/blockchain_txn_payment_v1.erl
@@ -142,33 +142,45 @@ is_valid(Txn, Chain) ->
                         false ->
                             {error, bad_signature};
                         true ->
-                            case Payer == Payee of
-                                false ->
-                                    Amount = ?MODULE:amount(Txn),
-                                    TxnFee = ?MODULE:fee(Txn),
-                                        AmountCheck = case blockchain:config(?allow_zero_amount, Ledger) of
-                                                          {ok, false} ->
-                                                              %% check that amount is greater than 0
-                                                              Amount > 0;
-                                                          _ ->
-                                                              %% if undefined or true, use the old check
-                                                              Amount >= 0
-                                                      end,
-                                        case AmountCheck of
-                                            false ->
-                                                {error, invalid_transaction};
-                                            true ->
-                                                AreFeesEnabled = blockchain_ledger_v1:txn_fees_active(Ledger),
-                                                ExpectedTxnFee = ?MODULE:calculate_fee(Txn, Chain),
-                                                case ExpectedTxnFee =< TxnFee orelse not AreFeesEnabled of
-                                                    false ->
-                                                        {error, {wrong_txn_fee, {ExpectedTxnFee, TxnFee}}};
-                                                    true ->
-                                                        blockchain_ledger_v1:check_dc_or_hnt_balance(Payer, TxnFee, Ledger, AreFeesEnabled)
-                                                end
-                                        end;
-                                true ->
-                                    {error, invalid_transaction_self_payment}
+                            case blockchain_ledger_v1:find_entry(Payer, Ledger) of
+                                {error, _}=Error0 ->
+                                    Error0;
+                                {ok, Entry} ->
+                                    TxnNonce = ?MODULE:nonce(Txn),
+                                    NextLedgerNonce = blockchain_ledger_entry_v1:nonce(Entry) +1,
+                                    case TxnNonce =:= NextLedgerNonce of
+                                        false ->
+                                            {error, {bad_nonce, {payment, TxnNonce, NextLedgerNonce}}};
+                                        true ->
+                                            case Payer == Payee of
+                                                false ->
+                                                    Amount = ?MODULE:amount(Txn),
+                                                    TxnFee = ?MODULE:fee(Txn),
+                                                        AmountCheck = case blockchain:config(?allow_zero_amount, Ledger) of
+                                                                          {ok, false} ->
+                                                                              %% check that amount is greater than 0
+                                                                              Amount > 0;
+                                                                          _ ->
+                                                                              %% if undefined or true, use the old check
+                                                                              Amount >= 0
+                                                                      end,
+                                                        case AmountCheck of
+                                                            false ->
+                                                                {error, invalid_transaction};
+                                                            true ->
+                                                                AreFeesEnabled = blockchain_ledger_v1:txn_fees_active(Ledger),
+                                                                ExpectedTxnFee = ?MODULE:calculate_fee(Txn, Chain),
+                                                                case ExpectedTxnFee =< TxnFee orelse not AreFeesEnabled of
+                                                                    false ->
+                                                                        {error, {wrong_txn_fee, {ExpectedTxnFee, TxnFee}}};
+                                                                    true ->
+                                                                        blockchain_ledger_v1:check_dc_or_hnt_balance(Payer, TxnFee, Ledger, AreFeesEnabled)
+                                                                end
+                                                        end;
+                                                true ->
+                                                    {error, invalid_transaction_self_payment}
+                                            end
+                                    end
                             end
                     end;
                 Error ->

--- a/src/transactions/v1/blockchain_txn_payment_v1.erl
+++ b/src/transactions/v1/blockchain_txn_payment_v1.erl
@@ -147,10 +147,10 @@ is_valid(Txn, Chain) ->
                                     Error0;
                                 {ok, Entry} ->
                                     TxnNonce = ?MODULE:nonce(Txn),
-                                    NextLedgerNonce = blockchain_ledger_entry_v1:nonce(Entry) +1,
-                                    case TxnNonce =:= NextLedgerNonce of
+                                    LedgerNonce = blockchain_ledger_entry_v1:nonce(Entry),
+                                    case TxnNonce =:= LedgerNonce + 1 of
                                         false ->
-                                            {error, {bad_nonce, {payment, TxnNonce, NextLedgerNonce}}};
+                                            {error, {bad_nonce, {payment, TxnNonce, LedgerNonce}}};
                                         true ->
                                             case Payer == Payee of
                                                 false ->

--- a/src/transactions/v1/blockchain_txn_state_channel_open_v1.erl
+++ b/src/transactions/v1/blockchain_txn_state_channel_open_v1.erl
@@ -237,38 +237,41 @@ do_is_valid_checks(Txn, Chain) ->
                                                 _ ->
                                                     case blockchain_ledger_v1:find_state_channel(ID, Owner, Ledger) of
                                                         {error, not_found} ->
-                                                            case blockchain_ledger_v1:find_entry(Owner, Ledger) of
-                                                                {error, _}=Error0 ->
-                                                                    Error0;
-                                                                {ok, Entry} ->
-                                                                    TxnNonce = ?MODULE:nonce(Txn),
-                                                                    NextLedgerNonce = blockchain_ledger_entry_v1:nonce(Entry) +1,
-                                                                    case TxnNonce =:= NextLedgerNonce of
-                                                                        false ->
-                                                                            {error, {bad_nonce, {state_channel_open, TxnNonce, NextLedgerNonce}}};
-                                                                        true ->
-                                                                            %% No state channel with this ID for this Owner exists
-                                                                            AreFeesEnabled = blockchain_ledger_v1:txn_fees_active(Ledger),
-                                                                            TxnFee = ?MODULE:fee(Txn),
-                                                                            OriginalAmount = ?MODULE:amount(Txn),
-                                                                            ActualAmount = actual_amount(OriginalAmount, Ledger),
-                                                                            ExpectedTxnFee = ?MODULE:calculate_fee(Txn, Chain),
-                                                                            case ExpectedTxnFee =< TxnFee orelse not AreFeesEnabled of
-                                                                                false ->
-                                                                                    {error, {wrong_txn_fee, {ExpectedTxnFee, TxnFee}}};
-                                                                                true ->
-                                                                                    case blockchain:config(?sc_open_validation_bugfix, Ledger) of
-                                                                                        {ok, 1} ->
-                                                                                            %% Check whether the actual amount (overcommit *
-                                                                                            %% original amount) + txn_fee is payable by this
-                                                                                            %% owner
-                                                                                            blockchain_ledger_v1:check_dc_balance(Owner, ActualAmount + TxnFee, Ledger);
-                                                                                        _ ->
-                                                                                            blockchain_ledger_v1:check_dc_or_hnt_balance(Owner, TxnFee, Ledger, AreFeesEnabled)
-                                                                                    end
-                                                                            end
+                                                            %% No state channel with this ID for this Owner exists
+                                                            LedgerNonce =
+                                                                case blockchain_ledger_v1:find_dc_entry(Owner, Ledger) of
+                                                                    {error, _} ->
+                                                                        %% if we dont have a DC entry then default expected next nonce to 1
+                                                                        0;
+                                                                    {ok, Entry} ->
+                                                                        blockchain_ledger_data_credits_entry_v1:nonce(Entry)
+                                                                end,
+                                                                TxnNonce = ?MODULE:nonce(Txn),
+                                                                case TxnNonce =:= LedgerNonce + 1 of
+                                                                    false ->
+                                                                        {error, {bad_nonce, {state_channel_open, TxnNonce, LedgerNonce}}};
+                                                                    true ->
+
+                                                                        AreFeesEnabled = blockchain_ledger_v1:txn_fees_active(Ledger),
+                                                                        TxnFee = ?MODULE:fee(Txn),
+                                                                        OriginalAmount = ?MODULE:amount(Txn),
+                                                                        ActualAmount = actual_amount(OriginalAmount, Ledger),
+                                                                        ExpectedTxnFee = ?MODULE:calculate_fee(Txn, Chain),
+                                                                        case ExpectedTxnFee =< TxnFee orelse not AreFeesEnabled of
+                                                                            false ->
+                                                                                {error, {wrong_txn_fee, {ExpectedTxnFee, TxnFee}}};
+                                                                            true ->
+                                                                                case blockchain:config(?sc_open_validation_bugfix, Ledger) of
+                                                                                    {ok, 1} ->
+                                                                                        %% Check whether the actual amount (overcommit *
+                                                                                        %% original amount) + txn_fee is payable by this
+                                                                                        %% owner
+                                                                                        blockchain_ledger_v1:check_dc_balance(Owner, ActualAmount + TxnFee, Ledger);
+                                                                                    _ ->
+                                                                                        blockchain_ledger_v1:check_dc_or_hnt_balance(Owner, TxnFee, Ledger, AreFeesEnabled)
+                                                                                end
                                                                         end
-                                                                    end;
+                                                                end;
                                                         {ok, _} ->
                                                             {error, state_channel_already_exists};
                                                         {error, _}=Err ->

--- a/src/transactions/v1/blockchain_txn_token_burn_v1.erl
+++ b/src/transactions/v1/blockchain_txn_token_burn_v1.erl
@@ -162,10 +162,10 @@ is_valid(Txn, Chain) ->
                                     Error0;
                                 {ok, Entry} ->
                                     TxnNonce = ?MODULE:nonce(Txn),
-                                    NextLedgerNonce = blockchain_ledger_entry_v1:nonce(Entry) +1,
-                                    case TxnNonce =:= NextLedgerNonce of
+                                    LedgerNonce = blockchain_ledger_entry_v1:nonce(Entry),
+                                    case TxnNonce =:= LedgerNonce + 1 of
                                         false ->
-                                            {error, {bad_nonce, {token_burn, TxnNonce, NextLedgerNonce}}};
+                                            {error, {bad_nonce, {token_burn, TxnNonce, LedgerNonce}}};
                                         true ->
                                         HNTAmount = ?MODULE:amount(Txn),
                                         case blockchain_ledger_v1:check_balance(Payer, HNTAmount, Ledger) of

--- a/src/transactions/v2/blockchain_txn_payment_v2.erl
+++ b/src/transactions/v2/blockchain_txn_payment_v2.erl
@@ -223,10 +223,10 @@ do_is_valid_checks(Txn, Chain, MaxPayments) ->
                             Error0;
                         {ok, Entry} ->
                             TxnNonce = ?MODULE:nonce(Txn),
-                            NextLedgerNonce = blockchain_ledger_entry_v1:nonce(Entry) +1,
-                            case TxnNonce =:= NextLedgerNonce of
+                            LedgerNonce = blockchain_ledger_entry_v1:nonce(Entry),
+                            case TxnNonce =:= LedgerNonce + 1 of
                                 false ->
-                                    {error, {bad_nonce, {payment_v2, TxnNonce, NextLedgerNonce}}};
+                                    {error, {bad_nonce, {payment_v2, TxnNonce, LedgerNonce}}};
                                 true ->
                                     case LengthPayments > MaxPayments of
                                         %% Check that we don't exceed max payments

--- a/test/blockchain_price_oracle_SUITE.erl
+++ b/test/blockchain_price_oracle_SUITE.erl
@@ -1354,8 +1354,8 @@ staking_key_mode_mappings_add_full_gateway(Config) ->
     AddGatewayTxFee = blockchain_txn_add_gateway_v1:calculate_fee(AddGatewayTx0, Chain),
     AddGatewayStFee = blockchain_txn_add_gateway_v1:calculate_staking_fee(AddGatewayTx0, Chain),
     %% full gateways costs 40 usd
+
     ?assertEqual(40 * ?USD_TO_DC, AddGatewayStFee),
-    ?assertEqual(ok, blockchain_txn_payment_v1:is_valid(SignedPaymentTx1, Chain)),
     ct:pal("Add gateway txn fee ~p, staking fee ~p, total: ~p", [AddGatewayTxFee, AddGatewayStFee, AddGatewayTxFee + AddGatewayStFee]),
 
     %% set the fees on the base txn and then sign the various txns
@@ -1365,6 +1365,7 @@ staking_key_mode_mappings_add_full_gateway(Config) ->
     SignedOwnerAddGatewayTx2 = blockchain_txn_add_gateway_v1:sign(AddGatewayTx2, OwnerSigFun),
     SignedGatewayAddGatewayTx2 = blockchain_txn_add_gateway_v1:sign_request(SignedOwnerAddGatewayTx2, GatewaySigFun),
     SignedPayerAddGatewayTx2 = blockchain_txn_add_gateway_v1:sign_payer(SignedGatewayAddGatewayTx2, StakerSigFun),
+    ?assertEqual(ok, blockchain_txn_add_gateway_v1:is_valid(SignedPayerAddGatewayTx2, Chain)),
 
     {ok, AddGatewayBlock} = test_utils:create_block(ConsensusMembers, [SignedPayerAddGatewayTx2]),
     %% add the block
@@ -1437,7 +1438,6 @@ staking_key_mode_mappings_add_nonconsensus_gateway(Config) ->
     AddGatewayStFee = blockchain_txn_add_gateway_v1:calculate_staking_fee(AddGatewayTx0, Chain),
     %% non consensus gateway costs same to add as a full gateway
     ?assertEqual(40 * ?USD_TO_DC, AddGatewayStFee),
-    ?assertEqual(ok, blockchain_txn_payment_v1:is_valid(SignedPaymentTx1, Chain)),
     ct:pal("Add gateway txn fee ~p, staking fee ~p, total: ~p", [AddGatewayTxFee, AddGatewayStFee, AddGatewayTxFee + AddGatewayStFee]),
 
     %% set the fees on the base txn and then sign the various txns
@@ -1448,6 +1448,7 @@ staking_key_mode_mappings_add_nonconsensus_gateway(Config) ->
     SignedGatewayAddGatewayTx2 = blockchain_txn_add_gateway_v1:sign_request(SignedOwnerAddGatewayTx2, GatewaySigFun),
     SignedPayerAddGatewayTx2 = blockchain_txn_add_gateway_v1:sign_payer(SignedGatewayAddGatewayTx2, StakerSigFun),
 
+    ?assertEqual(ok, blockchain_txn_add_gateway_v1:is_valid(SignedPayerAddGatewayTx2, Chain)),
     {ok, AddGatewayBlock} = test_utils:create_block(ConsensusMembers, [SignedPayerAddGatewayTx2]),
     %% add the block
     blockchain:add_block(AddGatewayBlock, Chain),
@@ -1518,7 +1519,6 @@ staking_key_mode_mappings_add_light_gateway(Config) ->
     AddGatewayStFee = blockchain_txn_add_gateway_v1:calculate_staking_fee(AddGatewayTx0, Chain),
     %% light gateway costs 20 usd
     ?assertEqual(20 * ?USD_TO_DC, AddGatewayStFee),
-    ?assertEqual(ok, blockchain_txn_payment_v1:is_valid(SignedPaymentTx1, Chain)),
     ct:pal("Add gateway txn fee ~p, staking fee ~p, total: ~p", [AddGatewayTxFee, AddGatewayStFee, AddGatewayTxFee + AddGatewayStFee]),
 
     %% set the fees on the base txn and then sign the various txns
@@ -1529,6 +1529,7 @@ staking_key_mode_mappings_add_light_gateway(Config) ->
     SignedGatewayAddGatewayTx2 = blockchain_txn_add_gateway_v1:sign_request(SignedOwnerAddGatewayTx2, GatewaySigFun),
     SignedPayerAddGatewayTx2 = blockchain_txn_add_gateway_v1:sign_payer(SignedGatewayAddGatewayTx2, StakerSigFun),
 
+    ?assertEqual(ok, blockchain_txn_add_gateway_v1:is_valid(SignedPayerAddGatewayTx2, Chain)),
     {ok, AddGatewayBlock} = test_utils:create_block(ConsensusMembers, [SignedPayerAddGatewayTx2]),
     %% add the block
     blockchain:add_block(AddGatewayBlock, Chain),

--- a/test/blockchain_simple_SUITE.erl
+++ b/test/blockchain_simple_SUITE.erl
@@ -386,7 +386,8 @@ htlc_payee_redeem_test(Config) ->
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     SignedTx = blockchain_txn_payment_v1:sign(Tx, SigFun),
 
-    ?assertEqual(ok, blockchain_txn_payment_v1:is_valid(SignedTx, Chain)),
+    %% check both txns are valid, in context
+    ?assertMatch({_, []}, blockchain_txn:validate([SignedCreateTx, SignedTx], Chain)),
 
     %% these transactions depend on each other, but they should be able to exist in the same block
     {ok, Block} = test_utils:create_block(ConsensusMembers, [SignedCreateTx, SignedTx]),
@@ -428,7 +429,7 @@ htlc_payee_redeem_test(Config) ->
 
     % confirm the replay of the previously absorbed txn fails validations
     % as we are reusing the same nonce
-    ?assertEqual({error,{bad_nonce,{create_htlc,1,3}}}, blockchain_txn_create_htlc_v1:is_valid(SignedCreateTx, Chain)),
+    ?assertEqual({error,{bad_nonce,{create_htlc,1,2}}}, blockchain_txn_create_htlc_v1:is_valid(SignedCreateTx, Chain)),
     ok.
 
 htlc_payer_redeem_test(Config) ->
@@ -501,7 +502,7 @@ htlc_payer_redeem_test(Config) ->
 
     % confirm the replay of the previously absorbed txn fails validations
     % as we are reusing the same nonce
-    ?assertEqual({error,{bad_nonce,{create_htlc,1,2}}}, blockchain_txn_create_htlc_v1:is_valid(SignedCreateTx, Chain)),
+    ?assertEqual({error,{bad_nonce,{create_htlc,1,1}}}, blockchain_txn_create_htlc_v1:is_valid(SignedCreateTx, Chain)),
 
     ok.
 

--- a/test/blockchain_state_channel_SUITE.erl
+++ b/test/blockchain_state_channel_SUITE.erl
@@ -578,6 +578,7 @@ multiple_test(Config) ->
     RouterChain = ct_rpc:call(RouterNode, blockchain_worker, blockchain, []),
     RouterSwarm = ct_rpc:call(RouterNode, blockchain_swarm, swarm, []),
     RouterPubkeyBin = ct_rpc:call(RouterNode, blockchain_swarm, pubkey_bin, []),
+    ct:pal("RouterNode: ~p", [RouterNode]),
 
     %% Forward this process's submit_txn to meck_test_util which
     %% sends this process a msg reply back which we later handle
@@ -586,6 +587,7 @@ multiple_test(Config) ->
 
     %% Create OUI txn
     SignedOUITxn = create_oui_txn(1, RouterNode, [], 8),
+
     ct:pal("SignedOUITxn: ~p", [SignedOUITxn]),
 
     %% Create state channel open txn


### PR DESCRIPTION
A number of txns which accommodate a nonce field are not validating the nonce as part of their validations.

This results in a txn passing validations but later failing to absorb as at that point the nonce is checked as part of the account debiting.

The bad_nonce error is then returned to blockchain_txn:validate/6 which will end up bubbling the error back to  the txn mgr.  

In the scenario where we have a txn with an out of sequence nonce, that txn should be declared as neither valid nor invalid and thus remain in the txn mgr's cache, ready to be resubmitted next block.

However if a bad nonce error is hit as part of the validate's *absorb* call, it will declare the txn as invalid and it will be removed from the txn mgr's cache and the callback hit with a failed error response.

If the bad nonce error is hit as part of the validates *is_valid* call, the correct behaviour is encountered, the txn will be declared as neither invalid nor valid and will remain in the txn mgr's cache.

This fix is then two fold:

1.  Ensure out of sequence nonce errors encountered as part of blockchain_txn:validate's  *absord* call are handled the same way as prior *is_valid* call and return a neither valid or invalid response to txn mgr

2.  Add the nonce check to the is_valid checks of the relevant txns

Either of the above on its own would resolve the problem but including both eliminate possible future oddities.


