### PR TITLE
Update condition for next plausible block

### DIFF
--- a/src/blockchain_block.erl
+++ b/src/blockchain_block.erl
@@ -16,6 +16,8 @@
 -callback signatures(block()) -> [signature()].
 -callback set_signatures(block(), [signature()]) -> block().
 -callback is_rescue_block(block()) -> boolean().
+-callback is_election_block(block()) -> boolean().
+-callback verified_signees(block()) -> [libp2p_crypto:pubkey_bin()].
 
 %% arity 4 is for external users of this function who don't need to
 %% care about whether or not something is a rescue block.
@@ -44,6 +46,7 @@
          time/1,
          hbbft_round/1,
          is_genesis/1,
+         is_election_block/1,
          type/1,
          signatures/1, set_signatures/2,
          verify_signatures/4, verify_signatures/5,
@@ -51,7 +54,8 @@
          serialize/1,
          deserialize/1,
          is_rescue_block/1,
-         to_json/2
+         to_json/2,
+         verified_signees/1
         ]).
 
 new_genesis_block(Transactions) ->
@@ -83,6 +87,14 @@ hbbft_round(Block) ->
 -spec is_genesis(block()) -> boolean().
 is_genesis(Block) ->
     (type(Block)):is_genesis(Block).
+
+-spec is_election_block(block()) -> boolean().
+is_election_block(Block) ->
+    (type(Block)):is_election_block(Block).
+
+-spec verified_signees(block()) -> [libp2p_crypto:pubkey_bin()].
+verified_signees(Block) ->
+    (type(Block)):verified_signees(Block).
 
 -spec serialize(block()) -> binary().
 serialize(Block) ->

--- a/src/handlers/blockchain_gossip_handler.erl
+++ b/src/handlers/blockchain_gossip_handler.erl
@@ -83,7 +83,7 @@ add_block(Block, Chain, Sender, SwarmTID) ->
                     regossip_block(Block, SwarmTID),
                     ok;
                 plausible ->
-                    lager:warning("plausuble gossipped block doesn't fit with our chain, will start sync if not already active"),
+                    lager:warning("plausible gossipped block doesn't fit with our chain, will start sync if not already active"),
                     blockchain_worker:maybe_sync(),
                     %% pass it along
                     regossip_block(Block, SwarmTID),

--- a/test/plausible_block_SUITE.erl
+++ b/test/plausible_block_SUITE.erl
@@ -3,8 +3,6 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--include("blockchain.hrl").
-
 -export([
     all/0, init_per_testcase/2, end_per_testcase/2
 ]).
@@ -12,17 +10,16 @@
 -export([
     basic/1,
     definitely_invalid/1,
-    ultimately_invalid/1
-        ]).
+    ultimately_invalid/1,
+    valid/1
+]).
 
 all() ->
-    [basic, definitely_invalid, ultimately_invalid].
+    [basic, definitely_invalid, ultimately_invalid, valid].
 
 init_per_testcase(TestCase, Config) ->
     catch gen_server:stop(blockchain_sup),
     blockchain_ct_utils:init_base_dir_config(?MODULE, TestCase, Config).
-
-
 
 end_per_testcase(_, _Config) ->
     catch gen_server:stop(blockchain_sup),
@@ -224,3 +221,92 @@ ultimately_invalid(Config) ->
     [] = blockchain:get_plausible_blocks(Chain),
     ok.
 
