### PR TITLE
Fix reward unit calculation

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -185,7 +185,7 @@
 -define(witness_redundancy, witness_redundancy).
 -define(poc_reward_decay_rate, poc_reward_decay_rate).
 -define(rewards_txn_version, rewards_txn_version).
--define(fix_tx_reward_unit, fix_tx_reward_unit).
+-define(tx_reward_unit_cap, tx_reward_unit_cap).
 
 %%%
 %%% bundle txn vars

--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -185,7 +185,7 @@
 -define(witness_redundancy, witness_redundancy).
 -define(poc_reward_decay_rate, poc_reward_decay_rate).
 -define(rewards_txn_version, rewards_txn_version).
--define(tx_reward_unit_cap, tx_reward_unit_cap).
+-define(hip15_tx_reward_unit_cap, hip15_tx_reward_unit_cap).
 
 %%%
 %%% bundle txn vars

--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -185,6 +185,7 @@
 -define(witness_redundancy, witness_redundancy).
 -define(poc_reward_decay_rate, poc_reward_decay_rate).
 -define(rewards_txn_version, rewards_txn_version).
+-define(fix_tx_reward_unit, fix_tx_reward_unit).
 
 %%%
 %%% bundle txn vars

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -993,6 +993,12 @@ validate_var(?rewards_txn_version, Value) ->
         N when is_integer(N), N >= 1, N =< 2 -> ok;
         _ -> throw({error, {invalid_rewards_txn_version, Value}})
     end;
+validate_var(?fix_tx_reward_unit, Value) ->
+    case Value of
+        true -> ok;
+        false -> ok;
+        _ -> throw({error, {invalid_fix_tx_reward_unit, Value}})
+    end;
 
 %% bundle vars
 validate_var(?max_bundle_size, Value) ->

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -993,12 +993,10 @@ validate_var(?rewards_txn_version, Value) ->
         N when is_integer(N), N >= 1, N =< 2 -> ok;
         _ -> throw({error, {invalid_rewards_txn_version, Value}})
     end;
-validate_var(?fix_tx_reward_unit, Value) ->
-    case Value of
-        true -> ok;
-        false -> ok;
-        _ -> throw({error, {invalid_fix_tx_reward_unit, Value}})
-    end;
+validate_var(?tx_reward_unit_cap, Value) ->
+    %% According to HIP-15, the cap should be set to 2.0
+    %% 5.0 is just for future proofing if need be
+    validate_float(Value, "tx_reward_unit_cap", 0.0, 5.0);
 
 %% bundle vars
 validate_var(?max_bundle_size, Value) ->

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -993,10 +993,10 @@ validate_var(?rewards_txn_version, Value) ->
         N when is_integer(N), N >= 1, N =< 2 -> ok;
         _ -> throw({error, {invalid_rewards_txn_version, Value}})
     end;
-validate_var(?tx_reward_unit_cap, Value) ->
+validate_var(?hip15_tx_reward_unit_cap, Value) ->
     %% According to HIP-15, the cap should be set to 2.0
     %% 5.0 is just for future proofing if need be
-    validate_float(Value, "tx_reward_unit_cap", 0.0, 5.0);
+    validate_float(Value, "hip15_tx_reward_unit_cap", 0.0, 5.0);
 
 %% bundle vars
 validate_var(?max_bundle_size, Value) ->

--- a/src/transactions/v2/blockchain_txn_rewards_v2.erl
+++ b/src/transactions/v2/blockchain_txn_rewards_v2.erl
@@ -618,6 +618,11 @@ get_reward_vars(Start, End, Ledger) ->
                         _ -> undefined
                     end,
 
+    FixTxRewardUnit = case blockchain:config(?fix_tx_reward_unit, Ledger) of
+                          {ok, Val} -> Val;
+                          _ -> undefined
+                      end,
+
     EpochReward = calculate_epoch_reward(Start, End, Ledger),
     #{
         monthly_reward => MonthlyReward,
@@ -635,7 +640,8 @@ get_reward_vars(Start, End, Ledger) ->
         reward_version => RewardVersion,
         witness_redundancy => WitnessRedundancy,
         poc_reward_decay_rate => DecayRate,
-        density_tgt_res => DensityTgtRes
+        density_tgt_res => DensityTgtRes,
+        fix_tx_reward_unit => FixTxRewardUnit
     }.
 
 -spec calculate_epoch_reward(pos_integer(), pos_integer(), blockchain_ledger_v1:ledger()) -> float().


### PR DESCRIPTION
Problem: The `normalize_reward_unit` function would incorrectly cap the unit at 1.0 instead of 2.0 for the second case of "Reward formula for Tx" as mentioned in [HIP-15](https://github.com/helium/HIP/blob/master/0015-beaconing-rewards.md), this value should tend towards 2.0 instead of 1.0

More details available in bug: https://github.com/helium/blockchain-core/issues/835

Solution:

- Add a new float chain var `hip15_tx_reward_unit_cap`
- Update normalization function to cap reward unit at `hip15_tx_reward_unit_cap`
- Add a simple eunit for the updated normalization function
- Set value for `hip15_tx_reward_unit_cap = 2.0` on chain