### PR TITLE
Double the memory limit for snapshot creation

### DIFF
--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -144,7 +144,7 @@ snapshot(Ledger0, Blocks, Mode) ->
                 {
                     max_heap_size,
                     (fun() ->
-                        Mb = application:get_env(blockchain, snapshot_memory_limit, 100),
+                        Mb = application:get_env(blockchain, snapshot_memory_limit, 200),
                         Mb * 1024 * 1024 div erlang:system_info(wordsize)
                     end)()
                 },


### PR DESCRIPTION
This change reflects the growth of the network and also the dramatically
lower memory footprint even older miners have since we switched to
checkpoints.