### PR TITLE
for ETL + rescue block error, avoid checking a particular block for rewards

### DIFF
--- a/src/transactions/v2/blockchain_txn_rewards_v2.erl
+++ b/src/transactions/v2/blockchain_txn_rewards_v2.erl
@@ -391,6 +391,8 @@ new_reward(Account, Amount) ->
                                Ledger :: blockchain_ledger_v1:ledger(),
                                Acc :: rewards_share_metadata() ) -> rewards_share_metadata().
 fold_blocks_for_rewards(Current, End, _Chain, _Vars, _Ledger, Acc) when Current == End + 1 -> Acc;
+fold_blocks_for_rewards(910360, End, Chain, Vars, Ledger, Acc) ->
+    fold_blocks_for_rewards(910361, End, Chain, Vars, Ledger, Acc);
 fold_blocks_for_rewards(Current, End, Chain, Vars, Ledger, Acc) ->
     case blockchain:get_block(Current, Chain) of
         {error, _Reason} = Error -> throw(Error);


### PR DESCRIPTION
see eventual writeup.