### PR TITLE
HIP-28 consensus reward calc grace period

### DIFF
--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -987,7 +987,7 @@ validate_var(?poc_reward_decay_rate, Value) ->
     validate_float(Value, "poc_reward_decay_rate", 0.0, 1.0);
 validate_var(?reward_version, Value) ->
     case Value of
-        N when is_integer(N), N >= 1,  N =< 5 ->
+        N when is_integer(N), N >= 1,  N =< 6 ->
             ok;
         _ ->
             throw({error, {invalid_reward_version, Value}})

--- a/src/transactions/v2/blockchain_txn_rewards_v2.erl
+++ b/src/transactions/v2/blockchain_txn_rewards_v2.erl
@@ -277,10 +277,18 @@ calculate_rewards_metadata(Start, End, Chain) ->
         Results0 = fold_blocks_for_rewards(Start, End, Chain,
                                           Vars, Ledger, AccInit),
 
-        %% Forcing calculation of the EpochReward amount for the CG to always
+        %% Prior to HIP 28 (reward_version <6), force EpochReward amount for the CG to always
         %% be around ElectionInterval (30 blocks) so that there is less incentive
-        %% to stay in the consensus group
-        ConsensusEpochReward = calculate_epoch_reward(1, Start, End, Ledger),
+        %% to stay in the consensus group. With HIP 28, relax that to be up to election_interval +
+        %% election_retry_interval to allow for time for election to complete.
+        ConsensusEpochReward = 
+            case maps:get(reward_version,Vars) of
+               RewardVersion when RewardVersion >= 6 ->
+                    calculate_consensus_epoch_reward(Start, End, Vars);
+                _ ->
+                    calculate_epoch_reward(1, Start, End, Ledger)
+            end,
+
         Vars1 = Vars#{ consensus_epoch_reward => ConsensusEpochReward },
 
         Results = finalize_reward_calculations(Results0, Ledger, Vars1),
@@ -667,6 +675,16 @@ calculate_epoch_reward(Version, Start, End, Ledger) ->
 
 -spec calculate_epoch_reward(pos_integer(), pos_integer(), pos_integer(),
                              pos_integer(), pos_integer(), pos_integer()) -> float().
+calculate_epoch_reward(Version, Start, End, BlockTime0, _ElectionInterval, MonthlyReward) when Version >= 6 ->
+    BlockTime1 = (BlockTime0/1000),
+    % Convert to blocks per min
+    BlockPerMin = 60/BlockTime1,
+    % Convert to blocks per hour
+    BlockPerHour = BlockPerMin*60,
+    % Calculate election interval in blocks
+    ElectionInterval = End - Start + 1, % epoch is inclusive of start and end
+    ElectionPerHour = BlockPerHour/ElectionInterval,
+    MonthlyReward/30/24/ElectionPerHour;
 calculate_epoch_reward(Version, Start, End, BlockTime0, _ElectionInterval, MonthlyReward) when Version >= 2 ->
     BlockTime1 = (BlockTime0/1000),
     % Convert to blocks per min
@@ -686,6 +704,24 @@ calculate_epoch_reward(_Version, _Start, _End, BlockTime0, ElectionInterval, Mon
     % Calculate number of elections per hour
     ElectionPerHour = BlockPerHour/ElectionInterval,
     MonthlyReward/30/24/ElectionPerHour.
+
+
+
+-spec calculate_consensus_epoch_reward(pos_integer(), pos_integer(), reward_vars()) -> float().
+calculate_consensus_epoch_reward(Start, End, #{ block_time := BlockTime0,
+                                                election_interval := ElectionInterval, 
+                                                election_restart_interval := ElectionRestartInterval, 
+                                                monthly_reward := MonthlyReward }) ->
+
+    BlockTime1 = (BlockTime0/1000),
+    % Convert to blocks per min
+    BlockPerMin = 60/BlockTime1,
+    % Convert to blocks per month
+    BlockPerMonth = BlockPerMin*60*24*30,
+    % Calculate epoch length in blocks, cap at election interval + grace period
+    EpochLength = erlang:min(End - Start + 1, ElectionInterval + ElectionRestartInterval),
+    MonthlyReward/BlockPerMonth*EpochLength.
+
 
 -spec consensus_members_rewards(blockchain_ledger_v1:ledger(),
                                 reward_vars(),
@@ -1818,5 +1854,24 @@ common_poc_vars() ->
         ?poc_v4_target_score_curve => 5,
         ?poc_v5_target_prob_randomness_wt => 0.0
     }.
+
+
+hip28_calc_test() ->
+    % set test vars such that rewards are 1 per block
+    Vars = #{ block_time => 60000, 
+              election_interval => 30, 
+              election_restart_interval => 5, 
+              monthly_reward => 43200,
+              reward_version => 6 },
+    ?assertEqual(30.0, calculate_consensus_epoch_reward(1,30,Vars)),
+    ?assertEqual(35.0, calculate_consensus_epoch_reward(1,50,Vars)).
+
+consensus_epoch_reward_test() ->
+    % using test values such that reward is 1 per block
+    % should always return the election interval as the answer
+    ?assertEqual(30.0,calculate_epoch_reward(1,1,25,60000,30,43200)),
+
+    % more than 30 blocks should return 30
+    ?assertEqual(30.0,calculate_epoch_reward(1,1,50,60000,30,43200)).
 
 -endif.


### PR DESCRIPTION
As described in [HIP-28](https://github.com/helium/HIP/blob/master/0028-consensus-reward-adjustments.md), this update adds a grace period in the consensus epoch reward calculation. Instead of always basing the calculation on election_interval number of block epochs, allow for up to election_interval + election_retry_interval blocks to be used in an epoch for calculating consensus rewards in order to provide time for the election itself. Change is protected behind reward_version chain var and is active when the value is >=6.

This PR does not address the other suggested changes in the HIP, specifically reallocating unearned consensus rewards to PoC as evanmcc and others have some alternative suggestions.

Lastly, this fixes the epoch reward calc for other reward types as well which was off by one block. Start and End are inclusive but epoch length was calculated as End - Start. Changed to End - Start + 1.

To-Do: add some test cases. I have verified it compiles and all existing EUnit tests execute successfully. However, I have not added any tests specific to the new code.