### PR TITLE
return dup error when definitive dup encountered

### DIFF
--- a/src/transactions/blockchain_txn_mgr.erl
+++ b/src/transactions/blockchain_txn_mgr.erl
@@ -372,7 +372,7 @@ process_cached_txns(Chain, CurBlockHeight, SubmitF, _Sync, IsNewElection, NewGro
                             lager:debug("txn has undecided validations, leaving in cache: ~p", [blockchain_txn:hash(Txn)]),
                             ok
                     end;
-                {{Txn, InvalidReason}, true} ->
+                {{Txn, _InvalidReason}, true} ->
                     %% hmm we have a txn which is a member of the valid and the invalid list
                     %% this can only mean we have dup txns, like 2 payment txns submitted with same nonce and payload
                     %% During validate, the first will be rendered valid, the second will be declared invalid
@@ -392,7 +392,7 @@ process_cached_txns(Chain, CurBlockHeight, SubmitF, _Sync, IsNewElection, NewGro
                                                 CurBlockHeight, IsNewElection);
                         _ ->
                             %% declare this copy as invalid
-                            process_invalid_txn(CachedTxn, {error, {invalid, InvalidReason}})
+                            process_invalid_txn(CachedTxn, {error, {invalid, duplicate_txn}})
                     end;
                 {{Txn, InvalidReason}, _} ->
                     %% the txn is invalid


### PR DESCRIPTION
This change see a "duplicate_txn" error response passed to the txn callback and thus for example onwards to ETL.

The dup error response is only returned when there is a definitive dup, that is the same txn payload exists in both the valid and invalid list after a run via blockchain_txn:validate and thus there are at least two copies of the same txn payload in the txn mgr cache.

This should provide some additional clarity around suspected duplicated assert loc v2 txns and help to eliminate some of the noise by being able to eliminate definitive dups from the equation.  Dups in ETL will show with this error msg rather than validation specific error msgs such as wrong_staking_fee or invalid_nonce.
