### PR TITLE
WIP: Force creation of hex densities memo table (stop-gap)

### DIFF
--- a/src/blockchain_hex.erl
+++ b/src/blockchain_hex.erl
@@ -184,7 +184,10 @@ calculate_scale(Location, VarMap, TargetRes, Ledger) ->
 densities(H3Index, VarMap, Ledger) ->
     case lookup(H3Index, ?DENSITY_MEMO_TBL) of
         {ok, Densities} -> Densities;
-        not_found -> memoize(?DENSITY_MEMO_TBL, H3Index,
+        not_found -> 
+            %% Make FOR SURE the table is created
+            _ = maybe_start(?DENSITY_MEMO_TBL),
+            memoize(?DENSITY_MEMO_TBL, H3Index,
                             calculate_densities(H3Index, VarMap, Ledger))
     end.
 


### PR DESCRIPTION
This is a stop gap I've identified for ensuring that `?DENSITY_MEMO_TBL` is actually present when calling `memoize`. There seems to be some race condition that catches so even though `lookup` should be creating the table, it's not present when memoize is actually called.

This probably isn't the best solution, but wanted to get some visibility for a proper fix.

Related to https://github.com/helium/blockchain-node/issues/38