### PR TITLE
support GW mode specific assert location staking fees

### DIFF
--- a/include/blockchain_caps.hrl
+++ b/include/blockchain_caps.hrl
@@ -1,5 +1,5 @@
 %%
-%% A gateway can be set to one of 3 modes, light, nonconsensus and full
+%% A gateway can be set to one of 3 modes, dataonly, light and full
 %% each mode then has a bitmask defined via a chain var which
 %% determines the range of capabilities applicable for the given mode
 %%
@@ -19,8 +19,8 @@
 %% but the corresponding bitmask chain var is not found....which should never really happen but
 %% I feel better for covering the scenario
 %%
--define(GW_CAPABILITIES_LIGHT_GATEWAY_V1, 0 bor ?GW_CAPABILITY_ROUTE_PACKETS).
--define(GW_CAPABILITIES_NON_CONSENSUS_GATEWAY_V1, 0 bor ?GW_CAPABILITY_ROUTE_PACKETS
+-define(GW_CAPABILITIES_DATAONLY_GATEWAY_V1, 0 bor ?GW_CAPABILITY_ROUTE_PACKETS).
+-define(GW_CAPABILITIES_LIGHT_GATEWAY_V1, 0 bor ?GW_CAPABILITY_ROUTE_PACKETS
                                                     bor ?GW_CAPABILITY_POC_CHALLENGER
                                                     bor ?GW_CAPABILITY_POC_CHALLENGEE
                                                     bor ?GW_CAPABILITY_POC_WITNESS

--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -353,7 +353,7 @@
 -define(txn_fees, txn_fees).
 %% valid staking server keys, encoded via <<Len1:8/unsigned-integer, Key1/binary, Len2:8/unsigned-integer, Key2/binary, ...>>
 -define(staking_keys, staking_keys).
-%% staking server keys with a mapping to gateway type ( full, light or non-consensus )
+%% staking server keys with a mapping to gateway type ( dataonly, light and full )
 -define(staking_keys_to_mode_mappings, staking_keys_to_mode_mappings).
 %% the staking fee in DC for each OUI
 -define(staking_fee_txn_oui_v1, staking_fee_txn_oui_v1).
@@ -361,10 +361,17 @@
 -define(staking_fee_txn_oui_v1_per_address, staking_fee_txn_oui_v1_per_address).
 %% the staking fee in DC for adding a full gateway
 -define(staking_fee_txn_add_gateway_v1, staking_fee_txn_add_gateway_v1).
+%% the staking fee in DC for adding a dataonly gateway
+-define(staking_fee_txn_add_dataonly_gateway_v1, staking_fee_txn_add_dataonly_gateway_v1).
 %% the staking fee in DC for adding a light gateway
 -define(staking_fee_txn_add_light_gateway_v1, staking_fee_txn_add_light_gateway_v1).
 %% the staking fee in DC for asserting a location
 -define(staking_fee_txn_assert_location_v1, staking_fee_txn_assert_location_v1).
+%% the staking fee in DC for asserting a location for a dataonly gateway
+-define(staking_fee_txn_assert_location_dataonly_gateway_v1, staking_fee_txn_assert_location_dataonly_gateway_v1).
+%% the staking fee in DC for asserting a location for a light gateway
+-define(staking_fee_txn_assert_location_light_gateway_v1, staking_fee_txn_assert_location_light_gateway_v1).
+
 %% a mutliplier which will be applied to the txn fee of all txns, in order to make their DC costs meaningful
 -define(txn_fee_multiplier, txn_fee_multiplier).
 
@@ -434,10 +441,10 @@
 -define(max_antenna_gain, max_antenna_gain).        %% Set to 150 (15 dBi)
 
 %% ------------------------------------------------------------------
+%% the mask value to represent the capabilities of dataonly gateways, defined as an integer and used as a bitmask
+-define(dataonly_gateway_capabilities_mask, dataonly_gateway_capabilities_mask).
 %% the mask value to represent the capabilities of light gateways, defined as an integer and used as a bitmask
 -define(light_gateway_capabilities_mask, light_gateway_capabilities_mask).
-%% the mask value to represent the capabilities of non consensus gateways, defined as an integer and used as a bitmask
--define(non_consensus_gateway_capabilities_mask, non_consensus_gateway_capabilities_mask).
 %% the mask value to represent the capabilities of full gateways, defined as an integer and used as a bitmask
 -define(full_gateway_capabilities_mask, full_gateway_capabilities_mask).
 

--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -593,9 +593,9 @@ staking_keys_to_mode_mappings_test() ->
     EccPK1 = libp2p_crypto:pubkey_to_bin(RawEccPK1),
     EccPK2 = libp2p_crypto:pubkey_to_bin(RawEccPK2),
     EdPK = libp2p_crypto:pubkey_to_bin(RawEdPK),
-    BinMappings = prop_to_bin([{EccPK1, <<"light">>}, {EccPK2, <<"nonconsensus">>}, {EdPK, <<"full">>}]),
+    BinMappings = prop_to_bin([{EccPK1, <<"dataonly">>}, {EccPK2, <<"light">>}, {EdPK, <<"full">>}]),
     Results = bin_to_prop(BinMappings),
-    ?assertEqual([{EccPK1, <<"light">>}, {EccPK2, <<"nonconsensus">>}, {EdPK, <<"full">>}], Results),
+    ?assertEqual([{EccPK1, <<"dataonly">>}, {EccPK2, <<"light">>}, {EdPK, <<"full">>}], Results),
     Results1 = [ libp2p_crypto:bin_to_pubkey(K) || {K, _V} <- Results ],
     ?assertEqual([RawEccPK1, RawEccPK2, RawEdPK], Results1).
 

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -220,8 +220,11 @@
     staking_fee_txn_oui_v1/1,
     staking_fee_txn_oui_v1_per_address/1,
     staking_fee_txn_add_gateway_v1/1,
+    staking_fee_txn_add_dataonly_gateway_v1/1,
     staking_fee_txn_add_light_gateway_v1/1,
     staking_fee_txn_assert_location_v1/1,
+    staking_fee_txn_assert_location_dataonly_gateway_v1/1,
+    staking_fee_txn_assert_location_light_gateway_v1/1,
     staking_keys/1,
     staking_keys_to_mode_mappings/1,
     txn_fee_multiplier/1,
@@ -2308,6 +2311,17 @@ staking_fee_txn_add_gateway_v1(Ledger)->
     end.
 
 %%--------------------------------------------------------------------
+%% @doc  get staking fee chain var value for add dataonly gateway
+%% or return default
+%% @end
+%%--------------------------------------------------------------------
+-spec staking_fee_txn_add_dataonly_gateway_v1(Ledger :: ledger()) -> pos_integer().
+staking_fee_txn_add_dataonly_gateway_v1(Ledger)->
+    case blockchain:config(?staking_fee_txn_add_dataonly_gateway_v1, Ledger) of
+        {error, not_found} -> 1;
+        {ok, V} -> V
+    end.
+%%--------------------------------------------------------------------
 %% @doc  get staking fee chain var value for add light gateway
 %% or return default
 %% @end
@@ -2339,6 +2353,28 @@ txn_fee_multiplier(Ledger)->
 -spec staking_fee_txn_assert_location_v1(Ledger :: ledger()) -> pos_integer().
 staking_fee_txn_assert_location_v1(Ledger)->
     case blockchain:config(?staking_fee_txn_assert_location_v1, Ledger) of
+        {error, not_found} -> 1;
+        {ok, V} -> V
+    end.
+%%--------------------------------------------------------------------
+%% @doc  get staking fee chain var value for assert_location_v1 for a dataonly gateway
+%% or return default
+%% @end
+%%--------------------------------------------------------------------
+-spec staking_fee_txn_assert_location_dataonly_gateway_v1(Ledger :: ledger()) -> pos_integer().
+staking_fee_txn_assert_location_dataonly_gateway_v1(Ledger)->
+    case blockchain:config(?staking_fee_txn_assert_location_dataonly_gateway_v1, Ledger) of
+        {error, not_found} -> 1;
+        {ok, V} -> V
+    end.
+%%--------------------------------------------------------------------
+%% @doc  get staking fee chain var value for assert_location_v1 for a light gateway
+%% or return default
+%% @end
+%%--------------------------------------------------------------------
+-spec staking_fee_txn_assert_location_light_gateway_v1(Ledger :: ledger()) -> pos_integer().
+staking_fee_txn_assert_location_light_gateway_v1(Ledger)->
+    case blockchain:config(?staking_fee_txn_assert_location_light_gateway_v1, Ledger) of
         {error, not_found} -> 1;
         {ok, V} -> V
     end.

--- a/src/transactions/v1/blockchain_txn_add_gateway_v1.erl
+++ b/src/transactions/v1/blockchain_txn_add_gateway_v1.erl
@@ -380,10 +380,10 @@ gateway_mode(Ledger, Payer) ->
         not_found ->
                 full;
         Mappings when is_list(Mappings) ->
-            %% check if there is an entry for the payer key, if not default to light gw
-            %% if a GW needs to be non light, its payer MUST have an entry in the staking key mappings table
+            %% check if there is an entry for the payer key, if not default to dataonly gw
+            %% if a GW needs to be non dataonly, its payer MUST have an entry in the staking key mappings table
             case proplists:get_value(Payer, Mappings, not_found) of
-                not_found -> light;
+                not_found -> dataonly;
                 GWMode -> binary_to_atom(GWMode, utf8)
             end
     end.
@@ -417,9 +417,11 @@ to_json(Txn, _Opts) ->
      }.
 
 -spec staking_fee_for_gw_mode(blockchain_ledger_gateway_v2:mode(), blockchain_ledger_v1:ledger()) -> non_neg_integer().
+staking_fee_for_gw_mode(dataonly, Ledger)->
+    blockchain_ledger_v1:staking_fee_txn_add_dataonly_gateway_v1(Ledger);
 staking_fee_for_gw_mode(light, Ledger)->
     blockchain_ledger_v1:staking_fee_txn_add_light_gateway_v1(Ledger);
-staking_fee_for_gw_mode(_, Ledger)->
+staking_fee_for_gw_mode(full, Ledger)->
     blockchain_ledger_v1:staking_fee_txn_add_gateway_v1(Ledger).
 
 

--- a/src/transactions/v1/blockchain_txn_assert_location_v1.erl
+++ b/src/transactions/v1/blockchain_txn_assert_location_v1.erl
@@ -191,9 +191,18 @@ calculate_fee(Txn, Ledger, DCPayloadSize, TxnFeeMultiplier, true) ->
 -spec calculate_staking_fee(txn_assert_location(), blockchain:blockchain()) -> non_neg_integer().
 calculate_staking_fee(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
-    Fee = blockchain_ledger_v1:staking_fee_txn_assert_location_v1(Ledger),
+    Gateway = ?MODULE:gateway(Txn),
+    Fee =
+        case blockchain_ledger_v1:find_gateway_info(Gateway, Ledger) of
+            {error, _} ->
+                %% err we cant find gateway what to do??
+                %% defaulting to regular fee
+                 blockchain_ledger_v1:staking_fee_txn_assert_location_v1(Ledger);
+            {ok, GwInfo} ->
+                GWMode = blockchain_ledger_gateway_v2:mode(GwInfo),
+                staking_fee_for_gw_mode(GWMode, Ledger)
+        end,
     calculate_staking_fee(Txn, Ledger, Fee, [],blockchain_ledger_v1:txn_fees_active(Ledger)).
-
 -spec calculate_staking_fee(txn_assert_location(), blockchain_ledger_v1:ledger(), non_neg_integer(), [{atom(), non_neg_integer()}], boolean()) -> non_neg_integer().
 calculate_staking_fee(_Txn, _Ledger, _Fee, _ExtraData, false) ->
     ?LEGACY_STAKING_FEE;
@@ -474,6 +483,14 @@ to_json(Txn, _Opts) ->
       staking_fee => staking_fee(Txn),
       fee => fee(Txn)
      }.
+
+-spec staking_fee_for_gw_mode(blockchain_ledger_gateway_v2:mode(), blockchain_ledger_v1:ledger()) -> non_neg_integer().
+staking_fee_for_gw_mode(dataonly, Ledger)->
+    blockchain_ledger_v1:staking_fee_txn_assert_location_dataonly_gateway_v1(Ledger);
+staking_fee_for_gw_mode(light, Ledger)->
+    blockchain_ledger_v1:staking_fee_txn_assert_location_light_gateway_v1(Ledger);
+staking_fee_for_gw_mode(_, Ledger)->
+    blockchain_ledger_v1:staking_fee_txn_assert_location_v1(Ledger).
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -761,8 +761,8 @@ validate_staking_keys_to_mode_mappings([{PubKey, GWMode} | T]) ->
             throw({error, {invalid_staking_to_mode_mapping, {PubKey, GWMode}}})
     end.
 
-validate_staking_key_mode_mapping_value(GWMode) when GWMode == <<"light">>;
-                                                     GWMode == <<"nonconsensus">>;
+validate_staking_key_mode_mapping_value(GWMode) when GWMode == <<"dataonly">>;
+                                                     GWMode == <<"light">>;
                                                      GWMode == <<"full">> ->
     ok;
 validate_staking_key_mode_mapping_value(GWMode) ->
@@ -1115,7 +1115,7 @@ validate_var(?staking_keys, Value) ->
     validate_staking_keys_format(Value);
 
 validate_var(?staking_keys_to_mode_mappings, Value) ->
-    %% the staking key mode mappings, a key value list of staking keys and their associated gateway types ( light, nonconsensus and full )
+    %% the staking key mode mappings, a key value list of staking keys and their associated gateway types ( dataonly, light, and full )
     validate_staking_keys_to_mode_mappings_format(Value);
 
 %% txn fee vars below are in DC
@@ -1131,6 +1131,10 @@ validate_var(?staking_fee_txn_add_gateway_v1, Value) ->
     %% the staking fee price for an add gateway txn, in DC
     validate_int(Value, "staking_fee_txn_add_gateway_v1", 0, 1000 * ?USD_TO_DC, false);
 
+validate_var(?staking_fee_txn_add_dataonly_gateway_v1, Value) ->
+    %% the staking fee price for an add gateway txn where the gateway is of mode dataonly, in DC
+    validate_int(Value, "staking_fee_txn_add_dataonly_gateway_v1", 0, 1000 * ?USD_TO_DC, false);
+
 validate_var(?staking_fee_txn_add_light_gateway_v1, Value) ->
     %% the staking fee price for an add gateway txn where the gateway is of mode light, in DC
     validate_int(Value, "staking_fee_txn_add_light_gateway_v1", 0, 1000 * ?USD_TO_DC, false);
@@ -1138,6 +1142,14 @@ validate_var(?staking_fee_txn_add_light_gateway_v1, Value) ->
 validate_var(?staking_fee_txn_assert_location_v1, Value) ->
     %% the staking fee price for an assert location txn, in DC
     validate_int(Value, "staking_fee_txn_assert_location_v1", 0, 1000 * ?USD_TO_DC, false);
+
+validate_var(?staking_fee_txn_assert_location_dataonly_gateway_v1, Value) ->
+    %% the staking fee price for an assert location txn for a dataonly gw, in DC
+    validate_int(Value, "staking_fee_txn_assert_location_dataonly_gateway_v1", 0, 1000 * ?USD_TO_DC, false);
+
+validate_var(?staking_fee_txn_assert_location_light_gateway_v1, Value) ->
+    %% the staking fee price for an assert location txn for a light gw, in DC
+    validate_int(Value, "staking_fee_txn_assert_location_light_gateway_v1", 0, 1000 * ?USD_TO_DC, false);
 
 validate_var(?txn_fee_multiplier, Value) ->
     %% a multiplier applied to txn fee, in DC
@@ -1201,17 +1213,17 @@ validate_var(?max_antenna_gain, Value) ->
     %% Initially set to 150 to imply 15 dBi
     validate_int(Value, "max_antenna_gain", 10, 200, false);
 
+validate_var(?dataonly_gateway_capabilities_mask, Value) ->
+    %% a bitmask determining capabilities of a dataonly gateway - using a 16bit mask.
+    %% see blockchain_caps.hrl for capability list
+    %% TODO - allow for > 16 bit mask here?
+    validate_int(Value, "dataonly_gateway_capabilities_mask", 0, 65536, false);
+
 validate_var(?light_gateway_capabilities_mask, Value) ->
     %% a bitmask determining capabilities of a light gateway - using a 16bit mask.
     %% see blockchain_caps.hrl for capability list
     %% TODO - allow for > 16 bit mask here?
     validate_int(Value, "light_gateway_capabilities_mask", 0, 65536, false);
-
-validate_var(?non_consensus_gateway_capabilities_mask, Value) ->
-    %% a bitmask determining capabilities of a non consensus gateway - using a 16bit mask.
-    %% see blockchain_caps.hrl for capability list
-    %% TODO - allow for > 16 bit mask here?
-    validate_int(Value, "non_consensus_gateway_capabilities_mask", 0, 65536, false);
 
 validate_var(?full_gateway_capabilities_mask, Value) ->
     %% a bitmask determining capabilities of a full gateway - using a 16bit mask.

--- a/src/transactions/v2/blockchain_txn_assert_location_v2.erl
+++ b/src/transactions/v2/blockchain_txn_assert_location_v2.erl
@@ -202,7 +202,17 @@ calculate_fee(Txn, Ledger, DCPayloadSize, TxnFeeMultiplier, true) ->
 -spec calculate_staking_fee(txn_assert_location(), blockchain:blockchain()) -> non_neg_integer().
 calculate_staking_fee(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
-    Fee = blockchain_ledger_v1:staking_fee_txn_assert_location_v1(Ledger),
+    Gateway = ?MODULE:gateway(Txn),
+    Fee =
+        case blockchain_ledger_v1:find_gateway_info(Gateway, Ledger) of
+            {error, _} ->
+                %% err we cant find gateway what to do??
+                %% defaulting to regular fee
+                 blockchain_ledger_v1:staking_fee_txn_assert_location_v1(Ledger);
+            {ok, GwInfo} ->
+                GWMode = blockchain_ledger_gateway_v2:mode(GwInfo),
+                staking_fee_for_gw_mode(GWMode, Ledger)
+        end,
     calculate_staking_fee(Txn, Ledger, Fee, [], blockchain_ledger_v1:txn_fees_active(Ledger)).
 
 -spec calculate_staking_fee(txn_assert_location(), blockchain_ledger_v1:ledger(), non_neg_integer(), [{atom(), non_neg_integer()}], boolean()) -> non_neg_integer().
@@ -525,6 +535,14 @@ to_json(Txn, _Opts) ->
 %% ------------------------------------------------------------------
 %% Internal Function Definitions
 %% ------------------------------------------------------------------
+
+-spec staking_fee_for_gw_mode(blockchain_ledger_gateway_v2:mode(), blockchain_ledger_v1:ledger()) -> non_neg_integer().
+staking_fee_for_gw_mode(dataonly, Ledger)->
+    blockchain_ledger_v1:staking_fee_txn_assert_location_dataonly_gateway_v1(Ledger);
+staking_fee_for_gw_mode(light, Ledger)->
+    blockchain_ledger_v1:staking_fee_txn_assert_location_light_gateway_v1(Ledger);
+staking_fee_for_gw_mode(_, Ledger)->
+    blockchain_ledger_v1:staking_fee_txn_assert_location_v1(Ledger).
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/test/blockchain_simple_SUITE.erl
+++ b/test/blockchain_simple_SUITE.erl
@@ -32,8 +32,8 @@
     election_test/1,
     election_v3_test/1,
     election_v4_test/1,
+    dataonly_gw_election_v4_test/1,
     light_gw_election_v4_test/1,
-    nonconsensus_gw_election_v4_test/1,
     election_v5_test/1,
     chain_vars_test/1,
     chain_vars_set_unset_test/1,
@@ -86,8 +86,8 @@ all() ->
         election_test,
         election_v3_test,
         election_v4_test,
+        dataonly_gw_election_v4_test,
         light_gw_election_v4_test,
-        nonconsensus_gw_election_v4_test,
         chain_vars_test,
         chain_vars_set_unset_test,
         token_burn_test,
@@ -120,8 +120,8 @@ init_per_testcase(TestCase, Config) ->
                           election_bba_penalty => 0.01,
                           election_seen_penalty => 0.03};
                     X when X == election_v4_test;
-                           X == light_gw_election_v4_test;
-                           X == nonconsensus_gw_election_v4_test ->
+                           X == dataonly_gw_election_v4_test;
+                           X == light_gw_election_v4_test ->
                         #{election_version => 4,
                           election_bba_penalty => 0.01,
                           election_seen_penalty => 0.03};
