### PR TITLE
misc txn fixes

### DIFF
--- a/src/transactions/v1/blockchain_txn_stake_validator_v1.erl
+++ b/src/transactions/v1/blockchain_txn_stake_validator_v1.erl
@@ -21,7 +21,7 @@
          owner/1,
          stake/1,
          owner_signature/1,
-         fee/1, calculate_fee/2, calculate_fee/5, 
+         fee/1, calculate_fee/2, calculate_fee/5,
          fee_payer/2,
          sign/2,
          is_valid/2,
@@ -166,7 +166,7 @@ is_valid(Txn, Chain) ->
                                     true -> ok;
                                     false -> throw({balance_too_low, {bal, Balance, stk, Stake}})
                                 end;
-                            {error, not_found} ->
+                            {error, address_entry_not_found} ->
                                 throw(unknown_owner);
                             {error, Error} ->
                                 throw(Error)

--- a/src/transactions/v2/blockchain_txn_assert_location_v2.erl
+++ b/src/transactions/v2/blockchain_txn_assert_location_v2.erl
@@ -343,9 +343,14 @@ do_is_valid_checks(Txn, Chain) ->
 is_new_location(Txn, Ledger) ->
     GwPubkeyBin = ?MODULE:gateway(Txn),
     NewLoc = ?MODULE:location(Txn),
-    {ok, Gw} = blockchain_ledger_v1:find_gateway_info(GwPubkeyBin, Ledger),
-    ExistingLoc = blockchain_ledger_gateway_v2:location(Gw),
-    NewLoc /= ExistingLoc.
+    case blockchain_ledger_v1:find_gateway_info(GwPubkeyBin, Ledger) of
+        {ok, Gw} ->
+            ExistingLoc = blockchain_ledger_gateway_v2:location(Gw),
+            NewLoc /= ExistingLoc;
+        {error, _Reason} ->
+            %% if GW doesnt exist, default to true
+            true
+    end.
 
 -spec do_remaining_checks(Txn :: txn_assert_location(),
                           TotalFee :: non_neg_integer(),

--- a/src/transactions/v2/blockchain_txn_assert_location_v2.erl
+++ b/src/transactions/v2/blockchain_txn_assert_location_v2.erl
@@ -349,7 +349,7 @@ is_new_location(Txn, Ledger) ->
             NewLoc /= ExistingLoc;
         {error, _Reason} ->
             %% if GW doesnt exist, default to true
-            true
+            throw({error, gateway_not_found})
     end.
 
 -spec do_remaining_checks(Txn :: txn_assert_location(),

--- a/test/blockchain_payment_v2_SUITE.erl
+++ b/test/blockchain_payment_v2_SUITE.erl
@@ -644,7 +644,7 @@ transfer(Amount, {Src, SrcSigFun}, Dst, ExpectHeight, Chain, ConsensusMembers) -
     DstBalance0 = balance(Dst, Chain),
     Ledger = blockchain:ledger(Chain),
     Nonce = case blockchain_ledger_v1:find_entry(Src, Ledger) of
-                {error, not_found} -> 1;
+                {error, address_entry_not_found} -> 1;
                 {ok, Entry} -> blockchain_ledger_entry_v1:nonce(Entry) + 1
             end,
     Tx = blockchain_txn_payment_v2:new(Src, [blockchain_payment_v2:new(Dst, Amount)], Nonce),
@@ -665,7 +665,7 @@ transfer(Amount, {Src, SrcSigFun}, Dst, ExpectHeight, Chain, ConsensusMembers) -
 balance(<<Addr/binary>>, Chain) ->
     Ledger = blockchain:ledger(Chain),
     case blockchain_ledger_v1:find_entry(Addr, Ledger) of
-        {error, not_found} ->
+        {error, address_entry_not_found} ->
             0;
         {ok, Entry} ->
             blockchain_ledger_entry_v1:balance(Entry)


### PR DESCRIPTION
Addresses two issues

1. Replaces the "not_found" response from blockchain_ledger_v1:find_gateway/2 when a gateway entry is not found with the more descriptive msg "address_entry_not_found".   The updated response is then handled within blockchain_ledger_v1:check_dc_or_hnt_balance/4 and translated into a meaningful error msg which will be propagated to txn_mgr and from there out to ETL via the txn callback mechanism.


2.  Handles the scenario of a gateway not being found as part of assert location v2's is_new_location/2 function.  Prevents this crashing out and polluting ETL logs
