### PR TITLE
lists:filter/2 predicate needs a bool

### DIFF
--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -1181,7 +1181,7 @@ delete_dir(Filename) ->
                 {ok, F} -> F
             end,
 
-    do_clean_dir(Files, fun(X) -> X end).
+    do_clean_dir(Files, fun(_) -> true end).
 
 clean_dir(Dir) ->
     WeekOld = erlang:system_time(seconds) - ?WEEK_OLD_SECONDS,


### PR DESCRIPTION
Problem to solve: When attempting to clean a directory, the snapshot download code complains about a `case_clause` error in `lists:filter/2`. This is because `lists:filter/2` predicate function must return a boolean value.

Solution: Return a boolean value.