@@ -1829,9 +1829,9 @@ election_v4_test(Config) ->
 
     ok.
 
-nonconsensus_gw_election_v4_test(Config) ->
+light_gw_election_v4_test(Config) ->
     %% this reusues the election v4 test but modifies it so that before the new election
-    %% all the GWs are updated to be nonconsensus mode
+    %% all the GWs are updated to be light mode
     %% this means they should be exlcuded from becoming part of the new group
     %% as the test updates all the GWs the new group ends up being same as the old group
     BaseDir = ?config(base_dir, Config),
@@ -1855,7 +1855,7 @@ nonconsensus_gw_election_v4_test(Config) ->
          Alpha = 1.0 + rand:uniform(20),
          Beta = 1.0 + rand:uniform(4),
          I2 = blockchain_ledger_gateway_v2:set_alpha_beta_delta(Alpha, Beta, 1, I),
-         I3 = blockchain_ledger_gateway_v2:mode(nonconsensus, I2),
+         I3 = blockchain_ledger_gateway_v2:mode(light, I2),
          blockchain_ledger_v1:update_gateway(I3, Addr, Ledger1)
      end
      || {Addr, _} <- GenesisMembers],
@@ -1906,7 +1906,7 @@ nonconsensus_gw_election_v4_test(Config) ->
     {ok, OldGroup} = blockchain_ledger_v1:consensus_members(Ledger),
     ct:pal("old ~p", [OldGroup]),
 
