### PR TITLE
[DNM] Assert res 9 testing

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -456,3 +456,9 @@
 -define(penalty_history_limit, penalty_history_limit). % blocks
 -define(dkg_penalty, dkg_penalty). % float
 -define(tenure_penalty, tenure_penalty). % float
+
+
+%%%
+%%% boolean switch to assert res 9
+%%%
+-define(switch_assert_res_9, switch_assert_res_9). % boolean

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -1390,6 +1390,7 @@ vars(Vars, Unset, Ledger) ->
 set_aux_vars(AuxVars, #ledger_v1{mode=aux}=AuxLedger) ->
     Ctx = new_context(AuxLedger),
     ok = vars(AuxVars, [], Ctx),
+    ok = blockchain_txn_vars_v1:process_hooks(AuxVars, [], Ctx),
     ok = commit_context(Ctx),
     ok;
 set_aux_vars(_ExtraVars, _Ledger) ->

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -6,7 +6,7 @@
 
 -export([
     new/1, new/4, new/5,
-    new_aux/1,
+    new_aux/1, new_aux/2,
     bootstrap_aux/2,
     mode/1, mode/2,
     has_aux/1,

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -590,6 +590,7 @@ delayed_absorb(Txn, Ledger) ->
     Vars = decode_vars(vars(Txn)),
     Unsets = decode_unsets(unsets(Txn)),
     ok = blockchain_ledger_v1:vars(Vars, Unsets, Ledger),
+    ok = process_hooks(Vars, Unsets, Ledger),
     case blockchain:config(?use_multi_keys, Ledger) of
         {ok, true} ->
             case multi_keys(Txn) of
@@ -1319,6 +1320,43 @@ invalid_var(Var, Value) ->
 invalid_var(Var, Value) ->
     throw({error, {unknown_var, Var, Value}}).
 -endif.
+
+
+process_hooks(Vars, Unsets, Ledger) ->
+    _ = maps:map(
+          fun(Var, Value) ->
+                  var_hook(Var, Value, Ledger)
+          end, Vars),
+    _ = lists:foreach(
+          fun(Var) ->
+                  unset_hook(Var, Ledger)
+          end, Unsets),
+    ok.
+
+%% separate out hook functions and call them in separate functions
+%% below the hook section.
+var_hook(?sweep_neighbors, true, Ledger) ->
+    neighbor_sweep(Ledger),
+    ok;
+var_hook(_Var, _Value, _Ledger) ->
+    ok.
+
+unset_hook(_Var, _Ledger) ->
+    ok.
+
+
+neighbor_sweep(Ledger) ->
+    case blockchain_ledger_v1:config(?poc_version, Ledger) of
+        {ok, V} when V > 3 ->
+            Gateways = blockchain_ledger_v1:active_gateways(Ledger),
+            %% find all neighbors for everyone
+            maps:map(
+              fun(A, G) ->
+                      G1 = blockchain_ledger_gateway_v2:neighbors([], G),
+                      blockchain_ledger_v1:update_gateway(G1, A, Ledger)
+              end, Gateways);
+        _ -> ok
+    end.
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -37,7 +37,8 @@
          rescue_absorb/2,
          sign/2,
          print/1,
-         to_json/2
+         to_json/2,
+         process_hooks/3
         ]).
 
 %% helper API
@@ -1321,7 +1322,7 @@ invalid_var(Var, Value) ->
     throw({error, {unknown_var, Var, Value}}).
 -endif.
 
-
+-spec process_hooks(Vars :: map(), Unsets :: list(), Ledger :: blockchain_ledger_v1:ledger()) -> ok.
 process_hooks(Vars, Unsets, Ledger) ->
     _ = maps:map(
           fun(Var, Value) ->
@@ -1335,28 +1336,11 @@ process_hooks(Vars, Unsets, Ledger) ->
 
 %% separate out hook functions and call them in separate functions
 %% below the hook section.
-var_hook(?sweep_neighbors, true, Ledger) ->
-    neighbor_sweep(Ledger),
-    ok;
 var_hook(_Var, _Value, _Ledger) ->
     ok.
 
 unset_hook(_Var, _Ledger) ->
     ok.
-
-
-neighbor_sweep(Ledger) ->
-    case blockchain_ledger_v1:config(?poc_version, Ledger) of
-        {ok, V} when V > 3 ->
-            Gateways = blockchain_ledger_v1:active_gateways(Ledger),
-            %% find all neighbors for everyone
-            maps:map(
-              fun(A, G) ->
-                      G1 = blockchain_ledger_gateway_v2:neighbors([], G),
-                      blockchain_ledger_v1:update_gateway(G1, A, Ledger)
-              end, Gateways);
-        _ -> ok
-    end.
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/test/blockchain_change_assert_res_SUITE.erl
+++ b/test/blockchain_change_assert_res_SUITE.erl
@@ -1,0 +1,84 @@
+%%
+%% Steps:
+%% - Download a ledger from S3
+%% - Change assert res to 9 (This gets applied as a chain var hook) on the aux ledger
+%% - Check that all gws switched to res9 h3
+%%
+
+-module(blockchain_change_assert_res_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include("blockchain_vars.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1, init_per_testcase/2, end_per_testcase/2]).
+
+-export([
+    basic_test/1
+]).
+
+all() ->
+    [
+        basic_test
+    ].
+
+init_per_suite(Config) ->
+    S3URL = "https://blockchain-core.s3-us-west-1.amazonaws.com/ledger-865940.tar.gz",
+    Ledger = blockchain_ct_utils:ledger(#{}, S3URL),
+    [{ledger, Ledger} | Config].
+
+end_per_suite(Config) ->
+    Config.
+
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+end_per_testcase(_, _Config) ->
+    ok.
+
+basic_test(Config) ->
+    %% Check we have the correct ledger from S3
+    Ledger = ?config(ledger, Config),
+    {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
+    ct:pal("Height: ~p", [Height]),
+    ?assertEqual(865940, Height),
+
+    %% Check we can construct an aux ledger and it matches the height
+    AuxLedger = blockchain_ledger_v1:new_aux("aux.db", Ledger),
+    {ok, AuxHeight} = blockchain_ledger_v1:current_height(AuxLedger),
+    ct:pal("AuxHeight: ~p", [AuxHeight]),
+    ?assertEqual(865940, Height),
+
+    %% Check that every single hotspot on the ledger either has loc at res=12
+    true = lists:all(fun(Loc) -> h3:get_resolution(Loc) == 12 end, get_locations(Ledger)),
+
+    %% Get the aux ledger
+    AL = blockchain_ledger_v1:mode(aux, AuxLedger),
+
+    %% Set aux vars on the aux ledger
+    ok = blockchain_ledger_v1:set_aux_vars(aux_vars(), AL),
+
+    %% Check that every single hotspot on the aux-ledger either has loc at res=9
+    true = lists:all(fun(Loc) -> h3:get_resolution(Loc) == 9 end, get_locations(AL)),
+
+    ok.
+
+get_locations(Ledger) ->
+    AG = blockchain_ledger_v1:active_gateways(Ledger),
+    maps:fold(
+        fun(_GwAddr, Gw, Acc) ->
+            case blockchain_ledger_gateway_v2:location(Gw) of
+                undefined -> Acc;
+                Loc -> [Loc | Acc]
+            end
+        end,
+        [],
+        AG
+    ).
+
+aux_vars() ->
+    #{
+        ?switch_assert_res_9 => true,
+        ?min_assert_h3_res => 9,
+        ?poc_v4_parent_res => 8
+    }.


### PR DESCRIPTION
Testing what it will take to switch all existing gateways and subsequently added gateways to have gateway location asserted at h3 resolution 9.

Notes:

- Add `switch_assert_res_9` chain var
- Add `blockchain_change_assert_res_SUITE`
- This depends on var hook support
- Sync is broken, obviously
- From limited testing, it appears that wherever `h3:parent(SomeLoc, Res)` gets called and Res > 9, :boom: 
- So at the very minimum we need to set the following variables, although I don't yet fully know if there are others which could be borked.

```
    #{
        ?switch_assert_res_9 => true,
        ?min_assert_h3_res => 9,
        ?poc_v4_parent_res => 8
    }.
```

TODO:

- [ ] Resyncing
- [ ] Model POC behavior change
- [ ] Model reward behavior change