+valid(Config) ->
+    BaseDir = ?config(base_dir, Config),
+    SimDir = ?config(sim_dir, Config),
+
+    Balance = 5000,
+    BlocksN = 80,
+    {ok, _Sup, {PrivKey, PubKey}, _Opts} = test_utils:init(BaseDir),
+    {ok, _GenesisMembers, _GenesisBlock, ConsensusMembers, _} = test_utils:init_chain(Balance, {PrivKey, PubKey}),
+    Chain0 = blockchain_worker:blockchain(),
+    {ok, Genesis} = blockchain:genesis_block(Chain0),
+
+    % Add some blocks
+    Blocks = lists:reverse(lists:foldl(
+        fun(_, Acc) ->
+            {ok, Block} = test_utils:create_block(ConsensusMembers, []),
+            blockchain:add_block(Block, Chain0),
+            [Block|Acc]
+        end,
+        [],
+        lists:seq(1, BlocksN)
+    )),
+    LastBlock = lists:last(Blocks),
+
+    {ok, Chain} = blockchain:new(SimDir, Genesis, undefined, undefined),
+
+    plausible = blockchain:can_add_block(LastBlock, Chain),
+    %% check we return the plausible message to the caller
+    plausible = blockchain:add_block(LastBlock, Chain),
+    %% don't return the plausible message more than once
+    ok = blockchain:add_block(LastBlock, Chain),
+    ?assertEqual({ok, 1}, blockchain:height(Chain)),
+    ?assertEqual({ok, 1}, blockchain:sync_height(Chain)),
+    [LastBlock] = blockchain:get_plausible_blocks(Chain),
+    %% add a block and check the plausible block remains
+    ok = blockchain:add_block(hd(Blocks), Chain),
+    ?assertEqual({ok, 2}, blockchain:height(Chain)),
+    ?assertEqual({ok, 2}, blockchain:sync_height(Chain)),
+    [LastBlock] = blockchain:get_plausible_blocks(Chain),
+    %% add all the rest of the blocks (emulate a sync)
+    ok = blockchain:add_blocks(Blocks -- [LastBlock], Chain),
+    %% check the plausible block is now the head of the chain
+    ?assertEqual({ok, 81}, blockchain:height(Chain)),
+    ?assertEqual({ok, 81}, blockchain:sync_height(Chain)),
+    ?assertEqual(blockchain:head_hash(Chain), {ok, blockchain_block:hash_block(LastBlock)}),
+    %% make sure the plausible blocks got removed
+    [] = blockchain:get_plausible_blocks(Chain),
+
+    %% NOTE:
+    %% N = 7, F = 2 (testing)
+    %% Even if we replace upto 3 ( F + 1) members, it should be
+    %% considered a plausible block
+    true = check_plausibility_after_replacing_k_members(1, ConsensusMembers, Chain),        %% keep 6
+    true = check_plausibility_after_replacing_k_members(2, ConsensusMembers, Chain),        %% keep 5
+    true = check_plausibility_after_replacing_k_members(3, ConsensusMembers, Chain),        %% keep 4
+    true = check_plausibility_after_replacing_k_members(4, ConsensusMembers, Chain),        %% keep 3
+    false = check_plausibility_after_replacing_k_members(5, ConsensusMembers, Chain),       %% keep 2
+    false = check_plausibility_after_replacing_k_members(6, ConsensusMembers, Chain),       %% keep 1
+    false = check_plausibility_after_replacing_k_members(7, ConsensusMembers, Chain),       %% keep 0
+
+    ok.
+
+replace_members(ConsensusMembers, ToReplace) ->
+    N = length(ConsensusMembers),
+    NewKeys = test_utils:generate_keys(ToReplace),
+    lists:sublist(ConsensusMembers, (N - ToReplace)) ++ NewKeys.
+
+check_plausibility_after_replacing_k_members(K, ConsensusMembers, Chain) ->
+    N = length(ConsensusMembers),
+    ct:pal("N: ~p", [N]),
+    ct:pal("K: ~p", [K]),
+    ?assertEqual(7, N),
+
+    NewMembers = replace_members(ConsensusMembers, K),
+    ?assertEqual(N, length(NewMembers)),
+
+    CM = [libp2p_crypto:bin_to_b58(I) || {I, _} <- ConsensusMembers],
+    CM2 = [libp2p_crypto:bin_to_b58(I) || {I, _} <- NewMembers],
+    ct:pal("ConsensusMembers: ~p", [CM]),
+    ct:pal("NewMembers: ~p", [CM2]),
+
+    %% check that ConsensusMembers and NewMembers have (N - K) elements in common
+    true = sets:size(sets:intersection(sets:from_list(ConsensusMembers), sets:from_list(NewMembers))) == (N - K),
+
+    {ok, BlockByNewMembers} = test_utils:create_block(NewMembers, []),
+    ct:pal("AnotherBlock: ~p", [BlockByNewMembers]),
+
+    IsPlausible = blockchain:is_block_plausible(BlockByNewMembers, Chain),
+    ct:pal("IsPlausible: ~p", [IsPlausible]),
+    IsPlausible.


### PR DESCRIPTION
Problem: `is_block_plausible` will incorrectly return false when the next block can indeed be considered plausible, for example getting a block after an election happens. This happens because of a sublist + shuffle when invoking `verify_signatures` for a block, and is exacerbated by the fact that `verify_signatures` terminates early on a single signature verification failure.

Solution:

- Expose `verified_signees/1` from block, this just accumulates those members who verifiably signed the block
- Change plausibility condition to a sets:size + intersection call
- Add test to verify said behavior
- Also added `is_election_block` optional callback (intended to use it for something, but decided against it, lmk if it needs to go away)