-    %% update all of the GWs to nonconsensus modes
+    %% update all of the GWs to light modes
     %% this should block them from becoming part of any new group
     %% confirm they are not elected
     %% the new group should be same as the old group as there are no valid new members
@@ -1915,7 +1915,7 @@ nonconsensus_gw_election_v4_test(Config) ->
 
     [begin
          {ok, I} = blockchain_gateway_cache:get(Addr, Ledger2),
-         I2 = blockchain_ledger_gateway_v2:mode(nonconsensus, I),
+         I2 = blockchain_ledger_gateway_v2:mode(light, I),
          blockchain_ledger_v1:update_gateway(I2, Addr, Ledger2)
      end
      || {Addr, _} <- GenesisMembers],
@@ -1937,9 +1937,9 @@ nonconsensus_gw_election_v4_test(Config) ->
 
     ok.
 
-light_gw_election_v4_test(Config) ->
+dataonly_gw_election_v4_test(Config) ->
     %% this reusues the election v4 test but modifies it so that before the new election
-    %% all the GWs are updated to be light mode
+    %% all the GWs are updated to be dataonly mode
     %% this means they should be excluded from becoming part of the new group
     %% as the test updates all the GWs the new group ends up being same as the old group
     BaseDir = ?config(base_dir, Config),
