### PR TITLE
Fix deadlock when continuing to load snapshot

### DIFF
--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -681,7 +681,7 @@ maybe_sync(#state{mode = snapshot, blockchain = Chain, sync_pid = Pid} = State) 
             case State#state.snapshot_info of
                 %% when the current height is *lower* than than the
                 %% snap height, start the sync
-                {Hash, Height} when CurrHeight < Height ->
+                {Hash, Height} when CurrHeight < Height - 1 ->
                     snapshot_sync(Hash, Height, State);
                 _ ->
                     reset_sync_timer(State)
@@ -1104,8 +1104,7 @@ get_sync_mode(Blockchain) ->
                             {snapshot, {Hash, Height}};
                         _Chain ->
                             {ok, CurrHeight} = blockchain:height(Blockchain),
-                            %% this should be height - 1, but it crashes badly if you set it
-                            case CurrHeight >= Height of
+                            case CurrHeight >= Height - 1 of
                                 %% already loaded the snapshot
                                 true -> {normal, undefined};
                                 false -> {snapshot, {Hash, Height}}

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -503,9 +503,11 @@ load_blocks(Ledger0, Chain, Snapshot) ->
                       %% hash from the height is an acceptable presence check, and much cheaper
                       case blockchain:get_block_hash(Ht, Chain) of
                           {ok, _Hash} ->
+                              lager:info("skipping block ~p", [Ht]),
                               %% already have it, don't need to store it again.
                               ok;
                           _ ->
+                              lager:info("saving block ~p", [Ht]),
                               ok = blockchain:save_block(Block, Chain)
                       end,
                       case Ht > Curr2 of

--- a/test/blockchain_snapshot_SUITE.erl
+++ b/test/blockchain_snapshot_SUITE.erl
@@ -139,9 +139,7 @@ basic_test(_Config) ->
     DiffBC = blockchain_ledger_snapshot_v1:diff(SnapshotB, SnapshotC),
     ct:pal("DiffBC: ~p", [DiffBC]),
 
-    %% TODO: C has new elements in upgrades. Should we assert something more specific?
-    ?assertEqual([upgrades], DiffBC),
-    %% Otherwise B and C should be the same:
+    %% C has new elements in upgrades, otherwise B and C should be the same:
     ?assertEqual(
         maps:remove(upgrades, SnapshotB),
         maps:remove(upgrades, SnapshotC)


### PR DESCRIPTION
Additionally we avoid re-loading the ledger if we detect an interrupted
snapshot load.

Finally, we try to increase the file size for column families storing
blocks so that we do compactions less often because we are storing large
values.