### PR TITLE
Macpie/bloom fix

### DIFF
--- a/src/state_channel/blockchain_state_channels_server.erl
+++ b/src/state_channel/blockchain_state_channels_server.erl
@@ -64,8 +64,7 @@
 -type sc_key() :: blockchain_state_channel_v1:id().
 -type sc_value() :: {blockchain_state_channel_v1:state_channel(), skewed:skewed()}.
 -type state_channels() :: #{sc_key() => sc_value()}.
--type bloom_value() :: {ClientBloom :: bloom_nif:bloom(), PacketBloom :: bloom_nif:bloom()}.
--type blooms() :: #{sc_key() => bloom_value()}.
+-type blooms() :: #{sc_key() => bloom_nif:bloom()}.
 -type streams() :: #{libp2p_crypto:pubkey_bin() => {pid(), reference()}}.
 
 -ifdef(TEST).
@@ -331,7 +330,7 @@ handle_packet(ClientPubKeyBin, Packet, HandlerPid,
             State;
         {ok, SC} ->
             ActiveSCID = blockchain_state_channel_v1:id(SC),
-            {ClientBloom, PacketBloom} = maps:get(ActiveSCID, Blooms),
+            PacketBloom = maps:get(ActiveSCID, Blooms),
             {_, Skewed} = maps:get(ActiveSCID, SCs),
             case SCVer > 1 andalso bloom:check_and_set(PacketBloom, Payload) of
                 true ->
@@ -348,8 +347,8 @@ handle_packet(ClientPubKeyBin, Packet, HandlerPid,
                                     SC2;
                                 _ ->
                                     {SC3, _} =
-                                        update_sc_summary(ClientPubKeyBin, byte_size(Payload), State#state.dc_payload_size,
-                                                          SC2, ClientBloom, MaxActorsAllowed),
+                                        update_sc_summary(ClientPubKeyBin, byte_size(Payload),
+                                                          State#state.dc_payload_size, SC2, MaxActorsAllowed),
                                     SC3
                             end,
 
@@ -364,8 +363,11 @@ handle_packet(ClientPubKeyBin, Packet, HandlerPid,
     end.
 
 handle_offer(SCOffer, HandlerPid, #state{db=DB, dc_payload_size=DCPayloadSize, active_sc_ids=ActiveSCIDs,
-                                         state_channels=SCs, blooms=Blooms, owner={_Owner, OwnerSigFun},
+                                         state_channels=SCs, owner={_Owner, OwnerSigFun},
                                          max_actors_allowed=MaxActorsAllowed}=State0) ->
+    Hotspot = blockchain_state_channel_offer_v1:hotspot(SCOffer),
+    HotspotName = blockchain_utils:addr2name(Hotspot),
+    lager:debug("handling offer for ~p", [HotspotName]),
     PayloadSize = blockchain_state_channel_offer_v1:payload_size(SCOffer),
     case PayloadSize =< ?MAX_PAYLOAD_SIZE of
         false ->
@@ -374,7 +376,6 @@ handle_offer(SCOffer, HandlerPid, #state{db=DB, dc_payload_size=DCPayloadSize, a
             ok = send_rejection(HandlerPid),
             {noreply, State0};
         true ->
-            Hotspot = blockchain_state_channel_offer_v1:hotspot(SCOffer),
             case select_best_active_sc(Hotspot, State0) of
                 {error, _Reason} ->
                     lager:debug("could not get a good active SC (~p)", [_Reason]),
@@ -411,11 +412,10 @@ handle_offer(SCOffer, HandlerPid, #state{db=DB, dc_payload_size=DCPayloadSize, a
                             State1;
                         false ->
                             Routing = blockchain_state_channel_offer_v1:routing(SCOffer),
-                            lager:debug("routing: ~p, hotspot: ~p", [Routing, Hotspot]),
-                            {ClientBloom, _} = maps:get(ActiveSCID, Blooms),
+                            lager:debug("routing: ~p, hotspot: ~p", [Routing, HotspotName]),
                             case
                                 try_update_summary(ActiveSC, Hotspot, PayloadSize,
-                                                   DCPayloadSize, ClientBloom, MaxActorsAllowed)
+                                                   DCPayloadSize, MaxActorsAllowed)
                             of
                                 {error, _Reason} ->
                                     lager:warning("dropping this packet because: ~p ~p",
@@ -423,20 +423,25 @@ handle_offer(SCOffer, HandlerPid, #state{db=DB, dc_payload_size=DCPayloadSize, a
                                     ok = send_rejection(HandlerPid),
                                     State0;
                                 {ok, PurchaseSC} ->
+                                    lager:debug("purchasing offer from ~p", [HotspotName]),
                                     SignedPurchaseSC = blockchain_state_channel_v1:sign(PurchaseSC, OwnerSigFun),
                                     PacketHash = blockchain_state_channel_offer_v1:packet_hash(SCOffer),
                                     Region = blockchain_state_channel_offer_v1:region(SCOffer),
+                                    lager:debug("START send purchase ~p", [HotspotName]),
                                     ok = blockchain_state_channel_handler:send_purchase(HandlerPid,
                                                                                         SignedPurchaseSC,
                                                                                         Hotspot,
                                                                                         PacketHash,
                                                                                         Region),
+                                    lager:debug("END send purchase ~p", [HotspotName]),
                                     {_, Skewed} = maps:get(ActiveSCID, SCs),
                                     ok = blockchain_state_channel_v1:save(DB, SignedPurchaseSC, Skewed),
+                                    lager:debug("END save ~p", [HotspotName]),
                                     State1 =
                                         maybe_add_stream(Hotspot,
                                                          HandlerPid,
                                                          State0#state{state_channels=maps:put(ActiveSCID, {SignedPurchaseSC, Skewed}, SCs)}),
+                                    lager:debug("END maybe_add_stream ~p", [HotspotName]),
                                     State1
                             end
                             
@@ -475,8 +480,7 @@ update_state_sc_open(Txn,
                      #state{owner={Owner, OwnerSigFun},
                             state_channels=SCs,
                             active_sc_ids=ActiveSCIDs,
-                            blooms=Blooms,
-                            max_actors_allowed=MaxActorsAllowed}=State) ->
+                            blooms=Blooms}=State) ->
     case blockchain_txn_state_channel_open_v1:owner(Txn) of
         %% Do the map put when we are the owner of the state_channel
         Owner ->
@@ -491,7 +495,6 @@ update_state_sc_open(Txn,
 
             SignedSC = blockchain_state_channel_v1:sign(SC, OwnerSigFun),
 
-            {ok, ClientBloom} = bloom:new(?BITMAP_SIZE, MaxActorsAllowed),
             {ok, PacketBloom} = bloom:new(?BITMAP_SIZE, max(Amt, 1)),
 
             case ActiveSCIDs of
@@ -501,11 +504,11 @@ update_state_sc_open(Txn,
                     ok = maybe_broadcast_banner([SignedSC], State),
                     State#state{state_channels=maps:put(ID, {SignedSC, Skewed}, SCs),
                                 active_sc_ids=[ID],
-                                blooms=maps:put(ID, {ClientBloom, PacketBloom}, Blooms)};
+                                blooms=maps:put(ID, PacketBloom, Blooms)};
                 _ ->
                     lager:debug("already got ~p active", [[blockchain_utils:addr2name(I) || I <- ActiveSCIDs]]),
                     State#state{state_channels=maps:put(ID, {SignedSC, Skewed}, SCs),
-                                blooms=maps:put(ID, {ClientBloom, PacketBloom}, Blooms)}
+                                blooms=maps:put(ID, PacketBloom, Blooms)}
             end;
         _ ->
             %% Don't do anything cuz we're not the owner
@@ -866,13 +869,13 @@ maybe_get_new_active(WithoutSCIDs, #state{chain=Chain, sc_version=SCVersion, act
                          Hotspot :: libp2p_crypto:pubkey_bin(),
                          PayloadSize :: pos_integer(),
                          DCPayloadSize :: undefined | pos_integer(),
-                         ClientBloom :: bloom_nif:bloom(),
                          MaxActorsAllowed :: non_neg_integer()) ->
     {ok, blockchain_state_channel_v1:state_channel()} | {error, does_not_fit}.
-try_update_summary(SC, Hotspot, PayloadSize, DCPayloadSize, ClientBloom, MaxActorsAllowed) ->
+try_update_summary(SC, Hotspot, PayloadSize, DCPayloadSize, MaxActorsAllowed) ->
+    lager:debug("try_update_summary ~p", [blockchain_utils:addr2name(Hotspot)]),
     SCNonce = blockchain_state_channel_v1:nonce(SC),
     NewPurchaseSC0 = blockchain_state_channel_v1:nonce(SCNonce + 1, SC),
-    case update_sc_summary(Hotspot, PayloadSize, DCPayloadSize, NewPurchaseSC0, ClientBloom, MaxActorsAllowed) of
+    case update_sc_summary(Hotspot, PayloadSize, DCPayloadSize, NewPurchaseSC0, MaxActorsAllowed) of
         {NewPurchaseSC1, true} -> {ok, NewPurchaseSC1};
         {_SC, false} -> {error, does_not_fit}
     end.
@@ -901,10 +904,10 @@ send_rejection(Stream) ->
                         PayloadSize :: pos_integer(),
                         DCPayloadSize :: undefined | pos_integer(),
                         SC :: blockchain_state_channel_v1:state_channel(),
-                        ClientBloom :: bloom_nif:bloom(),
                         MaxActorsAllowed :: non_neg_integer()) ->
     {blockchain_state_channel_v1:state_channel(), boolean()}.
-update_sc_summary(ClientPubKeyBin, PayloadSize, DCPayloadSize, SC, ClientBloom, MaxActorsAllowed) ->
+update_sc_summary(ClientPubKeyBin, PayloadSize, DCPayloadSize, SC, MaxActorsAllowed) ->
+    lager:debug("update_sc_summary ~p", [blockchain_utils:addr2name(ClientPubKeyBin)]),
     case blockchain_state_channel_v1:get_summary(ClientPubKeyBin, SC) of
         {error, not_found} ->
             NumDCs = blockchain_utils:do_calculate_dc_amount(PayloadSize, DCPayloadSize),
@@ -913,11 +916,10 @@ update_sc_summary(ClientPubKeyBin, PayloadSize, DCPayloadSize, SC, ClientBloom, 
             {NewSC, DidFit} = blockchain_state_channel_v1:update_summary_for(ClientPubKeyBin,
                                                                              NewSummary,
                                                                              SC,
-                                                                             bloom:check(ClientBloom, ClientPubKeyBin),
                                                                              MaxActorsAllowed),
-            ok = maybe_set_client_bloom(ClientPubKeyBin, ClientBloom, DidFit),
             {NewSC, DidFit};
         {ok, ExistingSummary} ->
+            lager:debug("update_sc_summary ~p", [blockchain_utils:addr2name(ClientPubKeyBin)]),
             %% Update packet count for this client
             ExistingNumPackets = blockchain_state_channel_summary_v1:num_packets(ExistingSummary),
             %% Update DC count for this client
@@ -926,22 +928,16 @@ update_sc_summary(ClientPubKeyBin, PayloadSize, DCPayloadSize, SC, ClientBloom, 
             NewSummary = blockchain_state_channel_summary_v1:update(ExistingNumDCs + NumDCs,
                                                                     ExistingNumPackets + 1,
                                                                     ExistingSummary),
+            lager:debug("update_sc_summary ~p", [blockchain_utils:addr2name(ClientPubKeyBin)]),
             %% Update summaries
             {NewSC, DidFit} = blockchain_state_channel_v1:update_summary_for(ClientPubKeyBin,
                                                                              NewSummary,
                                                                              SC,
-                                                                             bloom:check(ClientBloom, ClientPubKeyBin),
                                                                              MaxActorsAllowed),
-            ok = maybe_set_client_bloom(ClientPubKeyBin, ClientBloom, DidFit),
+            lager:debug("update_sc_summary ~p", [blockchain_utils:addr2name(ClientPubKeyBin)]),
+            lager:debug("update_sc_summary ~p", [blockchain_utils:addr2name(ClientPubKeyBin)]),
             {NewSC, DidFit}
     end.
-
--spec maybe_set_client_bloom(ClientPubKeyBin :: libp2p_crypto:pubkey_bin(),
-                             ClientBloom :: bloom_nif:bloom(),
-                             DidFit :: boolean()) -> ok.
-maybe_set_client_bloom(_ClientPubKeyBin, _ClientBloom, false) -> ok;
-maybe_set_client_bloom(ClientPubKeyBin, ClientBloom, true) ->
-    bloom:set(ClientBloom, ClientPubKeyBin).
 
 -spec maybe_broadcast_banner(SC :: [blockchain_state_channel_v1:state_channel()],
                              State :: state()) -> ok.
@@ -988,11 +984,10 @@ send_banner(SC, Stream) ->
 -spec update_state_with_blooms(State :: state()) -> state().
 update_state_with_blooms(#state{state_channels=SCs}=State) when map_size(SCs) == 0 ->
     State;
-update_state_with_blooms(#state{state_channels=SCs, max_actors_allowed=MaxActorsAllowed}=State) ->
+update_state_with_blooms(#state{state_channels=SCs}=State) ->
     Blooms = maps:map(fun(_, {SC, _}) ->
-                              {ok, ClientBloom} = bloom:new(?BITMAP_SIZE, MaxActorsAllowed),
                               Amount = blockchain_state_channel_v1:amount(SC),
                               {ok, PacketBloom} = bloom:new(?BITMAP_SIZE, max(Amount, 1)),
-                              {ClientBloom, PacketBloom}
+                              PacketBloom
                       end, SCs),
     State#state{blooms=Blooms}.

--- a/src/state_channel/v1/blockchain_state_channel_v1.erl
+++ b/src/state_channel/v1/blockchain_state_channel_v1.erl
@@ -22,7 +22,7 @@
     signature/1, sign/2, validate/1, quick_validate/2,
     encode/1, decode/1,
     save/3, fetch/2,
-    summaries/1, summaries/2, update_summary_for/5,
+    summaries/1, summaries/2, update_summary_for/4,
 
     normalize/1,
 
@@ -126,14 +126,12 @@ summaries(Summaries, SC) ->
 -spec update_summary_for(ClientPubkeyBin :: libp2p_crypto:pubkey_bin(),
                          NewSummary :: blockchain_state_channel_summary_v1:summary(),
                          SC :: state_channel(),
-                         WillFit :: boolean(),
                          MaxActorsAllowed :: pos_integer()) -> {state_channel(), boolean()}.
 update_summary_for(ClientPubkeyBin,
                    NewSummary,
                    #blockchain_state_channel_v1_pb{summaries=Summaries}=SC,
-                   WillFit,
                    MaxActorsAllowed) ->
-    case WillFit orelse ?MODULE:can_fit(ClientPubkeyBin, SC, MaxActorsAllowed) of
+    case ?MODULE:can_fit(ClientPubkeyBin, SC, MaxActorsAllowed) of
         false ->
             %% Cannot fit this into summaries
             {SC, false};
@@ -488,14 +486,14 @@ merge(SCA, SCB, MaxActorsAllowed) ->
                             {error, not_found} ->
                                 {SC, _} =
                                     update_summary_for(blockchain_state_channel_summary_v1:client_pubkeybin(Summary),
-                                                       Summary, SCAcc, true, MaxActorsAllowed),
+                                                       Summary, SCAcc, MaxActorsAllowed),
                                 SC;
                             {ok, OurSummary} ->
                                 case blockchain_state_channel_summary_v1:num_dcs(OurSummary) < blockchain_state_channel_summary_v1:num_dcs(Summary) of
                                     true ->
                                         {SC, _} =
                                             update_summary_for(blockchain_state_channel_summary_v1:client_pubkeybin(Summary),
-                                                               Summary, SCAcc, true, MaxActorsAllowed),
+                                                               Summary, SCAcc, MaxActorsAllowed),
                                         SC;
                                     false ->
                                         SCAcc
@@ -647,7 +645,7 @@ update_summaries_test() ->
     io:format("Summaries1: ~p~n", [summaries(NewSC)]),
     ?assertEqual({ok, Summary}, get_summary(PubKeyBin, NewSC)),
     NewSummary = blockchain_state_channel_summary_v1:new(PubKeyBin, 1, 1),
-    {NewSC1, _} = blockchain_state_channel_v1:update_summary_for(PubKeyBin, NewSummary, NewSC, false, 2000),
+    {NewSC1, _} = blockchain_state_channel_v1:update_summary_for(PubKeyBin, NewSummary, NewSC, 2000),
     io:format("Summaries2: ~p~n", [summaries(NewSC1)]),
     ?assertEqual({ok, NewSummary}, get_summary(PubKeyBin, NewSC1)).
 

--- a/test/blockchain_bloom_SUITE.erl
+++ b/test/blockchain_bloom_SUITE.erl
@@ -1,0 +1,46 @@
+-module(blockchain_bloom_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-include("blockchain_vars.hrl").
+
+-export([
+    all/0
+]).
+
+-export([
+   bloom_test/1
+]).
+
+
+all() ->
+    [
+        bloom_test
+    ].
+
+%% Right now we put about 1100 actors per SC with the current 15000000 size it seems to be causing issues
+%% I have here an exemple of a better tailored bloom. If you repeat this test it will pass 99% of the time
+%% if you decide to increase m (Number of bits in the filter)  it will start having issue and taking too long
+%% https://hur.st/bloomfilter/?n=1100&p=1.0E-6&m=&k=20
+bloom_test(_Config) ->
+    Max = 1100,
+    {ok, ClientBloom} = bloom:new(31631, Max),
+    Runs = lists:foldl(
+        fun(I, Acc) ->
+            Key = crypto:strong_rand_bytes(32),
+            {Time1, _Result1} = timer:tc(bloom, check, [ClientBloom, Key]),
+            {Time2, _Result2} = timer:tc(bloom, set, [ClientBloom, Key]),
+            {Time3, _Result3} = timer:tc(bloom, check, [ClientBloom, Key]),
+            case Time1 > 10000 orelse Time2 > 10000 orelse Time3 > 10000 of
+                false -> Acc;
+                true -> [{I, Time1, Time2, Time3}|Acc]
+                
+            end
+        end,
+        [],
+        lists:seq(1, Max)
+    ),
+    ct:pal("~p", [Runs]),
+    ?assertEqual(0, erlang:length(Runs)),
+    ok.


### PR DESCRIPTION
I think I have identified why we see so many late packets it seems that the `ClientBloom` filter is miss configured.
I have a CT that can replicate potential issue. Not sure if this is just due to the algorithm or if the implementation is broken.

I went ahead and removed the client bloom anyway as it is mostly useless (I think, correct me if I am wrong). I seemed to be in place to avoid lookup but it is only a `maps:get` so it seems unnecessary.

I will try to test this asap on dev so I can confirm improvement. 