### PR TITLE
Tests relocations (from miner) with new testing tools

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -1480,9 +1480,19 @@ check_recent_blocks(Blockchain) ->
             {error, {missing_block, DelayedLedgerHeight}}
     end.
 
+-type crosscheck_error()
+        :: {ledger_delayed_ledger_lag_too_large, non_neg_integer()}
+        |  {ledger_delayed_ledger_lag_too_small, non_neg_integer()}
+        |  {chain_ledger_height_mismatch, non_neg_integer(), non_neg_integer()}
+        |  {fingerprint_mismatch, [term()]}
+        |  {missing_block, non_neg_integer()}
+        .
+
+-spec crosscheck(blockchain()) -> ok | {error, crosscheck_error()}.
 crosscheck(Blockchain) ->
     crosscheck(Blockchain, true).
 
+-spec crosscheck(blockchain(), boolean()) -> ok | {error, crosscheck_error()}.
 crosscheck(Blockchain, Recalc) ->
     {ok, Height} = height(Blockchain),
     Ledger = ledger(Blockchain),
@@ -1569,6 +1579,7 @@ compare(LedgerA, LedgerB) ->
             ok
     end.
 
+-spec analyze(blockchain()) -> ok | {error, crosscheck_error()}.
 analyze(Blockchain) ->
   case crosscheck(Blockchain) of
       {error, {fingerprint_mismatch, Mismatches}} ->

--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -98,20 +98,21 @@ do_calculate_dc_amount(PayloadSize, DCPayloadSize)->
     end.
 
 %%--------------------------------------------------------------------
-%% @doc Shuffle a list deterministically using a random binary as the seed.
+%% @doc Shuffle a list deterministically, given a binary seed.
 %% @end
 %%--------------------------------------------------------------------
 -spec shuffle_from_hash(binary(), list()) -> list().
 shuffle_from_hash(Hash, L) ->
     ?MODULE:rand_from_hash(Hash),
-    [X ||{_, X} <- lists:sort([{rand:uniform(), E} || E <- L])].
+    shuffle(L).
 
 %%--------------------------------------------------------------------
 %% @doc Shuffle a list randomly.
 %% @end
 %%--------------------------------------------------------------------
-shuffle(List) ->
-    [X || {_,X} <- lists:sort([{rand:uniform(), N} || N <- List])].
+-spec shuffle([A]) -> [A].
+shuffle(Xs) ->
+    [X || {_, X} <- lists:sort([{rand:uniform(), X} || X <- Xs])].
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -19,6 +19,7 @@
     num_consensus_members/0,
     consensus_addrs/0,
     integrate_genesis_block/1,
+    integrate_genesis_block_synchronously/1,
     submit_txn/1, submit_txn/2,
     peer_height/3,
     notify/1,
@@ -204,6 +205,12 @@ is_resyncing() ->
 integrate_genesis_block(Block) ->
     gen_server:cast(?SERVER, {integrate_genesis_block, Block}).
 
+-spec integrate_genesis_block_synchronously(blockchain_block:block()) ->
+    ok | {error, block_not_genesis}. % TODO Other errors?
+integrate_genesis_block_synchronously(Block) ->
+    Msg = {integrate_genesis_block_synchronously, Block},
+    gen_server:call(?SERVER, Msg, infinity).
+
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -345,9 +352,14 @@ init(Args) ->
     {ok, #state{swarm = Swarm, swarm_tid = SwarmTID, blockchain = Blockchain,
                 gossip_ref = Ref, mode = Mode, snapshot_info = Info}}.
 
