### PR TITLE
lazy snapshot field deserialization

### DIFF
--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -282,7 +282,7 @@ serialize(Snapshot, BlocksOrNoBlocks) ->
     Serialize(Snapshot, BlocksOrNoBlocks).
 
 -spec serialize_v6(snapshot_v6(), blocks | noblocks) -> iolist().
-serialize_v6(#{version := v6}=Snapshot, BlocksOrNoBlocks) ->
+serialize_v6(Snapshot, BlocksOrNoBlocks) when is_list(Snapshot) ->
     Key = blocks,
     Blocks =
         case BlocksOrNoBlocks of

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -1115,6 +1115,8 @@ deserialize_field(K, <<Bin/binary>>) ->
     end.
 
 -spec serialize_field(key(), term()) -> iolist().
+serialize_field(_K, V) when is_binary(V) ->
+    V;
 serialize_field(K, V) ->
     case is_raw_field(K) of
         true -> lists:map(fun bin_pair_to_iolist/1, V);

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -301,7 +301,7 @@ serialize_v6(Snapshot, BlocksOrNoBlocks) when is_list(Snapshot) ->
             noblocks ->
                 []
         end,
-    Pairs = lists:keysort(1, lists:keyreplace(Key, 1, Blocks, Snapshot)),
+    Pairs = lists:keysort(1, lists:keyreplace(Key, 1, Snapshot, {Key, Blocks})),
     frame(6, serialize_pairs(Pairs)).
 
 -spec serialize_v5(snapshot_v5(), noblocks) -> binary().

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -581,7 +581,8 @@ is_v6(_) -> false.
 get_h3dex(#{h3dex := H3Dex}) ->
     H3Dex.
 
-height(#{current_height := H}) ->
+height(L) ->
+    {_, H} = lists:keyfind(current_height, 1, L),
     H.
 
 -spec hash(snapshot_of_any_version()) -> binary().

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -287,17 +287,21 @@ serialize_v6(Snapshot, BlocksOrNoBlocks) when is_list(Snapshot) ->
     Blocks =
         case BlocksOrNoBlocks of
             blocks ->
-                    lists:map(
-                        fun (B) when is_tuple(B) ->
-                                blockchain_block:serialize(B);
-                            (B) -> B
-                        end,
-                        maps:get(Key, Snapshot, [])
-                    );
+                Bs = case lists:keyfind(Key, 1, Snapshot) of
+                         {_, Blks} -> Blks;
+                         _ -> []
+                     end,
+                lists:map(
+                  fun (B) when is_tuple(B) ->
+                          blockchain_block:serialize(B);
+                      (B) -> B
+                  end,
+                  Bs
+                 );
             noblocks ->
                 []
         end,
-    Pairs = lists:keysort(1, maps:to_list(maps:put(Key, Blocks, Snapshot))),
+    Pairs = lists:keysort(1, lists:keyreplace(Key, 1, Blocks, Snapshot)),
     frame(6, serialize_pairs(Pairs)).
 
 -spec serialize_v5(snapshot_v5(), noblocks) -> binary().

--- a/test/blockchain_snapshot_SUITE.erl
+++ b/test/blockchain_snapshot_SUITE.erl
@@ -109,7 +109,7 @@ basic_test(_Config) ->
 
     ?assertMatch(
         [_|_],
-        maps:get(upgrades, SnapshotA, undefined),
+        blockchain_ledger_snapshot_v1:deserialize_field(upgrades, maps:get(upgrades, SnapshotA, undefined)),
         "New snapshot (A) has \"upgrades\" field."
     ),
     SnapshotAIOList = blockchain_ledger_snapshot_v1:serialize(SnapshotA),
@@ -121,7 +121,7 @@ basic_test(_Config) ->
     {ok, SnapshotB} = blockchain_ledger_snapshot_v1:deserialize(SnapshotABin),
     ?assertMatch(
         [_|_],
-        maps:get(upgrades, SnapshotB, undefined),
+        blockchain_ledger_snapshot_v1:deserialize_field(upgrades, maps:get(upgrades, SnapshotB, undefined)),
         "Deserialized snapshot (B) has \"upgrades\" field."
     ),
     ?assertEqual(
@@ -138,7 +138,7 @@ basic_test(_Config) ->
     {ok, SnapshotC} = blockchain_ledger_snapshot_v1:snapshot(LedgerB, []),
     ?assertMatch(
         [_|_],
-        maps:get(upgrades, SnapshotC, undefined),
+        blockchain_ledger_snapshot_v1:deserialize_field(upgrades, maps:get(upgrades, SnapshotC, undefined)),
         "New snapshot (C) has \"upgrades\" field."
     ),
     ?assertEqual(
@@ -252,9 +252,6 @@ ledger() ->
 
     {ok, Snapshot} = blockchain_ledger_snapshot_v1:deserialize(BinSnap),
     SHA = blockchain_ledger_snapshot_v1:hash(Snapshot),
-
-    {ok, _GWCache} = blockchain_gateway_cache:start_link(),
-    {ok, _Pid} = blockchain_score_cache:start_link(),
 
     {ok, BinGen} = file:read_file("../../../../test/genesis"),
     GenesisBlock = blockchain_block:deserialize(BinGen),


### PR DESCRIPTION
I got this to the point where I could load a node that would sync using it, but I'm tapped out.

this attempts to use a lot less memory, or at least use it in a less all-at-once way, by leaving fields in binary format until the last moment before use.

This needs:
- better abstraction/cleanup, it was written in haste
- diff testing
- roundtrip testing (I suspect that the new_test is passing vacuously and the basic test seems broken)
- close review
