### PR TITLE
Trigger witness location nonces updates via ledger chainvar hooks

### DIFF
--- a/include/blockchain.hrl
+++ b/include/blockchain.hrl
@@ -27,6 +27,6 @@
 
 -define(BC_UPGRADE_NAMES, [<<"gateway_v2">>, <<"hex_targets">>, <<"gateway_oui">>,
                            <<"h3dex">>, <<"h3dex2">>,
-                           <<"gateway_lg3">>]).
+                           <<"gateway_lg3">>, <<"witness_last_location_nonce">>]).
 
 -define(bones(HNT), HNT * 100000000).

--- a/include/blockchain.hrl
+++ b/include/blockchain.hrl
@@ -27,6 +27,6 @@
 
 -define(BC_UPGRADE_NAMES, [<<"gateway_v2">>, <<"hex_targets">>, <<"gateway_oui">>,
                            <<"h3dex">>, <<"h3dex2">>,
-                           <<"gateway_lg3">>, <<"witness_last_location_nonce">>]).
+                           <<"gateway_lg3">>]).
 
 -define(bones(HNT), HNT * 100000000).

--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -467,3 +467,10 @@
 -define(penalty_history_limit, penalty_history_limit). % blocks
 -define(dkg_penalty, dkg_penalty). % float
 -define(tenure_penalty, tenure_penalty). % float
+
+
+%%%
+%%% ledger hook variables
+%%%
+-define(ledger_hook_trigger, ledger_hook_trigger). % chain var to trigger ledger hook function based on its presence and value setting in a txn
+

--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -63,7 +63,8 @@
 
     db_handle/1,
     blocks_cf/1,
-    heights_cf/1
+    heights_cf/1,
+    fix_witness_location_nonces/1
 
 ]).
 

--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -109,8 +109,7 @@
                           %% reinitializing it with a different name specified in the hrl
                           fun bootstrap_h3dex/1,
                           fun bootstrap_h3dex/1,
-                          fun upgrade_gateways_lg/1,
-                          fun fix_witness_location_nonces/1]).
+                          fun upgrade_gateways_lg/1]).
 
 -type blocks() :: #{blockchain_block:hash() => blockchain_block:block()}.
 -type blockchain() :: #blockchain{}.

--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -110,7 +110,7 @@
                           fun bootstrap_h3dex/1,
                           fun bootstrap_h3dex/1,
                           fun upgrade_gateways_lg/1,
-                          fun fix_witness_last_location_nonce/1]).
+                          fun fix_witness_location_nonces/1]).
 
 -type blocks() :: #{blockchain_block:hash() => blockchain_block:block()}.
 -type blockchain() :: #blockchain{}.
@@ -244,17 +244,12 @@ upgrade_gateways_lg(Ledger) ->
       whatever,
       Ledger).
 
-fix_witness_last_location_nonce(Ledger) ->
+fix_witness_location_nonces(Ledger) ->
     blockchain_ledger_v1:cf_fold(
       active_gateways,
       fun({Addr, BinGw}, _) ->
               Gw = blockchain_ledger_gateway_v2:deserialize(BinGw),
-              case blockchain_ledger_gateway_v2:fix_witness_last_location_nonce(Gw, Ledger) of
-                  not_changed ->
-                      ok;
-                  NewGw ->
-                      blockchain_ledger_v1:update_gateway(NewGw, Addr, Ledger)
-              end
+              blockchain_ledger_gateway_v2:fix_witness_location_nonces(Gw, Addr, Ledger)
       end,
       whatever,
       Ledger).
@@ -1894,7 +1889,7 @@ add_gateway_txn(OwnerB58, PayerB58, Fee, StakingFee) ->
 %% the gateway, and the given owner and payer
 %%
 %% NOTE: This is an alternative add_gateway creation that calculates the fee and
-%% staking fee from the current live blockchain. 
+%% staking fee from the current live blockchain.
 -spec add_gateway_txn(OwnerB58::string(),
                       PayerB58::string() | undefined) -> {ok, binary()}.
 add_gateway_txn(OwnerB58, PayerB58) ->

