### PR TITLE
Add a no_staking_mapping test

### DIFF
--- a/src/transactions/v1/blockchain_txn_add_gateway_v1.erl
+++ b/src/transactions/v1/blockchain_txn_add_gateway_v1.erl
@@ -300,14 +300,14 @@ is_valid_payer(#blockchain_txn_add_gateway_v1_pb{payer=PubKeyBin,
 -spec is_valid_staking_key(txn_add_gateway(), blockchain_ledger_v1:ledger())-> boolean().
 is_valid_staking_key(#blockchain_txn_add_gateway_v1_pb{payer=Payer}=_Txn, Ledger) ->
     case blockchain_ledger_v1:staking_keys(Ledger) of
-        not_found -> 
+        not_found ->
             true; %% chain var not active, so default to true
-        Keys -> 
+        Keys ->
             case gateway_mode(Ledger, Payer) of
-                dataonly -> 
+                dataonly ->
                     %% dataonly gatewas are always allowed
                     true;
-                _ -> 
+                _ ->
                     %% All other modes require a staking key present
                     lists:member(Payer, Keys)
             end


### PR DESCRIPTION
Added a test which confirms that if the `staking_key_mode_to_mapping` var is not found on ledger, we fall back to the membership check (this is the current behavior on chain afaict). We should probably extend this test and add a var txn which does set the mapping var and checks that dataonly path is taken forward.