@@ -1963,7 +1963,7 @@ light_gw_election_v4_test(Config) ->
          Alpha = 1.0 + rand:uniform(20),
          Beta = 1.0 + rand:uniform(4),
          I2 = blockchain_ledger_gateway_v2:set_alpha_beta_delta(Alpha, Beta, 1, I),
-         I3 = blockchain_ledger_gateway_v2:mode(nonconsensus, I2),
+         I3 = blockchain_ledger_gateway_v2:mode(dataonly, I2),
          blockchain_ledger_v1:update_gateway(I3, Addr, Ledger1)
      end
      || {Addr, _} <- GenesisMembers],
@@ -2014,7 +2014,7 @@ light_gw_election_v4_test(Config) ->
     {ok, OldGroup} = blockchain_ledger_v1:consensus_members(Ledger),
     ct:pal("old ~p", [OldGroup]),
 
-    %% update all of the GWs to light mode
+    %% update all of the GWs to dataonly mode
     %% this should block them from becoming part of any new group
     %% confirm they are not elected
     %% the new group should be same as the old group as there are no valid new members
@@ -2023,7 +2023,7 @@ light_gw_election_v4_test(Config) ->
 
     [begin
          {ok, I} = blockchain_gateway_cache:get(Addr, Ledger2),
-         I2 = blockchain_ledger_gateway_v2:mode(light, I),
+         I2 = blockchain_ledger_gateway_v2:mode(dataonly, I),
          blockchain_ledger_v1:update_gateway(I2, Addr, Ledger2)
      end
      || {Addr, _} <- GenesisMembers],


### PR DESCRIPTION
Adds support for:

1.  GW mode specific assert location staking fees
2. Light GW specific staking fees ( previously if not dataonly would default to same fee as full, now we can have a distinct fee for light if required )
3. Renamed GW mode names ( 'light' becomes 'dataonly', 'nonconsensus' becomes 'light', full unchanged )