--- a/src/ledger/v1/blockchain_ledger_gateway_v2.erl
+++ b/src/ledger/v1/blockchain_ledger_gateway_v2.erl
@@ -769,9 +769,9 @@ fix_witness_last_location_nonce(GW = #gateway_v2{witnesses = Witnesses}, Ledger)
                                          0 ->
                                              %% default value, read actual nonce from ledger
                                              {ok, WitnessGW} = blockchain_ledger_v1:find_gateway_info(WitnessPubkeyBin, Ledger),
-                                             {true, [Witness#witness{added_location_nonce=WitnessGW#gateway_v2.last_location_nonce}|Acc]};
+                                             {true, [{WitnessPubkeyBin, Witness#witness{added_location_nonce=WitnessGW#gateway_v2.last_location_nonce}}|Acc]};
                                          _ ->
-                                             {HasChanged, [Witness|Acc]}
+                                             {HasChanged, [{WitnessPubkeyBin, Witness}|Acc]}
                                      end
                              end, {false, []}, Witnesses),
     case Updated of

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -1409,6 +1409,7 @@ vars(Vars, Unset, Ledger) ->
 set_aux_vars(AuxVars, #ledger_v1{mode=aux}=AuxLedger) ->
     Ctx = new_context(AuxLedger),
     ok = vars(AuxVars, [], Ctx),
+    ok = blockchain_txn_vars_v1:process_hooks(AuxVars, [], Ctx),
     ok = commit_context(Ctx),
     ok;
 set_aux_vars(_ExtraVars, _Ledger) ->

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1165,8 +1165,7 @@ validate_var(?data_aggregation_version, Value) ->
 
 %% ledger hook vars
 validate_var(?ledger_hook_trigger, Value) ->
-    validate_int(Value, "ledger_hook_trigger", 1, 65536, false);
-
+    validate_int(Value, "ledger_hook_trigger", 0, 65536, false);
 
 validate_var(?use_multi_keys, Value) ->
     case Value of
@@ -1358,6 +1357,7 @@ invalid_var(Var, Value) ->
 
 -spec process_hooks(Vars :: map(), Unsets :: list(), Ledger :: blockchain_ledger_v1:ledger()) -> ok.
 process_hooks(Vars, Unsets, Ledger) ->
+    lager:debug("process hooks with vars ~p", [Vars]),
     _ = maps:map(
           fun(Var, Value) ->
                   var_hook(Var, Value, Ledger)

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -37,7 +37,8 @@
          rescue_absorb/2,
          sign/2,
          print/1,
-         to_json/2
+         to_json/2,
+         process_hooks/3
         ]).
 
 %% helper API
@@ -1350,7 +1351,7 @@ invalid_var(Var, Value) ->
     throw({error, {unknown_var, Var, Value}}).
 -endif.
 
-
+-spec process_hooks(Vars :: map(), Unsets :: list(), Ledger :: blockchain_ledger_v1:ledger()) -> ok.
 process_hooks(Vars, Unsets, Ledger) ->
     _ = maps:map(
           fun(Var, Value) ->
@@ -1364,28 +1365,11 @@ process_hooks(Vars, Unsets, Ledger) ->
 
 %% separate out hook functions and call them in separate functions
 %% below the hook section.
-var_hook(?sweep_neighbors, true, Ledger) ->
-    neighbor_sweep(Ledger),
-    ok;
 var_hook(_Var, _Value, _Ledger) ->
     ok.
 
 unset_hook(_Var, _Ledger) ->
     ok.
-
-
-neighbor_sweep(Ledger) ->
-    case blockchain_ledger_v1:config(?poc_version, Ledger) of
-        {ok, V} when V > 3 ->
-            Gateways = blockchain_ledger_v1:active_gateways(Ledger),
-            %% find all neighbors for everyone
-            maps:map(
-              fun(A, G) ->
-                      G1 = blockchain_ledger_gateway_v2:neighbors([], G),
-                      blockchain_ledger_v1:update_gateway(G1, A, Ledger)
-              end, Gateways);
-        _ -> ok
-    end.
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1363,8 +1363,10 @@ process_hooks(Vars, Unsets, Ledger) ->
           end, Unsets),
     ok.
 
-%% separate out hook functions and call them in separate functions
-%% below the hook section.
+
+var_hook(?unknown_chain_var, 1, Ledger) ->
+    %% peg the updating of default witness location nonces to the XX chain var
+    blockchain:fix_witness_location_nonces(Ledger);
 var_hook(_Var, _Value, _Ledger) ->
     ok.
 

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -594,6 +594,7 @@ delayed_absorb(Txn, Ledger) ->
     Vars = decode_vars(vars(Txn)),
     Unsets = decode_unsets(unsets(Txn)),
     ok = blockchain_ledger_v1:vars(Vars, Unsets, Ledger),
+    ok = process_hooks(Vars, Unsets, Ledger),
     case blockchain:config(?use_multi_keys, Ledger) of
         {ok, true} ->
             case multi_keys(Txn) of
@@ -1348,6 +1349,43 @@ invalid_var(Var, Value) ->
 invalid_var(Var, Value) ->
     throw({error, {unknown_var, Var, Value}}).
 -endif.
+
+
+process_hooks(Vars, Unsets, Ledger) ->
+    _ = maps:map(
+          fun(Var, Value) ->
+                  var_hook(Var, Value, Ledger)
+          end, Vars),
+    _ = lists:foreach(
+          fun(Var) ->
+                  unset_hook(Var, Ledger)
+          end, Unsets),
+    ok.
+
+%% separate out hook functions and call them in separate functions
+%% below the hook section.
+var_hook(?sweep_neighbors, true, Ledger) ->
+    neighbor_sweep(Ledger),
+    ok;
+var_hook(_Var, _Value, _Ledger) ->
+    ok.
+
+unset_hook(_Var, _Ledger) ->
+    ok.
+
+
+neighbor_sweep(Ledger) ->
+    case blockchain_ledger_v1:config(?poc_version, Ledger) of
+        {ok, V} when V > 3 ->
+            Gateways = blockchain_ledger_v1:active_gateways(Ledger),
+            %% find all neighbors for everyone
+            maps:map(
+              fun(A, G) ->
+                      G1 = blockchain_ledger_gateway_v2:neighbors([], G),
+                      blockchain_ledger_v1:update_gateway(G1, A, Ledger)
+              end, Gateways);
+        _ -> ok
+    end.
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1163,6 +1163,11 @@ validate_var(?txn_fee_multiplier, Value) ->
 validate_var(?data_aggregation_version, Value) ->
     validate_int(Value, "data_aggregation_version", 1, 3, false);
 
+%% ledger hook vars
+validate_var(?ledger_hook_trigger, Value) ->
+    validate_int(Value, "ledger_hook_trigger", 1, 65536, false);
+
+
 validate_var(?use_multi_keys, Value) ->
     case Value of
         true -> ok;
@@ -1366,10 +1371,12 @@ process_hooks(Vars, Unsets, Ledger) ->
 %% TODO:  determine a chain var to peg these hooks to
 %% Option1: add a new dedicated chain var specific to hooks, increment its value with each newly added hook
 %% Option2: piggy back on some existing chain var
-%% Option3: ???
-%% Option1 would likely make most sense
-var_hook(?unknown_chain_var, 1, Ledger) ->
-    %% peg the updating of default witness location nonces to the XX chain var
+%% Option3: other ???
+%% Went with option 1 here....
+var_hook(?ledger_hook_trigger, 1, Ledger) ->
+    %% peg the updating of default witness location nonces to the ledger_hook_trigger
+    %% being present in current txn with a value of 1
+    %% TODO: need to consider the scenario of the chain var being present in later second txn with the same value ?
     blockchain:fix_witness_location_nonces(Ledger);
 var_hook(_Var, _Value, _Ledger) ->
     ok.

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1363,7 +1363,11 @@ process_hooks(Vars, Unsets, Ledger) ->
           end, Unsets),
     ok.
 
-
+%% TODO:  determine a chain var to peg these hooks to
+%% Option1: add a new dedicated chain var specific to hooks, increment its value with each newly added hook
+%% Option2: piggy back on some existing chain var
+%% Option3: ???
+%% Option1 would likely make most sense
 var_hook(?unknown_chain_var, 1, Ledger) ->
     %% peg the updating of default witness location nonces to the XX chain var
     blockchain:fix_witness_location_nonces(Ledger);


### PR DESCRIPTION
The current defaulting to a value of zero for witness related nonce vars ( WitnessGW#gateway_v2.last_location_nonce and Witness#witness.added_location_nonce )  makes it difficult to converge on agreement for a new snap as the application of the default value is non deterministic ( for example a witness GW could reassert its location at any time and that update may not be seen at the same time across the spots thus the spots vary in the value of these vars )

The fix here is to default the mentioned two witness vars to the current nonce value of the witness GW and  to do so at a consistent point in time.  This is achieved by linking the updating of the vars to a chain var with a specific value.  The provides the necessary determinism to ensure the spots all have a consistent view and thus thereafter be able to converge on a new snap.

This PR pulls in and amends the following two previous PRs:

https://github.com/helium/blockchain-core/pull/352
https://github.com/helium/blockchain-core/pull/896

TODO:
------
There are a couple of TODO's noted in the comments, which should be reviewed

