### PR TITLE
route dep txns to dialed members if root txns have no acceptions

### DIFF
--- a/src/transactions/blockchain_txn_mgr.erl
+++ b/src/transactions/blockchain_txn_mgr.erl
@@ -472,7 +472,7 @@ check_for_deps_and_resubmit(TxnKey, Txn, CachedTxns, Chain, SubmitF, #txn_data{ 
                 end,
 
             ElegibleMembers = sets:to_list(lists:foldl(fun({Dep2TxnKey, _Dep2Txn, _Dep2TxnData}, Acc) ->
-                                                                {ok, {_, _, #txn_data{acceptions = Dep2TxnAcceptions, dialers = Dep2TxnDialers} = _Dep2TxnData}} = cached_txn(Dep2TxnKey),
+                                                                {ok, {_, _, #txn_data{acceptions = Dep2TxnAcceptions, dialers = Dep2TxnDialers} = _Dep2TxnData1}} = cached_txn(Dep2TxnKey),
                                                                 A1 =
                                                                     case Dep2TxnAcceptions  of
                                                                         [] ->

--- a/src/transactions/blockchain_txn_mgr.erl
+++ b/src/transactions/blockchain_txn_mgr.erl
@@ -459,12 +459,30 @@ check_for_deps_and_resubmit(TxnKey, Txn, CachedTxns, Chain, SubmitF, #txn_data{ 
         Dependencies ->
             %% for txns with dep txns, we only want to submit to members which have accepted one of the dep txns previously
             %% so we need to build up an explicit set of elegible members rather than sending to random CG members
-            {Dep1TxnKey, _Dep1Txn, _Dep1TxnData} = hd(Dependencies),
-            {ok, {_, _, #txn_data{acceptions = A0}}} = cached_txn(Dep1TxnKey),
+            %% eligible members will be those members which have accepted the dependant upon txn or if its not yet
+            %% accepted the members to which it has been submitted ( the dialled list )
+            {Dep1TxnKey, _Dep1Txn, _Dep1TxnData0} = hd(Dependencies),
+            {ok, {_, _, #txn_data{acceptions = Dep1TxnAcceptions, dialers = Dep1TxnDialers} = _Dep1TxnData1}} = cached_txn(Dep1TxnKey),
+            A0 =
+                case Dep1TxnAcceptions  of
+                    [] ->
+                        [Dep1TxnDialedMember || {_, Dep1TxnDialedMember} <- Dep1TxnDialers];
+                    Dep1TxnAccs ->
+                        Dep1TxnAccs
+                end,
+
             ElegibleMembers = sets:to_list(lists:foldl(fun({Dep2TxnKey, _Dep2Txn, _Dep2TxnData}, Acc) ->
-                                                               {ok, {_, _, #txn_data{acceptions = A}}} = cached_txn(Dep2TxnKey),
-                                                               sets:intersection(Acc, sets:from_list(A))
+                                                                {ok, {_, _, #txn_data{acceptions = Dep2TxnAcceptions, dialers = Dep2TxnDialers} = _Dep2TxnData}} = cached_txn(Dep2TxnKey),
+                                                                A1 =
+                                                                    case Dep2TxnAcceptions  of
+                                                                        [] ->
+                                                                            [Dep2TxnDialedMember || {_, Dep2TxnDialedMember} <- Dep2TxnDialers];
+                                                                        Dep2TxnAccs ->
+                                                                            Dep2TxnAccs
+                                                                    end,
+                                                               sets:intersection(Acc, sets:from_list(A1))
                                                        end, sets:from_list(A0), tl(Dependencies))),
+            lager:debug("txn ~p has eligible members: ~p", [blockchain_txn:hash(Txn), ElegibleMembers]),
             {_, ExistingDialers} = lists:unzip(Dialers),
             %% remove any CG members from the elegible list which have already accepted or rejected the txn and also
             %% those which we are already dialling


### PR DESCRIPTION
This fixes an issue whereby if we have a set of dependant txns the txn mgr submits only a single txn of the dependant set per block.

The cause of the problem is that when handling the first txn with a dependency we look to the root txn to build a list of eligible members to which we will send the current txn. We want to send the dependant txns to the same CG members as otherwise we will encounter validation failures due to out of sequence nonces for example.

When building the list of eligible members from the dependant on txn list, we derive the membership from the list of members which have accepted the prior txn ( the accepted list )

However there is no guarantee the root txn or the previous txn in the dependant set will have yet been accepted and thus its accepted list may be empty. We then end up with zero eligible members to send the current txn.

The fix is to include the dialled members of the root or prior txn of the dependant set in the list of eligible members but only if the accepted list is empty.