-handle_call(_, _From, #state{blockchain={no_genesis, _}}=State) ->
+handle_call({integrate_genesis_block_synchronously, GenesisBlock}, _From, #state{}=S0) ->
+    {Result, S1} = integrate_genesis_block_(GenesisBlock, S0),
+    {reply, Result, S1};
+handle_call(Msg, _From, #state{blockchain={no_genesis, _}}=State) ->
+    lager:warning("Called when blockchain={no_genesis_}. Returning undefined. Msg: ~p", [Msg]),
     {reply, undefined, State};
-handle_call(_, _From, #state{blockchain=undefined}=State) ->
+handle_call(Msg, _From, #state{blockchain=undefined}=State) ->
+    lager:warning("Called when blockchain=undefined. Returning undefined. Msg: ~p", [Msg]),
     {reply, undefined, State};
 handle_call(num_consensus_members, _From, #state{blockchain = Chain} = State) ->
     {ok, N} = blockchain:config(?num_consensus_members, blockchain:ledger(Chain)),
@@ -491,26 +503,9 @@ handle_cast({load, BaseDir, GenDir}, #state{blockchain=undefined}=State) ->
     {Mode, Info} = get_sync_mode(Blockchain),
     notify({new_chain, Blockchain}),
     {noreply, State#state{blockchain = Blockchain, gossip_ref = Ref, mode=Mode, snapshot_info=Info}};
-handle_cast({integrate_genesis_block, GenesisBlock}, #state{blockchain={no_genesis, Blockchain},
-                                                            swarm_tid=SwarmTid}=State) ->
-    case blockchain_block:is_genesis(GenesisBlock) of
-        false ->
-            lager:warning("~p is not a genesis block", [GenesisBlock]),
-            {noreply, State};
-        true ->
-            ok = blockchain:integrate_genesis(GenesisBlock, Blockchain),
-            [ConsensusAddrs] = [blockchain_txn_consensus_group_v1:members(T)
-                                || T <- blockchain_block:transactions(GenesisBlock),
-                                   blockchain_txn:type(T) == blockchain_txn_consensus_group_v1],
-            lager:info("blockchain started with ~p, consensus ~p", [lager:pr(Blockchain, blockchain), ConsensusAddrs]),
-            {ok, GenesisHash} = blockchain:genesis_hash(Blockchain),
-            ok = notify({integrate_genesis_block, GenesisHash}),
-            {ok, GossipRef} = add_handlers(SwarmTid, Blockchain),
-            ok = blockchain_txn_mgr:set_chain(Blockchain),
-            true = libp2p_swarm:network_id(SwarmTid, GenesisHash),
-            self() ! maybe_sync,
-            {noreply, State#state{blockchain=Blockchain, gossip_ref = GossipRef}}
-    end;
+handle_cast({integrate_genesis_block, GenesisBlock}, #state{}=S0) ->
+    {_, S1} = integrate_genesis_block_(GenesisBlock, S0),
+    {noreply, S1};
 handle_cast(_, #state{blockchain=undefined}=State) ->
     {noreply, State};
 handle_cast(_, #state{blockchain={no_genesis, _}}=State) ->
@@ -673,6 +668,46 @@ terminate(_Reason, #state{blockchain=Chain}) ->
 %% ------------------------------------------------------------------
 %% Internal Function Definitions
 %% ------------------------------------------------------------------
+
+integrate_genesis_block_(
+    GenesisBlock,
+    #state{
+        blockchain = {no_genesis, Chain},
+        swarm_tid  = SwarmTid
+    }=S0
+) ->
+    case blockchain_block:is_genesis(GenesisBlock) of
+        false ->
+            lager:warning("~p is not a genesis block", [GenesisBlock]),
+            {{error, block_not_genesis}, S0};
+        true ->
+            ok = blockchain:integrate_genesis(GenesisBlock, Chain),
+            [ConsensusAddrs] =
+                [
+                    blockchain_txn_consensus_group_v1:members(T)
+                ||
+                    T <- blockchain_block:transactions(GenesisBlock),
+                    blockchain_txn:type(T) == blockchain_txn_consensus_group_v1
+                ],
+            lager:info(
+                "blockchain started with ~p, consensus ~p",
+                [lager:pr(Chain, blockchain), ConsensusAddrs]
+            ),
+            {ok, GenesisHash} = blockchain:genesis_hash(Chain),
+            ok = notify({integrate_genesis_block, GenesisHash}),
+            {ok, GossipRef} = add_handlers(SwarmTid, Chain),
+            ok = blockchain_txn_mgr:set_chain(Chain),
+            true = libp2p_swarm:network_id(SwarmTid, GenesisHash),
+            self() ! maybe_sync,
+            S1 =
+                S0#state{
+                    blockchain = Chain,
+                    gossip_ref = GossipRef
+                },
+            {ok, S1}
+    end;
+integrate_genesis_block_(_, #state{}=State0) ->
+    {{error, not_in_no_genesis_state}, State0}.
 
 maybe_sync(#state{mode = normal} = State) ->
     maybe_sync_blocks(State);

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -1410,6 +1410,7 @@ multi_keys(NewKeys, Ledger) ->
     DefaultCF = default_cf(Ledger),
     cache_put(Ledger, DefaultCF, ?MULTI_KEYS, blockchain_utils:keys_list_to_bin(NewKeys)).
 
+-spec vars(#{Key => term()}, [Key], ledger()) -> ok.
 vars(Vars, Unset, Ledger) ->
     DefaultCF = default_cf(Ledger),
     maps:map(
@@ -1433,6 +1434,7 @@ set_aux_vars(AuxVars, #ledger_v1{mode=aux}=AuxLedger) ->
 set_aux_vars(_ExtraVars, _Ledger) ->
     error(cannot_set_vars_not_aux_ledger).
 
+-spec config(term(), ledger()) -> {ok, term()} | {error, term()}.
 config(ConfigName, Ledger) ->
     DefaultCF = default_cf(Ledger),
     case cache_get(Ledger, DefaultCF, var_name(ConfigName), []) of

--- a/test/blockchain_ct_utils.erl
+++ b/test/blockchain_ct_utils.erl
@@ -167,10 +167,7 @@ get_config(Arg, Default) ->
     end.
 
 random_n(N, List) ->
-    lists:sublist(shuffle(List), N).
-
-shuffle(List) ->
-    [x || {_,x} <- lists:sort([{rand:uniform(), N} || N <- List])].
+    lists:sublist(blockchain_utils:shuffle(List), N).
 
 init_per_suite(Config) ->
     application:ensure_all_started(ranch),

--- a/test/blockchain_payment_v2_SUITE.erl
+++ b/test/blockchain_payment_v2_SUITE.erl
@@ -113,9 +113,7 @@ end_per_testcase(_, Config) ->
 %%--------------------------------------------------------------------
 
 multisig_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     Amount = 10,
@@ -155,10 +153,8 @@ multisig_test(Config) ->
     ).
 
 single_payee_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
     Balance = ?config(balance, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     %% Test a payment transaction, add a block and check balances
@@ -194,10 +190,8 @@ single_payee_test(Config) ->
     ok.
 
 same_payees_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
     _Balance = ?config(balance, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
     _Swarm = ?config(swarm, Config),
 
@@ -219,10 +213,8 @@ same_payees_test(Config) ->
     ok.
 
 different_payees_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
     Balance = ?config(balance, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     %% Test a payment transaction, add a block and check balances
@@ -265,9 +257,7 @@ different_payees_test(Config) ->
     ok.
 
 empty_payees_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     %% Test a payment transaction, add a block and check balances
@@ -283,9 +273,7 @@ empty_payees_test(Config) ->
     ok.
 
 self_payment_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     %% Test a payment transaction, add a block and check balances
@@ -307,9 +295,7 @@ self_payment_test(Config) ->
     ok.
 
 max_payments_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
@@ -334,10 +320,8 @@ max_payments_test(Config) ->
     ok.
 
 signature_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
     _Balance = ?config(balance, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
     _Swarm = ?config(swarm, Config),
 
@@ -361,9 +345,7 @@ signature_test(Config) ->
     ok.
 
 zero_amount_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     %% Test a payment transaction, add a block and check balances
@@ -382,9 +364,7 @@ zero_amount_test(Config) ->
     ok.
 
 negative_amount_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     %% Test a payment transaction, add a block and check balances
@@ -403,10 +383,8 @@ negative_amount_test(Config) ->
     ok.
 
 valid_memo_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
     Balance = ?config(balance, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     %% Test a payment transaction, add a block and check balances
@@ -448,9 +426,7 @@ valid_memo_test(Config) ->
     ok.
 
 negative_memo_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     %% Test a payment transaction, add a block and check balances
@@ -471,9 +447,7 @@ negative_memo_test(Config) ->
     ok.
 
 valid_memo_not_set_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
-    BaseDir = ?config(base_dir, Config),
     Balance = ?config(balance, Config),
     Chain = ?config(chain, Config),
 
@@ -517,9 +491,7 @@ valid_memo_not_set_test(Config) ->
     ok.
 
 invalid_memo_not_set_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     %% Test a payment transaction, add a block and check balances
@@ -540,9 +512,7 @@ invalid_memo_not_set_test(Config) ->
     ok.
 
 big_memo_valid_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
-    BaseDir = ?config(base_dir, Config),
     Balance = ?config(balance, Config),
     Chain = ?config(chain, Config),
 
@@ -577,9 +547,7 @@ big_memo_valid_test(Config) ->
     ok.
 
 big_memo_invalid_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     %% Test a payment transaction, add a block and check balances

--- a/test/blockchain_simple_SUITE.erl
+++ b/test/blockchain_simple_SUITE.erl
@@ -206,10 +206,8 @@ end_per_testcase(_, Config) ->
 %%--------------------------------------------------------------------
 
 basic_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
     Balance = ?config(balance, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     % Test a payment transaction, add a block and check balances
@@ -366,11 +364,8 @@ restart_test(Config) ->
 
 
 htlc_payee_redeem_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
-
     ConsensusMembers = ?config(consensus_members, Config),
     Balance = ?config(balance, Config),
-    BaseDir = ?config(base_dir, Config),
     PubKey = ?config(pubkey, Config),
     PrivKey = ?config(privkey, Config),
     Chain = ?config(chain, Config),
@@ -443,11 +438,8 @@ htlc_payee_redeem_test(Config) ->
     ok.
 
 htlc_payer_redeem_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
-
     ConsensusMembers = ?config(consensus_members, Config),
     Balance = ?config(balance, Config),
-    BaseDir = ?config(base_dir, Config),
     PubKey = ?config(pubkey, Config),
     PrivKey = ?config(privkey, Config),
     Chain = ?config(chain, Config),
@@ -867,10 +859,7 @@ export_test(Config) ->
 
 
 delayed_ledger_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
-
     ConsensusMembers = ?config(consensus_members, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
     Balance = ?config(balance, Config),
 
@@ -948,10 +937,7 @@ delayed_ledger_test(Config) ->
     ok.
 
 fees_since_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
-
     ConsensusMembers = ?config(consensus_members, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
@@ -989,11 +975,8 @@ fees_since_test(Config) ->
     meck:unload(blockchain_txn_payment_v1).
 
 security_token_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
-
     ConsensusMembers = ?config(consensus_members, Config),
     Balance = ?config(balance, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     % Test a payment transaction, add a block and check balances
@@ -1020,10 +1003,7 @@ security_token_test(Config) ->
     ok.
 
 routing_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
-
     ConsensusMembers = ?config(consensus_members, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
     Swarm = ?config(swarm, Config),
     Ledger = blockchain:ledger(Chain),
@@ -1214,10 +1194,7 @@ routing_test(Config) ->
     ok.
 
 max_subnet_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
-
     ConsensusMembers = ?config(consensus_members, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
     Swarm = ?config(swarm, Config),
     Ledger = blockchain:ledger(Chain),
@@ -1281,11 +1258,8 @@ max_subnet_test(Config) ->
     ok.
 
 block_save_failed_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
-
     ConsensusMembers = ?config(consensus_members, Config),
     Balance = ?config(balance, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     % Test a payment transaction, add a block and check balances
@@ -1321,10 +1295,8 @@ block_save_failed_test(Config) ->
     ok.
 
 absorb_failed_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
     Balance = ?config(balance, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     % Test a payment transaction, add a block and check balances
@@ -1375,10 +1347,8 @@ absorb_failed_test(Config) ->
     ok.
 
 missing_last_block_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
     Balance = ?config(balance, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     % Test a payment transaction, add a block and check balances
@@ -1431,10 +1401,7 @@ missing_last_block_test(Config) ->
     ok.
 
 epoch_reward_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
-
     ConsensusMembers = ?config(consensus_members, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     [_, {PubKeyBin, {_, _PrivKey, _}}|_] = ConsensusMembers,
@@ -1490,11 +1457,8 @@ epoch_reward_test(Config) ->
     meck:unload(blockchain_txn_consensus_group_v1).
 
 election_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
-
     %% ConsensusMembers = ?config(consensus_members, Config),
     GenesisMembers = ?config(genesis_members, Config),
-    BaseDir = ?config(base_dir, Config),
     %% Chain = ?config(chain, Config),
     Chain = blockchain_worker:blockchain(),
     _Swarm = ?config(swarm, Config),
@@ -1553,11 +1517,8 @@ election_test(Config) ->
     ok.
 
 election_v3_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
-
     ConsensusMembers = ?config(consensus_members, Config),
     GenesisMembers = ?config(genesis_members, Config),
-    BaseDir = ?config(base_dir, Config),
     %% Chain = ?config(chain, Config),
     Chain = blockchain_worker:blockchain(),
     N = 7,
@@ -1690,11 +1651,8 @@ election_v3_test(Config) ->
     ok.
 
 election_v4_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
-
     ConsensusMembers = ?config(consensus_members, Config),
     GenesisMembers = ?config(genesis_members, Config),
-    BaseDir = ?config(base_dir, Config),
     %% Chain = ?config(chain, Config),
     Chain = blockchain_worker:blockchain(),
     N = 7,
@@ -1834,11 +1792,8 @@ light_gw_election_v4_test(Config) ->
     %% all the GWs are updated to be light mode
     %% this means they should be exlcuded from becoming part of the new group
     %% as the test updates all the GWs the new group ends up being same as the old group
-    BaseDir = ?config(base_dir, Config),
-
     ConsensusMembers = ?config(consensus_members, Config),
     GenesisMembers = ?config(genesis_members, Config),
-    BaseDir = ?config(base_dir, Config),
     %% Chain = ?config(chain, Config),
     Chain = blockchain_worker:blockchain(),
     N = 7,
@@ -1942,11 +1897,8 @@ dataonly_gw_election_v4_test(Config) ->
     %% all the GWs are updated to be dataonly mode
     %% this means they should be excluded from becoming part of the new group
     %% as the test updates all the GWs the new group ends up being same as the old group
-    BaseDir = ?config(base_dir, Config),
-
     ConsensusMembers = ?config(consensus_members, Config),
     GenesisMembers = ?config(genesis_members, Config),
-    BaseDir = ?config(base_dir, Config),
     %% Chain = ?config(chain, Config),
     Chain = blockchain_worker:blockchain(),
     N = 7,
@@ -2046,11 +1998,8 @@ dataonly_gw_election_v4_test(Config) ->
     ok.
 
 election_v5_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
-
     ConsensusMembers = ?config(consensus_members, Config),
     %% GenesisMembers = ?config(genesis_members, Config),
-    BaseDir = ?config(base_dir, Config),
     %% Chain = ?config(chain, Config),
     Chain = blockchain_worker:blockchain(),
     N = 7,
@@ -2269,11 +2218,8 @@ chain_vars_set_unset_test(Config) ->
     ok.
 
 token_burn_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
-
     ConsensusMembers = ?config(consensus_members, Config),
     Balance = ?config(balance, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
@@ -2361,11 +2307,8 @@ token_burn_test(Config) ->
     ok.
 
 payer_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
-
     ConsensusMembers = ?config(consensus_members, Config),
     Balance = ?config(balance, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
     Swarm = ?config(swarm, Config),
 
@@ -2607,9 +2550,7 @@ poc_sync_interval_test(Config) ->
     ok.
 
 zero_payment_v1_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     % Test a payment transaction, add a block and check balances
@@ -2626,9 +2567,7 @@ zero_payment_v1_test(Config) ->
     ok.
 
 negative_payment_v1_test(Config) ->
-    BaseDir = ?config(base_dir, Config),
     ConsensusMembers = ?config(consensus_members, Config),
-    BaseDir = ?config(base_dir, Config),
     Chain = ?config(chain, Config),
 
     % Test a payment transaction, add a block and check balances

--- a/test/blockchain_txn_bundle_SUITE.erl
+++ b/test/blockchain_txn_bundle_SUITE.erl
@@ -1,0 +1,488 @@
+-module(blockchain_txn_bundle_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kernel/include/inet.hrl").
+-include_lib("blockchain/include/blockchain_vars.hrl").
+
+-export([
+    init_per_testcase/2,
+    end_per_testcase/2,
+    all/0
+]).
+
+-export([
+    basic_test/1,
+    negative_test/1,
+    double_spend_test/1,
+    successive_test/1,
+    invalid_successive_test/1,
+    single_payer_test/1,
+    single_payer_invalid_test/1,
+    full_circle_test/1,
+    add_assert_test/1,
+    invalid_add_assert_test/1,
+    single_txn_bundle_test/1,
+    bundleception_test/1
+]).
+
+%% Setup ----------------------------------------------------------------------
+
+all() ->
+    [
+        basic_test,
+        negative_test,
+        double_spend_test,
+        successive_test,
+        invalid_successive_test,
+        single_payer_test,
+        single_payer_invalid_test,
+        full_circle_test,
+        add_assert_test,
+        invalid_add_assert_test,
+        single_txn_bundle_test,
+        bundleception_test
+    ].
+
+init_per_testcase(_TestCase, Cfg) ->
+    Cfg.
+
+end_per_testcase(_TestCase, _Cfg) ->
+    t_chain:stop().
+
+%% Cases ----------------------------------------------------------------------
+
+basic_test(Cfg0) ->
+    Src = t_user:new(),
+    SrcBalance0 = 5000,
+    Dst = t_user:new(),
+    DstBalance0 = 0,
+
+    Cfg = t_chain:start(Cfg0, #{users_with_hnt => [{Src, SrcBalance0}]}),
+
+    ConsensusGroup = ?config(users_in_consensus, Cfg),
+    Chain = ?config(chain, Cfg),
+
+    AmountPerTxn = 1000,
+    Txns =
+        [
+            t_txn:pay(Src, Dst, AmountPerTxn, 1),
+            t_txn:pay(Src, Dst, AmountPerTxn, 2)
+        ],
+    TxnBundle = blockchain_txn_bundle_v1:new(Txns),
+    ?assertMatch(ok, t_chain:commit(Chain, ConsensusGroup, [TxnBundle])),
+
+    AmountTotal = length(Txns) * AmountPerTxn,
+    ?assertEqual(SrcBalance0 - AmountTotal, t_chain:get_balance(Chain, Src)),
+    ?assertEqual(DstBalance0 + AmountTotal, t_chain:get_balance(Chain, Dst)),
+
+    ok.
+
+negative_test(Cfg0) ->
+    Src = t_user:new(),
+    SrcBalance0 = 5000,
+    Dst = t_user:new(),
+    DstBalance0 = 0,
+
+    Cfg = t_chain:start(Cfg0, #{users_with_hnt => [{Src, SrcBalance0}]}),
+
+    ConsensusGroup = ?config(users_in_consensus, Cfg),
+    Chain = ?config(chain, Cfg),
+
+    AmountPerTxn = 1000,
+    Txns =
+        %% Reversed order of nonces, invalidating the bundle:
+        [
+            t_txn:pay(Src, Dst, AmountPerTxn, 2),
+            t_txn:pay(Src, Dst, AmountPerTxn, 1)
+        ],
+    TxnBundle = blockchain_txn_bundle_v1:new(Txns),
+
+    ?assertMatch(
+        {error, {invalid_txns, [{_, invalid_bundled_txns}]}},
+        t_chain:commit(Chain, ConsensusGroup, [TxnBundle])
+    ),
+
+    %% Balances should not have changed since the bundle was invalid:
+    ?assertEqual(SrcBalance0, t_chain:get_balance(Chain, Src)),
+    ?assertEqual(DstBalance0, t_chain:get_balance(Chain, Dst)),
+
+    ok.
+
+double_spend_test(Cfg0) ->
+    Src = t_user:new(),
+    SrcBalance0 = 5000,
+    SrcNonce = 1,
+    Dst1 = t_user:new(),
+    Dst2 = t_user:new(),
+    Dst1Balance0 = 0,
+    Dst2Balance0 = 0,
+
+    Cfg = t_chain:start(Cfg0, #{users_with_hnt => [{Src, SrcBalance0}]}),
+
+    ConsensusGroup = ?config(users_in_consensus, Cfg),
+    Chain = ?config(chain, Cfg),
+
+    AmountPerTxn = 1000,
+    Txns =
+        [
+            %% good txn: first spend
+            t_txn:pay(Src, Dst1, AmountPerTxn, SrcNonce),
+
+            %% bad txn: double-spend = same nonce, diff dst
+            t_txn:pay(Src, Dst2, AmountPerTxn, SrcNonce)
+        ],
+    TxnBundle = blockchain_txn_bundle_v1:new(Txns),
+
+    ?assertMatch(
+        {error, {invalid_txns, [{_, invalid_bundled_txns}]}},
+        t_chain:commit(Chain, ConsensusGroup, [TxnBundle])
+    ),
+
+    %% All balances remain, since all txns were rejected, not just the bad one.
+    ?assertEqual(SrcBalance0 , t_chain:get_balance(Chain, Src)),
+    ?assertEqual(Dst1Balance0, t_chain:get_balance(Chain, Dst1)),
+    ?assertEqual(Dst2Balance0, t_chain:get_balance(Chain, Dst2)),
+
+    ok.
+
+successive_test(Cfg0) ->
+    %% Test a successive valid bundle payment
+    %% A -> B
+    %% B -> C
+    A = t_user:new(),
+    B = t_user:new(),
+    C = t_user:new(),
+    A_Balance0 = 5000,
+    B_Balance0 = 0,
+    C_Balance0 = 0,
+
+    %% All funds will originate from A, so only it needs a starting balance.
+    Cfg = t_chain:start(Cfg0, #{users_with_hnt => [{A, A_Balance0}]}),
+
+    ConsensusGroup = ?config(users_in_consensus, Cfg),
+    Chain = ?config(chain, Cfg),
+
+    AmountAToB = A_Balance0,
+    AmountBToC = AmountAToB - 1,
+    Txns =
+        [
+            t_txn:pay(A, B, AmountAToB, 1),
+            t_txn:pay(B, C, AmountBToC, 1)
+        ],
+    TxnBundle = blockchain_txn_bundle_v1:new(Txns),
+
+    ?assertMatch(ok, t_chain:commit(Chain, ConsensusGroup, [TxnBundle])),
+    ?assertEqual(A_Balance0 - AmountAToB             , t_chain:get_balance(Chain, A)),
+    ?assertEqual(B_Balance0 + AmountAToB - AmountBToC, t_chain:get_balance(Chain, B)),
+    ?assertEqual(C_Balance0 + AmountBToC             , t_chain:get_balance(Chain, C)),
+
+    ok.
+
+invalid_successive_test(Cfg0) ->
+    %% Test a successive invalid bundle payment
+    %% A -> B
+    %% B -> C <-- this is invalid
+    A = t_user:new(),
+    B = t_user:new(),
+    C = t_user:new(),
+    A_Balance0 = 5000,
+    B_Balance0 = 0,
+    C_Balance0 = 0,
+
+    %% All funds will originate from A, so only it needs a starting balance.
+    Cfg = t_chain:start(Cfg0, #{users_with_hnt => [{A, A_Balance0}]}),
+
+    ConsensusGroup = ?config(users_in_consensus, Cfg),
+    Chain = ?config(chain, Cfg),
+
+    AmountAToB = A_Balance0,
+    AmountBToC = B_Balance0 + AmountAToB + 1,  % overdraw attempt
+    Txns =
+        [
+            t_txn:pay(A, B, AmountAToB, 1),
+            t_txn:pay(B, C, AmountBToC, 1)
+        ],
+    TxnBundle = blockchain_txn_bundle_v1:new(Txns),
+
+    ?assertMatch(
+        {error, {invalid_txns, [{_, invalid_bundled_txns}]}},
+        t_chain:commit(Chain, ConsensusGroup, [TxnBundle])
+    ),
+    ?assertEqual(A_Balance0, t_chain:get_balance(Chain, A)),
+    ?assertEqual(B_Balance0, t_chain:get_balance(Chain, B)),
+    ?assertEqual(C_Balance0, t_chain:get_balance(Chain, C)),
+
+    ok.
+
+single_payer_test(Cfg0) ->
+    %% Test a bundled payment from single payer
+    %% A -> B
+    %% A -> C
+    A = t_user:new(),
+    B = t_user:new(),
+    C = t_user:new(),
+    A_Balance0 = 5000,
+    B_Balance0 = 0,
+    C_Balance0 = 0,
+
+    %% All funds will originate from A, so only it needs a starting balance.
+    Cfg = t_chain:start(Cfg0, #{users_with_hnt => [{A, A_Balance0}]}),
+
+    ConsensusGroup = ?config(users_in_consensus, Cfg),
+    Chain = ?config(chain, Cfg),
+
+    AmountAToB = 2000,
+    AmountAToC = 3000,
+    Txns =
+        [
+            t_txn:pay(A, B, AmountAToB, 1),
+            t_txn:pay(A, C, AmountAToC, 2)
+        ],
+    TxnBundle = blockchain_txn_bundle_v1:new(Txns),
+
+    ?assertMatch(ok, t_chain:commit(Chain, ConsensusGroup, [TxnBundle])),
+    ?assertEqual(A_Balance0 - AmountAToB - AmountAToC, t_chain:get_balance(Chain, A)),
+    ?assertEqual(B_Balance0 + AmountAToB             , t_chain:get_balance(Chain, B)),
+    ?assertEqual(C_Balance0 + AmountAToC             , t_chain:get_balance(Chain, C)),
+
+    ok.
+
+single_payer_invalid_test(Cfg0) ->
+    %% Test a bundled payment from single payer
+    %% Given:
+    %%   N < (K + M)
+    %%   A: N
+    %%   B: 0
+    %% Attempt:
+    %%   A -M-> B : OK
+    %%   A -K-> C : insufficient funds
+    A = t_user:new(),
+    B = t_user:new(),
+    C = t_user:new(),
+    A_Balance0 = 5000,
+    B_Balance0 = 0,
+    C_Balance0 = 0,
+
+    %% All funds will originate from A, so only it needs a starting balance.
+    Cfg = t_chain:start(Cfg0, #{users_with_hnt => [{A, A_Balance0}]}),
+
+    ConsensusGroup = ?config(users_in_consensus, Cfg),
+    Chain = ?config(chain, Cfg),
+
+    Overage = 1000,
+    AmountAToB = 2000,
+    AmountAToC = (A_Balance0 - AmountAToB) + Overage,
+
+    % Sanity checks
+    ?assert(A_Balance0 >= AmountAToB),
+    ?assert(A_Balance0 <  (AmountAToB + AmountAToC)),
+
+    Txns =
+        [
+            t_txn:pay(A, B, AmountAToB, 1),
+            t_txn:pay(A, C, AmountAToC, 2)
+        ],
+    TxnBundle = blockchain_txn_bundle_v1:new(Txns),
+
+    ?assertMatch(
+        {error, {invalid_txns, [{_, invalid_bundled_txns}]}},
+        t_chain:commit(Chain, ConsensusGroup, [TxnBundle])
+    ),
+
+    %% Because of one invalid txn (A->C), the whole bundle was rejected, so
+    %% nothing changed:
+    ?assertEqual(A_Balance0, t_chain:get_balance(Chain, A)),
+    ?assertEqual(B_Balance0, t_chain:get_balance(Chain, B)),
+    ?assertEqual(C_Balance0, t_chain:get_balance(Chain, C)),
+
+    ok.
+
+full_circle_test(Cfg0) ->
+    %% Test a full-circle transfer of funds:
+    %% Given:
+    %%   A: NA
+    %%   B: NB
+    %%   C: NC
+    %% Attempt:
+    %%   A -(NA      )-> B
+    %%   B -(NA+NB   )-> C
+    %%   C -(NA+NB+NC)-> A
+    %% Expect:
+    %%   A: NA + NB + NC
+    %%   B: 0
+    %%   C: 0
+    A = t_user:new(),
+    B = t_user:new(),
+    C = t_user:new(),
+    A_Balance0 = 5000,
+    B_Balance0 = 0,
+    C_Balance0 = 0,
+
+    %% All funds will originate from A, so only it needs a starting balance.
+    Cfg = t_chain:start(Cfg0, #{users_with_hnt => [{A, A_Balance0}]}),
+
+    ConsensusGroup = ?config(users_in_consensus, Cfg),
+    Chain = ?config(chain, Cfg),
+
+    AmountAToB = A_Balance0,
+    AmountBToC = A_Balance0 + B_Balance0,
+    AmountCToA = A_Balance0 + B_Balance0 + C_Balance0,
+    BalanceExpectedA = AmountCToA,
+    BalanceExpectedB = 0,
+    BalanceExpectedC = 0,
+
+    Txns =
+        [
+            t_txn:pay(A, B, AmountAToB, 1),
+            t_txn:pay(B, C, AmountBToC, 1),
+            t_txn:pay(C, A, AmountCToA, 1)
+        ],
+    TxnBundle = blockchain_txn_bundle_v1:new(Txns),
+
+    ?assertMatch(ok, t_chain:commit(Chain, ConsensusGroup, [TxnBundle])),
+    ?assertEqual(BalanceExpectedA, t_chain:get_balance(Chain, A)),
+    ?assertEqual(BalanceExpectedB, t_chain:get_balance(Chain, B)),
+    ?assertEqual(BalanceExpectedC, t_chain:get_balance(Chain, C)),
+
+    ok.
+
+add_assert_test(Cfg0) ->
+    %% Test add + assert in a bundled txn
+    %% A -> [add_gateway, assert_location]
+    Owner = t_user:new(),
+    Gateway = t_user:new(),
+
+    %% TODO Found experimentally. Where is the definition?
+    OwnerMinimumDCBalance = 2,
+    Cfg = t_chain:start(Cfg0, #{users_with_dc => [{Owner, OwnerMinimumDCBalance}]}),
+
+    ConsensusGroup = ?config(users_in_consensus, Cfg),
+    Chain = ?config(chain, Cfg),
+
+    LocationIndex = 631210968910285823,
+    Txns =
+        [
+            t_txn:gateway_add(Owner, Gateway),
+            t_txn:assert_location(Owner, Gateway, LocationIndex, 1)
+        ],
+    TxnBundle = blockchain_txn_bundle_v1:new(Txns),
+
+    ActiveGateways0 = t_chain:get_active_gateways(Chain),
+    ?assertMatch(ok, t_chain:commit(Chain, ConsensusGroup, [TxnBundle])),
+    ActiveGateways1 = t_chain:get_active_gateways(Chain),
+
+    ?assertEqual(
+        maps:size(ActiveGateways0) + 1,
+        maps:size(ActiveGateways1)
+    ),
+
+    %% Check that it has the correct location
+    AddedGw = maps:get(t_user:addr(Gateway), ActiveGateways1),
+    GwLoc = blockchain_ledger_gateway_v2:location(AddedGw),
+    ?assertEqual(GwLoc, LocationIndex),
+
+    ok.
+
+invalid_add_assert_test(Cfg0) ->
+    %% Test assert+add in a bundled txn
+    %% A -> [assert_location, add_gateway]
+    Owner = t_user:new(),
+    Gateway = t_user:new(),
+
+    %% TODO Found experimentally. Where is the definition?
+    OwnerMinimumDCBalance = 2,
+    Cfg = t_chain:start(Cfg0, #{users_with_dc => [{Owner, OwnerMinimumDCBalance}]}),
+
+    ConsensusGroup = ?config(users_in_consensus, Cfg),
+    Chain = ?config(chain, Cfg),
+
+    LocationIndex = 631210968910285823,
+    Txns =
+        [
+            t_txn:assert_location(Owner, Gateway, LocationIndex, 1),
+            t_txn:gateway_add(Owner, Gateway)
+        ],
+    TxnBundle = blockchain_txn_bundle_v1:new(Txns),
+
+    ActiveGateways0 = t_chain:get_active_gateways(Chain),
+    ?assertMatch(
+        {error, {invalid_txns, [{_, invalid_bundled_txns}]}},
+        t_chain:commit(Chain, ConsensusGroup, [TxnBundle])
+    ),
+    ActiveGateways1 = t_chain:get_active_gateways(Chain),
+
+    %% Check that the gateway did not get added
+    ?assertEqual(
+        maps:size(ActiveGateways0),
+        maps:size(ActiveGateways1)
+    ),
+
+    ok.
+
+single_txn_bundle_test(Cfg0) ->
+    Src = t_user:new(),
+    Dst = t_user:new(),
+    SrcBalance0 = 5000,
+    DstBalance0 = 0,
+
+    Cfg = t_chain:start(Cfg0, #{users_with_hnt => [{Src, SrcBalance0}]}),
+
+    ConsensusGroup = ?config(users_in_consensus, Cfg),
+    Chain = ?config(chain, Cfg),
+
+    Amount = 1000,
+    Txns = [t_txn:pay(Src, Dst, Amount, 1)],
+    TxnBundle = blockchain_txn_bundle_v1:new(Txns),
+
+    %% The bundle is invalid since it does not contain atleast two txns in it
+    ?assertMatch(
+        {error, {invalid_txns, [{_, invalid_min_bundle_size}]}},
+        t_chain:commit(Chain, ConsensusGroup, [TxnBundle])
+    ),
+
+    %% Sanity check that balances haven't changed:
+    ?assertEqual(SrcBalance0, t_chain:get_balance(Chain, Src)),
+    ?assertEqual(DstBalance0, t_chain:get_balance(Chain, Dst)),
+
+    ok.
+
+bundleception_test(Cfg0) ->
+    Src = t_user:new(),
+    Dst = t_user:new(),
+    SrcBalance0 = 5000,
+    DstBalance0 = 0,
+
+    Cfg = t_chain:start(Cfg0, #{users_with_hnt => [{Src, SrcBalance0}]}),
+
+    ConsensusGroup = ?config(users_in_consensus, Cfg),
+    Chain = ?config(chain, Cfg),
+
+    AmountPerTxn = 1000,
+    TxnBundle1 =
+        blockchain_txn_bundle_v1:new(
+            [
+                t_txn:pay(Src, Dst, AmountPerTxn, 1),
+                t_txn:pay(Src, Dst, AmountPerTxn, 2)
+            ]
+        ),
+    TxnBundle2 =
+        blockchain_txn_bundle_v1:new(
+            [
+                t_txn:pay(Src, Dst, AmountPerTxn, 3),
+                t_txn:pay(Src, Dst, AmountPerTxn, 4)
+            ]
+        ),
+    TxnBundleCeption = blockchain_txn_bundle_v1:new([TxnBundle1, TxnBundle2]),
+
+    ?assertMatch(
+        {error, {invalid_txns, [{_, invalid_bundleception}]}},
+        t_chain:commit(Chain, ConsensusGroup, [TxnBundleCeption])
+    ),
+
+    ?assertEqual(SrcBalance0, t_chain:get_balance(Chain, Src)),
+    ?assertEqual(DstBalance0, t_chain:get_balance(Chain, Dst)),
+
+    ok.
+
+%% Helpers --------------------------------------------------------------------

--- a/test/blockchain_vars_SUITE.erl
+++ b/test/blockchain_vars_SUITE.erl
@@ -1,0 +1,311 @@
+-module(blockchain_vars_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-include_lib("blockchain_vars.hrl").
+
+-export([
+    all/0,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+-export([
+    version_change_test/1,
+    master_key_test/1
+]).
+
+%% Setup ----------------------------------------------------------------------
+
+all() ->
+    [
+        version_change_test,
+        master_key_test
+    ].
+
+init_per_testcase(_TestCase, Cfg) ->
+    Opts =
+        #{
+            vars =>
+                #{
+                    %% Setting vars_commit_delay to 1 is crucial,
+                    %% otherwise var changes will not take effect.
+                    ?vars_commit_delay => 1
+                }
+        },
+    t_chain:start(Cfg, Opts).
+
+end_per_testcase(_TestCase, _Cfg) ->
+    t_chain:stop().
+
+%% Cases ----------------------------------------------------------------------
+
+version_change_test(Cfg) ->
+    {Priv, _} = ?config(master_key, Cfg),
+    ConsensusMembers = ?config(users_in_consensus, Cfg),
+    Chain = ?config(chain, Cfg),
+
+    Key = garbage_value,
+
+    %% enable vars v1
+    %% (enabling them at init causes init failures, so we do it here, post init)
+    ?assertMatch(
+        ok,
+        var_set(?chain_vars_version, 1, Priv, ConsensusMembers, Chain)
+    ),
+    ?assertEqual({ok, 1}, var_get(?chain_vars_version, Chain)),
+
+    %% check that vars v1 are working
+    ?assertMatch(
+        ok,
+        var_set_legacy(Key, totes_goats_garb, Priv, ConsensusMembers, Chain)
+    ),
+    ?assertEqual({ok, totes_goats_garb}, var_get(Key, Chain)),
+
+    %% switch back to vars v2
+    ?assertMatch(
+        ok,
+        var_set_legacy(?chain_vars_version, 2, Priv, ConsensusMembers, Chain)
+    ),
+    ?assertEqual({ok, 2}, var_get(?chain_vars_version, Chain)),
+
+    %% check that vars v2 are working
+    ?assertMatch(
+        ok,
+        var_set(Key, goats_are_not_garb, Priv, ConsensusMembers, Chain)
+    ),
+    ?assertEqual({ok, goats_are_not_garb}, var_get(Key, Chain)),
+
+    %% ensure vars v1 are no longer accepted
+    ?assertMatch(
+        {error, {invalid_txns, [{_, bad_block_proof}]}},
+        var_set_legacy(Key, goats_are_too_garb, Priv, ConsensusMembers, Chain)
+    ),
+    ?assertEqual({ok, goats_are_not_garb}, var_get(Key, Chain)),
+
+    ok.
+
+master_key_test(Cfg) ->
+    {Priv1, _Pub1} = ?config(master_key, Cfg),
+    ConsensusMembers = ?config(users_in_consensus, Cfg),
+    Chain = ?config(chain, Cfg),
+
+    Key = garbage_value,
+
+    Val1 = totes_goats_garb,
+    ?assertMatch(ok, var_set(Key, Val1, Priv1, ConsensusMembers, Chain)),
+    ?assertEqual({ok, Val1}, var_get(Key, Chain)),
+
+    %% bad master key
+    #{secret := Priv2, public := Pub2} = libp2p_crypto:generate_keys(ecc_compact),
+    BinPub2 = libp2p_crypto:pubkey_to_bin(Pub2),
+
+    Txn2_0 =
+        blockchain_txn_vars_v1:new(
+            #{Key => goats_are_not_garb},
+            nonce_next(Chain),
+            #{master_key => BinPub2}
+        ),
+    Proof2 = blockchain_txn_vars_v1:create_proof(Priv1, Txn2_0),
+    Txn2_1 = blockchain_txn_vars_v1:proof(Txn2_0, Proof2),
+
+
+    KeyProof2 = blockchain_txn_vars_v1:create_proof(Priv2, Txn2_0),
+    Txn2_2_Good = blockchain_txn_vars_v1:key_proof(Txn2_1, KeyProof2),
+
+    Txn2_2_Bad = blockchain_txn_vars_v1:key_proof(Txn2_1, <<Proof2/binary, "corruption">>),
+
+    ?assertMatch(
+        {error, {invalid_txns, [{_, bad_master_key}]}},
+        t_chain:commit(Chain, ConsensusMembers, [Txn2_2_Bad])
+    ),
+
+    %% good master key
+    ?assertMatch(ok, t_chain:commit(Chain, ConsensusMembers, [Txn2_2_Good])),
+
+    %% make sure old master key is no longer working
+    ?assertMatch(
+        {error, {invalid_txns, [{_, bad_block_proof}]}},
+        var_set(Key, goats_are_too_garb, Priv1, ConsensusMembers, Chain)
+    ),
+
+    %% double check that new master key works
+    ?assertMatch(
+        ok,
+        var_set(Key, goats_always_win, Priv2, ConsensusMembers, Chain)
+    ),
+    ?assertEqual({ok, goats_always_win}, var_get(Key, Chain)),
+
+    %% test all the multikey stuff
+
+    %% first enable them
+    ?assertMatch(
+        ok,
+        var_set(?use_multi_keys, true, Priv2, ConsensusMembers, Chain)
+    ),
+
+    #{secret := Priv3, public := Pub3} = libp2p_crypto:generate_keys(ecc_compact),
+    #{secret := Priv4, public := Pub4} = libp2p_crypto:generate_keys(ecc_compact),
+    #{secret := Priv5, public := Pub5} = libp2p_crypto:generate_keys(ecc_compact),
+    #{secret := Priv6, public := Pub6} = libp2p_crypto:generate_keys(ecc_compact),
+    #{secret := Priv7, public := Pub7} = libp2p_crypto:generate_keys(ecc_compact),
+    BinPub3 = libp2p_crypto:pubkey_to_bin(Pub3),
+    BinPub4 = libp2p_crypto:pubkey_to_bin(Pub4),
+    BinPub5 = libp2p_crypto:pubkey_to_bin(Pub5),
+    BinPub6 = libp2p_crypto:pubkey_to_bin(Pub6),
+    BinPub7 = libp2p_crypto:pubkey_to_bin(Pub7),
+
+    Txn7_0 = blockchain_txn_vars_v1:new(
+               #{Key => goat_jokes_are_so_single_key}, nonce_next(Chain),
+               #{multi_keys => [BinPub2, BinPub3, BinPub4, BinPub5, BinPub6]}),
+    Proofs7 = [blockchain_txn_vars_v1:create_proof(P, Txn7_0)
+               %% shuffle the proofs to make sure we no longer need
+               %% them in the correct order
+               || P <- blockchain_utils:shuffle([Priv2, Priv3, Priv4, Priv5, Priv6])],
+    Txn7_1 = blockchain_txn_vars_v1:multi_key_proofs(Txn7_0, Proofs7),
+    Proof7 = blockchain_txn_vars_v1:create_proof(Priv2, Txn7_1),
+    Txn7 = blockchain_txn_vars_v1:proof(Txn7_1, Proof7),
+    ?assertMatch(ok, t_chain:commit(Chain, ConsensusMembers, [Txn7])),
+
+    %% try with only three keys (and succeed)
+    ?assertMatch(
+        ok,
+        var_set(
+            Key,
+            but_what_now,
+            [Priv2, Priv3, Priv6],
+            ConsensusMembers,
+            Chain
+        )
+    ),
+    ?assertMatch({ok, but_what_now}, var_get(Key, Chain)),
+
+    %% try with only two keys (and fail)
+    NonceForTxn9 = nonce_next(Chain),
+    Txn9 = mvars(#{Key => sheep_jokes}, NonceForTxn9, [Priv3, Priv6]),
+    ?assertMatch(
+        {error, {invalid_txns, [{_, insufficient_votes}]}},
+        t_chain:commit(Chain, ConsensusMembers, [Txn9])
+    ),
+
+    %% try with two valid and one corrupted key proof (and fail again)
+    Txn10_0 = blockchain_txn_vars_v1:new(#{Key => cmon}, nonce_next(Chain)),
+    Proofs10_0 = [blockchain_txn_vars_v1:create_proof(P, Txn10_0)
+                || P <- [Priv2, Priv3, Priv4]],
+    [Proof10 | Rem] = Proofs10_0,
+    Proof10Corrupted = <<Proof10/binary, "asdasdasdas">>,
+    Txn10 = blockchain_txn_vars_v1:multi_proofs(Txn10_0, [Proof10Corrupted | Rem]),
+
+    ?assertMatch(
+        {error, {invalid_txns, [{_, insufficient_votes}]}},
+        t_chain:commit(Chain, ConsensusMembers, [Txn10])
+    ),
+
+    %% TODO Why agin? We already tried Txn9
+    ?assertMatch(
+        {error, {invalid_txns, [{_, insufficient_votes}]}},
+        t_chain:commit(Chain, ConsensusMembers, [Txn9])
+    ),
+
+    %% make sure that we safely ignore bad proofs and keys
+    #{secret := Priv8, public := _Pub8} = libp2p_crypto:generate_keys(ecc_compact),
+
+    Txn11a =
+        mvars(
+            #{Key => sheep_are_inherently_unfunny},
+            NonceForTxn9,
+            [Priv2, Priv3, Priv4, Priv5, Priv6, Priv8]
+        ),
+    ?assertMatch(
+        {error, {invalid_txns, [{_, too_many_proofs}]}},
+        t_chain:commit(Chain, ConsensusMembers, [Txn11a])
+    ),
+
+    ?assertMatch(
+        ok,
+        var_set(
+            Key,
+            sheep_are_inherently_unfunny,
+            [Priv2, Priv3, Priv5, Priv6, Priv8],
+            ConsensusMembers,
+            Chain
+        )
+    ),
+    ?assertMatch({ok, sheep_are_inherently_unfunny}, var_get(Key, Chain)),
+
+    Txn12_0 =
+        blockchain_txn_vars_v1:new(
+            #{Key => so_true},
+            nonce_next(Chain),
+            #{multi_keys => [BinPub3, BinPub4, BinPub5, BinPub6, BinPub7]}
+        ),
+    Proofs12 = [blockchain_txn_vars_v1:create_proof(P, Txn12_0)
+                %% shuffle the proofs to make sure we no longer need
+                %% them in the correct order
+                || P <- blockchain_utils:shuffle([Priv7])],
+    Txn12_1 = blockchain_txn_vars_v1:multi_key_proofs(Txn12_0, Proofs12),
+    Proofs = [blockchain_txn_vars_v1:create_proof(P, Txn12_1)
+               || P <- [Priv3, Priv4, Priv5]],
+    Txn12 = blockchain_txn_vars_v1:multi_proofs(Txn12_1, Proofs),
+    ?assertMatch(ok, t_chain:commit(Chain, ConsensusMembers, [Txn12])),
+    ?assertMatch({ok, so_true}, var_get(Key, Chain)),
+
+    ?assertMatch(
+        ok,
+        var_set(
+            Key,
+            lets_all_hate_on_sheep,
+            [Priv5, Priv6, Priv7],
+            ConsensusMembers,
+            Chain
+        )
+    ),
+    ?assertMatch({ok, lets_all_hate_on_sheep}, var_get(Key, Chain)),
+    ok.
+
+%% Helpers --------------------------------------------------------------------
+
+-spec nonce_curr(blockchain:blockchain()) -> integer().
+nonce_curr(Chain) ->
+    Ledger = blockchain:ledger(Chain),
+    {ok, Nonce} = blockchain_ledger_v1:vars_nonce(Ledger),
+    Nonce.
+
+-spec nonce_next(blockchain:blockchain()) -> integer().
+nonce_next(Chain) ->
+    nonce_curr(Chain) + 1.
+
+%% TODO refactor as t_txn
+var_set(Key, Val, PrivKey, ConsensusMembers, Chain) ->
+    Nonce = nonce_next(Chain),
+    MakeTxn =
+        case is_list(PrivKey) of
+            true -> fun mvars/3;
+            false -> fun vars/3
+        end,
+    Txn = MakeTxn(#{Key => Val}, Nonce, PrivKey),
+    t_chain:commit(Chain, ConsensusMembers, [Txn]).
+
+%% TODO refactor as t_txn
+var_set_legacy(Key, Val, PrivKey, ConsensusMembers, Chain) ->
+    Vars = #{Key => Val},
+    Txn1 = blockchain_txn_vars_v1:new(Vars, nonce_next(Chain)),
+    Proof = blockchain_txn_vars_v1:legacy_create_proof(PrivKey, Vars),
+    Txn2 = blockchain_txn_vars_v1:proof(Txn1, Proof),
+    t_chain:commit(Chain, ConsensusMembers, [Txn2]).
+
+%% TODO refactor as t_chain
+var_get(Key, Chain) ->
+    Ledger = blockchain:ledger(Chain),
+    blockchain:config(Key, Ledger).
+
+vars(Map, Nonce, Priv) ->
+    Txn0 = blockchain_txn_vars_v1:new(Map, Nonce),
+    Proof = blockchain_txn_vars_v1:create_proof(Priv, Txn0),
+    blockchain_txn_vars_v1:proof(Txn0, Proof).
+
+mvars(Map, Nonce, Privs) ->
+    Txn = blockchain_txn_vars_v1:new(Map, Nonce),
+    Proofs = [blockchain_txn_vars_v1:create_proof(P, Txn) || P <- blockchain_utils:shuffle(Privs)],
+    blockchain_txn_vars_v1:multi_proofs(Txn, Proofs).

--- a/test/t_chain.erl
+++ b/test/t_chain.erl
@@ -1,0 +1,390 @@
+-module(t_chain).
+
+-export_type([
+    t/0,
+    ct_cfg/0
+]).
+
+-export([
+    start/1,
+    start/2,
+    stop/0,
+
+    commit/3,
+    get_active_gateways/1,
+    get_balance/2
+]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-include_lib("include/blockchain.hrl").
+-include_lib("include/blockchain_vars.hrl").
+
+-type t() ::
+    blockchain:blockchain().
+
+-type ct_cfg() ::
+    [
+          {blockchain_sup, pid()}
+        | {chain, t()}
+        | {master_key, {libp2p_crypto:privkey(), libp2p_crypto:pubkey()}}
+        | {consensus_members, [t_user:t()]}
+        | {atom(), term()}
+    ].
+
+-type optional_params() ::
+    #{
+        vars                       => map(),
+        default_init_balance_hnt   => non_neg_integer(),
+        default_init_balance_dc    => non_neg_integer(),
+        default_init_balance_hst   => non_neg_integer(),
+        num_init_users             => non_neg_integer(),
+
+        user_master                => t_user:t(),
+        user_app                   => t_user:t(),
+        users_with_hnt             => [{t_user:t(), non_neg_integer()}],
+        users_with_hst             => [{t_user:t(), non_neg_integer()}],
+        users_with_dc              => [{t_user:t(), non_neg_integer()}],
+        users_as_gateways          => [t_user:t()],
+        users_in_consensus         => [t_user:t()]
+    }.
+
+-spec start(ct_cfg()) -> ct_cfg().
+start(Cfg) ->
+    start(Cfg, #{}).
+
+-spec start(ct_cfg(), optional_params()) -> ct_cfg().
+start(Cfg, Opts) when is_list(Cfg), is_map(Opts) ->
+    DirPerSuite = ?config(priv_dir, Cfg),
+    %% priv_dir, when called from:
+    %% - init_per_suite, is per suite;
+    %% - TestCase, is per test case.
+    %% by not relying on it being either way and just creating our own unique
+    %% string, we liberate the caller from worrying about the difference
+    %% between calling this function from either location.
+    DirUnique = filename:join(DirPerSuite, unique_string()),
+    DirForData = filename:join(DirUnique, "data"),
+
+    InitBalanceHNT = maps:get(default_init_balance_hnt, Opts, 5000),
+    InitBalanceDC  = maps:get(default_init_balance_dc , Opts, 5000),
+    InitBalanceHST = maps:get(default_init_balance_hst, Opts, 5000),
+    NumInitUsers   = maps:get(num_init_users  , Opts, 8),
+    ExtraVars      = maps:get(vars            , Opts, #{}),
+
+    Vars = maps:merge(vars_default(), ExtraVars),
+    NumInConsensus = maps:get(num_consensus_members, Vars),
+
+    MasterUser = maps_get_or(user_master, Opts, fun() -> t_user:new() end),
+    AppUser    = maps_get_or(user_app   , Opts, fun() -> t_user:new() end),
+
+    UsersGetOrGenPlain =
+        fun(K, N) ->
+            Gen = fun() -> t_user:n_new(N) end,
+            maps_get_or(K , Opts, Gen)
+        end,
+    UsersGetOrGenWithBalance =
+        fun(K, N, DefaultBalance) ->
+            Gen = fun() -> [{U, DefaultBalance} || U <- t_user:n_new(N)] end,
+            maps_get_or(K , Opts, Gen)
+        end,
+
+    UsersWithHNT = UsersGetOrGenWithBalance(users_with_hnt, NumInitUsers, InitBalanceHNT),
+    UsersWithHST = UsersGetOrGenWithBalance(users_with_hst, NumInitUsers, InitBalanceHST),
+    UsersWithDC  = UsersGetOrGenWithBalance(users_with_dc , NumInitUsers, InitBalanceDC),
+
+    UsersAsGateways  = UsersGetOrGenPlain(users_as_gateways , NumInitUsers),
+    UsersInConsensus = UsersGetOrGenPlain(users_in_consensus, NumInConsensus),
+
+    Addrs = fun (Us) -> [t_user:addr(U) || U <- Us] end,
+
+    GenesisTxns =
+        [genesis_txn_vars(Vars, t_user:key_pair(MasterUser))] ++
+        genesis_txns_pay_hnt([{t_user:addr(U), B} || {U, B} <- UsersWithHNT]) ++
+        genesis_txns_pay_dc( [{t_user:addr(U), B} || {U, B} <- UsersWithDC]) ++
+        genesis_txns_pay_sec([{t_user:addr(U), B} || {U, B} <- UsersWithHST]) ++
+        genesis_txns_consensus(Addrs(UsersAsGateways), election_version(ExtraVars)) ++
+        [blockchain_txn_consensus_group_v1:new(Addrs(UsersInConsensus), <<"proof">>, 1, 0)],
+    GenesisBlock = blockchain_block:new_genesis_block(GenesisTxns),
+
+    ok = application:set_env(blockchain, base_dir, DirForData),
+    ?assertMatch(
+        {ok, _},
+        blockchain_sup:start_link(
+            [
+                {key, t_user:key_triple(AppUser)},
+                {base_dir, DirForData}
+            ]
+        )
+    ),
+    ?assert(erlang:is_pid(blockchain_swarm:swarm())),
+    ?assertEqual(
+        ok,
+        blockchain_worker:integrate_genesis_block_synchronously(GenesisBlock)
+    ),
+    Chain = blockchain_worker:blockchain(),
+    ?assert(Chain =/= undefined),
+    ?assertEqual({ok, 1}, blockchain:height(Chain)),
+    {ok, HeadBlock} = blockchain:head_block(Chain),
+    ?assertEqual(
+        blockchain_block:hash_block(GenesisBlock),
+        blockchain_block:hash_block(HeadBlock)
+    ),
+    ?assertEqual(
+        {ok, GenesisBlock},
+        blockchain:head_block(Chain)
+    ),
+    ?assertEqual(
+        {ok, blockchain_block:hash_block(GenesisBlock)},
+        blockchain:genesis_hash(Chain)
+    ),
+    ?assertEqual(
+        {ok, GenesisBlock},
+        blockchain:genesis_block(Chain)
+    ),
+    ?assertEqual(
+        {ok, 1},
+        blockchain:height(Chain)
+    ),
+    {ok, SwarmPubKey, _, _} = blockchain_swarm:keys(),
+    ?assertEqual(
+        libp2p_crypto:pubkey_to_bin(SwarmPubKey),
+        t_user:addr(AppUser)
+    ),
+    %% TODO Assert other balances
+    lists:foreach(
+        fun ({User, Balance}) ->
+            ?assertEqual(Balance, get_balance(Chain, User))
+        end,
+        UsersWithHNT
+    ),
+    [
+        {chain, Chain},
+
+        {users_in_consensus, UsersInConsensus},
+        {users_with_hnt    , UsersWithHNT},
+        {users_with_hst    , UsersWithHST},
+        {users_with_dc     , UsersWithDC},
+        {users_as_gateways , UsersAsGateways},
+
+        %% TODO May not need the pair form eventually, as t_user is adopted.
+        {master_key, t_user:key_pair(MasterUser)},
+
+        %% XXX Some test cases still expect base_dir in config,
+        %%     though it's questionable if they really need it.
+        {base_dir, DirForData}
+    |
+        Cfg
+    ].
+
+-spec stop() -> ok.
+stop() ->
+    Sup = erlang:whereis(blockchain_sup),
+    case erlang:is_pid(Sup) andalso erlang:is_process_alive(Sup) of
+        true ->
+            true = erlang:exit(Sup, normal),
+            ok = test_utils:wait_until(fun() -> false =:= erlang:is_process_alive(Sup) end);
+        false ->
+            ok
+    end,
+    ok.
+
+%% Make block and add it to chain.
+-spec commit(t(), [t_user:t()], [t_txn:t()]) ->
+    ok | {error, _}.
+commit(Chain, ConsensusMembers, [_|_]=Txns0) ->
+    Txns = lists:sort(fun blockchain_txn:sort/2, Txns0),
+    case blockchain_txn:validate(Txns, Chain) of
+        {_, []} ->
+            Block = txns_to_block(Chain, ConsensusMembers, Txns),
+            {ok, Height0} = blockchain:height(Chain),
+            ok = blockchain:add_block(Block, Chain),
+            {ok, Height1} = blockchain:height(Chain),
+            ?assertEqual(1 + Height0, Height1),
+            ok;
+        {_, [_|_]=Invalid} ->
+            ct:pal("Invalid transactions: ~p", [Invalid]),
+            {error, {invalid_txns, Invalid}}
+    end.
+
+get_active_gateways(Chain) ->
+    Ledger = blockchain:ledger(Chain),
+    blockchain_ledger_v1:active_gateways(Ledger).
+
+%% TODO t-last order
+-spec get_balance(t(), t_user:t()) ->
+    non_neg_integer().
+get_balance(Chain, User) ->
+    Addr = t_user:addr(User),
+    Ledger = blockchain:ledger(Chain),
+    case blockchain_ledger_v1:find_entry(Addr, Ledger) of
+        {error, address_entry_not_found} ->
+            0;
+        {ok, Entry} ->
+            blockchain_ledger_entry_v1:balance(Entry)
+    end.
+
+%% Internal ===================================================================
+
+-spec maps_get_or(K, #{K => V}, fun(() -> V)) -> V.
+maps_get_or(K, Map, F) ->
+    opt_or(maps_get(K, Map), F).
+
+-spec maps_get(K, #{K => V}) ->
+    none | {some, V}.
+maps_get(K, Map) ->
+    case maps:find(K, Map) of
+        error -> none;
+        {ok, V} -> {some, V}
+    end.
+
+-spec opt_or(none | {some, A}, fun(() -> A)) -> A.
+opt_or(none, F) -> F();
+opt_or({some, X}, _) -> X.
+
+unique_string() ->
+    lists:flatten(io_lib:format("~b", [erlang:unique_integer([positive])])).
+
+-spec txns_to_block(blockchain:blockchain(), [t_user:t()], [blockchain_txn:txn()]) ->
+    blockchain_block:block().
+txns_to_block(Chain, ConsensusMembers, Txns) ->
+    {ok, HeadBlock} = blockchain:head_block(Chain),
+    {ok, PrevHash} = blockchain:head_hash(Chain),
+    Height = blockchain_block:height(HeadBlock) + 1,
+    Time = blockchain_block:time(HeadBlock) + 1,
+    ct:pal("making block with transactions: ~p", [Txns]),
+    BlockParams =
+        #{
+            prev_hash => PrevHash,
+            height => Height,
+            transactions => Txns,
+            signatures => [],
+            time => Time,
+            hbbft_round => 0,
+            election_epoch => 1,
+            epoch_start => 0,
+            seen_votes => [],
+            bba_completion => <<>>
+        },
+    Block0 = blockchain_block_v1:new(BlockParams),
+    BinBlock = blockchain_block:serialize(Block0),
+    Signatures = sign(ConsensusMembers, BinBlock),
+    Block1 = blockchain_block:set_signatures(Block0, Signatures),
+    ct:pal("made block: ~p", [Block1]),
+    Block1.
+
+-spec sign([t_user:t()], binary()) -> [{Addr :: binary(), Sig :: binary()}].
+sign(ConsensusMembers, <<Bin/binary>>) ->
+    [{t_user:addr(User), t_user:sign(Bin, User)} || User <- ConsensusMembers].
+
+genesis_txn_vars(Vars, {MasterKeyPriv, MasterKeyPub}) ->
+    Txn = blockchain_txn_vars_v1:new(Vars, 2, #{master_key => libp2p_crypto:pubkey_to_bin(MasterKeyPub)}),
+    Proof = blockchain_txn_vars_v1:create_proof(MasterKeyPriv, Txn),
+    blockchain_txn_vars_v1:key_proof(Txn, Proof).
+
+-spec genesis_txns_pay_hnt([{libp2p_crypto:pubkey_bin(), non_neg_integer()}]) ->
+    [blockchain_txn:txn()].
+genesis_txns_pay_hnt(AddrBalancePairs) ->
+    [blockchain_txn_coinbase_v1:new(A, B) || {A, B} <- AddrBalancePairs].
+
+-spec genesis_txns_pay_dc([{libp2p_crypto:pubkey_bin(), non_neg_integer()}]) ->
+    [blockchain_txn:txn()].
+genesis_txns_pay_dc(AddrBalancePairs) ->
+    [blockchain_txn_dc_coinbase_v1:new(A, B) || {A, B} <- AddrBalancePairs].
+
+-spec genesis_txns_pay_sec([{libp2p_crypto:pubkey_bin(), non_neg_integer()}]) ->
+    [blockchain_txn:txn()].
+genesis_txns_pay_sec(AddrBalancePairs) ->
+    [blockchain_txn_security_coinbase_v1:new(A, B) || {A, B} <- AddrBalancePairs].
+
+-spec genesis_txns_consensus(
+    [{libp2p_crypto:pubkey_bin(), non_neg_integer()}],
+    gt_5 | lt_5_or_unspecified
+) ->
+    [blockchain_txn:txn()].
+genesis_txns_consensus(AddressesOfGateways, ElectionVersion) ->
+    Locations =
+        [
+            h3:from_geo({37.780586, -122.469470 + I/100}, 12)
+        ||
+            I <- lists:seq(1, length(AddressesOfGateways))
+        ],
+    case ElectionVersion of
+        gt_5 ->
+            [
+                blockchain_txn_gen_validator_v1:new(Addr, Addr, ?bones(10000))
+            ||
+                Addr <- AddressesOfGateways
+            ];
+        lt_5_or_unspecified ->
+            [
+                blockchain_txn_gen_gateway_v1:new(Addr, Addr, Loc, 0)
+            ||
+                {Addr, Loc} <- lists:zip(AddressesOfGateways, Locations)
+            ]
+    end.
+
+election_version(#{election_version := V}) when V >= 5 ->
+    gt_5;
+election_version(_) ->
+    lt_5_or_unspecified.
+
+vars_default() ->
+    #{
+        ?allow_zero_amount                => false,
+        ?alpha_decay                      => 0.007,
+        ?beta_decay                       => 0.0005,
+        ?block_time                       => 30000,
+        ?block_version                    => v1,
+        ?chain_vars_version               => 2,
+        ?consensus_percent                => 0.10,
+        ?dc_payload_size                  => 24,
+        ?election_cluster_res             => 8,
+        ?election_interval                => 30,
+        ?election_removal_pct             => 85,
+        ?election_replacement_factor      => 4,
+        ?election_replacement_slope       => 20,
+        ?election_restart_interval        => 5,
+        ?election_selection_pct           => 70,
+        ?election_version                 => 2,
+        ?h3_exclusion_ring_dist           => 2,
+        ?h3_max_grid_distance             => 13,
+        ?h3_neighbor_res                  => 12,
+        ?max_open_sc                      => 2,
+        ?max_staleness                    => 100000,
+        ?max_subnet_num                   => 20,
+        ?max_subnet_size                  => 65536,
+        ?max_xor_filter_num               => 5,
+        ?max_xor_filter_size              => 1024*100,
+        ?min_assert_h3_res                => 12,
+        ?min_expire_within                => 10,
+        ?min_score                        => 0.15,
+        ?min_subnet_size                  => 8,
+        ?monthly_reward                   => ?bones(5000000),
+        ?num_consensus_members            => 7,
+        ?poc_centrality_wt                => 0.5,
+        ?poc_challenge_interval           => 30,
+        ?poc_challengees_percent          => 0.19 + 0.16,
+        ?poc_challengers_percent          => 0.09 + 0.06,
+        ?poc_good_bucket_high             => -80,
+        ?poc_good_bucket_low              => -132,
+        ?poc_max_hop_cells                => 2000,
+        ?poc_path_limit                   => 7,
+        ?poc_target_hex_parent_res        => 5,
+        ?poc_typo_fixes                   => true,
+        ?poc_v4_prob_count_wt             => 0.0,
+        ?poc_v4_prob_rssi_wt              => 0.0,
+        ?poc_v4_prob_time_wt              => 0.0,
+        ?poc_v4_randomness_wt             => 0.5,
+        ?poc_v4_target_prob_edge_wt       => 0.0,
+        ?poc_v4_target_prob_score_wt      => 0.0,
+        ?poc_v5_target_prob_randomness_wt => 1.0,
+        ?poc_version                      => 8,
+        ?poc_witnesses_percent            => 0.02 + 0.03,
+        ?predicate_threshold              => 0.85,
+        ?reward_version                   => 1,
+        ?securities_percent               => 0.35,
+        ?vars_commit_delay                => 10,
+        ?witness_refresh_interval         => 10,
+        ?witness_refresh_rand_n           => 100
+    }.

--- a/test/t_txn.erl
+++ b/test/t_txn.erl
@@ -1,0 +1,48 @@
+-module(t_txn).
+
+-export_type([
+    t/0
+]).
+
+-export([
+    pay/4,
+    gateway_add/2,
+    assert_location/4
+]).
+
+-type t() :: blockchain_txn:txn().
+
+-spec pay(t_user:t(), t_user:t(), non_neg_integer(), non_neg_integer()) ->
+    t().
+pay(Src, Dst, Amount, Nonce) ->
+    blockchain_txn_payment_v1:sign(
+        blockchain_txn_payment_v1:new(
+            t_user:addr(Src),
+            t_user:addr(Dst),
+            Amount,
+            Nonce
+        ),
+        t_user:sig_fun(Src)
+    ).
+
+-spec gateway_add(t_user:t(), t_user:t()) ->
+    t().
+gateway_add(Owner, Gateway) ->
+    Tx1 = blockchain_txn_add_gateway_v1:new(t_user:addr(Owner), t_user:addr(Gateway)),
+    Tx2 = blockchain_txn_add_gateway_v1:sign(Tx1, t_user:sig_fun(Owner)),
+    Tx3 = blockchain_txn_add_gateway_v1:sign_request(Tx2, t_user:sig_fun(Gateway)),
+    Tx3.
+
+-spec assert_location(t_user:t(), t_user:t(), non_neg_integer(), pos_integer()) ->
+    t().
+assert_location(Owner, Gateway, Index, Nonce) ->
+    Tx1 =
+        blockchain_txn_assert_location_v1:new(
+            t_user:addr(Gateway),
+            t_user:addr(Owner),
+            Index,
+            Nonce
+        ),
+    Tx2 = blockchain_txn_assert_location_v1:sign_request(Tx1, t_user:sig_fun(Gateway)),
+    Tx3 = blockchain_txn_assert_location_v1:sign(Tx2, t_user:sig_fun(Owner)),
+    Tx3.

--- a/test/t_user.erl
+++ b/test/t_user.erl
@@ -1,0 +1,91 @@
+-module(t_user).
+
+-export_type([
+    t/0
+]).
+
+-export([
+    new/0,
+    n_new/1,
+    addr/1,
+    sig_fun/1,
+    sign/2,       % access and apply sig_fun
+    key_triple/1, % passed into blockchain app start options
+    key_pair/1    % passed into ct config as {master_key, Pair}. TODO may not be needed
+]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-record(?MODULE, {
+    address  :: libp2p_crypto:pubkey_bin(),
+    priv     :: libp2p_crypto:privkey(),
+    pub      :: libp2p_crypto:pubkey(),
+    sig_fun  :: libp2p_crypto:sig_fun(),
+    ecdh_fun :: libp2p_crypto:ecdh_fun()
+}).
+
+-opaque t() ::
+    #?MODULE{}.
+
+-type key_type() ::
+    %% TODO Export key_type/0 from libp2p_crypto
+    ecc_compact | ed25519.
+
+%% API ========================================================================
+-spec n_new(pos_integer()) -> [t()].
+n_new(N) ->
+    [new() || _ <- lists:duplicate(N, {})].
+
+-spec new() -> t().
+new() ->
+    new(ecc_compact).
+
+-spec new(key_type()) -> t().
+new(KeyType) ->
+    #{public := Pub, secret := Priv} = libp2p_crypto:generate_keys(KeyType),
+    Addr = libp2p_crypto:pubkey_to_bin(Pub),
+    SigFun = libp2p_crypto:mk_sig_fun(Priv),
+    ECDHFun = libp2p_crypto:mk_ecdh_fun(Priv),
+    ?assert(is_binary(Addr)),
+    ?assert(is_function(SigFun)),
+    ?assert(is_function(ECDHFun)),
+    #?MODULE{
+        address  = Addr,
+        priv     = Priv,
+        pub      = Pub,
+        ecdh_fun = ECDHFun,
+        sig_fun  = SigFun
+    }.
+
+-spec key_triple(t()) ->
+    {
+        libp2p_crypto:pubkey(),
+        libp2p_crypto:sig_fun(),
+        libp2p_crypto:ecdh_fun()
+    }.
+key_triple(#?MODULE{pub=P, sig_fun=S, ecdh_fun=E}) ->
+    {P, S, E}.
+
+-spec key_pair(t()) ->
+    {
+        libp2p_crypto:privkey(),
+        libp2p_crypto:pubkey()
+    }.
+key_pair(#?MODULE{priv=Priv, pub=Pub}) ->
+    {Priv, Pub}.
+
+-spec addr(t()) -> binary().
+addr(#?MODULE{address = <<Addr/binary>>}) ->
+    Addr.
+
+-spec sig_fun(t()) -> libp2p_crypto:sig_fun().
+sig_fun(#?MODULE{sig_fun = SigFun}) ->
+    ?assert(is_function(SigFun)),
+    SigFun.
+
+-spec sign(binary(), t()) -> binary().
+sign(<<Bin/binary>>, #?MODULE{sig_fun = SigFun}) ->
+    ?assert(is_function(SigFun)),
+    SigFun(Bin).
+
+%% Private ====================================================================


### PR DESCRIPTION
Mainly 2 things here:
1. relocation of 2 suites from miner:
  - the whole `miner_txn_bundle_SUITE` into `blockchain_txn_bundle_SUITE` and
  - selections from `miner_blockchain_SUITE` into `blockchain_vars_SUITE`;
2. new test-scenario setup tools:
  - `t_chain`: chain setup, block creation and addition
  - `t_user`: crypto key storage abstraction
  - `t_txn`: transaction creation shortcuts

But also some drive-by spec additions which I felt the need for when reading
the code.

While 1 was the main objective, 2 came out of the need to re-write the tests
innards anyway, so why not do it a little better? Also professor asked for
more-flexible scenario setup tools.

`t_chain` mainly improves on functionality of `test_utils:init*` and
`test_utils:*_block` functions by giving the user a lot more control over what
addresses end-up owning what assets - this makes testing scenarios a lot
clearer about what their base expectations are. Additionally, it adds the
`commit` shortcut, which bundles validation, block creation and addition to
chain - this was surprisingly absent from `test_utils`, but was needed for the
imported tests.

`t_user` is a key-holding abstraction which simplifies playing god and creating
scenarios with ownership transfers.

`t_txn` is just a place to organize transaction-construction shortcuts which
understand `t_user`, similar to `test_utils:create_payment_transaction`.

Using the new testing tools/abstractions, a payment test can look as intuitive
and transparent as:

```erlang
[{Src, SrcBalance} | _] = ?config(users_with_hnt, Cfg),
Dst = t_user:new(),
DstBalance = t_chain:get_balance(Chain, Dst),
Amount = 1000,
Txn = t_txn:pay(Src, Dst, Amount, 1),

?assertEqual(ok, t_chain:commit(Chain, ConsensusMembers, [Txn])),
?assertEqual(SrcBalance - Amount, t_chain:get_balance(Chain, Src)),
?assertEqual(DstBalance + Amount, t_chain:get_balance(Chain, Dst)),
```

for more transparency and control, the above could start with:

```erlang
Src = t_user:new(),
SrcBalance = 5000,
Dst = t_user:new(),
DstBalance = 0,
Cfg = t_chain:start(Cfg0, #{users_with_hnt => [{Src, SrcBalance}]}),
...
```

Although, it may actually be better for `start` to accept a list of `{Address, Balance}` pairs...
