### PR TITLE
Clean up scratch files when cleaning snap dir

### DIFF
--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -1188,11 +1188,15 @@ delete_dir(Filename) ->
 clean_dir(Dir) ->
     WeekOld = erlang:system_time(seconds) - ?WEEK_OLD_SECONDS,
     FilterFun = fun(F) ->
-                        case file:read_file_info(F, [raw, {time, posix}]) of
-                            {error, _} -> false;
-                            {ok, FI} ->
-                                FI#file_info.type == regular
-                                andalso FI#file_info.mtime =< WeekOld
+                        case filename:extension(F) of
+                            ".scratch" -> true;
+                            _ ->
+                                case file:read_file_info(F, [raw, {time, posix}]) of
+                                    {error, _} -> false;
+                                    {ok, FI} ->
+                                        FI#file_info.type == regular
+                                        andalso FI#file_info.mtime =< WeekOld
+                                end
                         end
                 end,
 


### PR DESCRIPTION
Problem to solve: Files are only removed from the snapshot directory when they're older than a week. That means largish scratch files can linger for a while and take up space.

Solution: Explicitly remove scratch files which may exist when we clean out the snapshot download folder.