### PR TITLE
Receipts for HTLC Redemptions

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -2168,8 +2168,8 @@ open_db(Dir) ->
 
     GlobalOpts = application:get_env(rocksdb, global_opts, []),
     DBOptions = [{create_if_missing, true}, {atomic_flush, true}] ++ GlobalOpts,
-    DefaultCFs = ["default", "blocks", "heights", "temp_blocks",
-                  "plausible_blocks", "snapshots", "implicit_burns", "info"],
+    DefaultCFs = ["default", "blocks", "heights", "temp_blocks", 
+                  "plausible_blocks", "snapshots", "implicit_burns", "info", "htlc_receipts"],
     ExistingCFs =
         case rocksdb:list_column_families(DBDir, DBOptions) of
             {ok, CFs0} ->

--- a/src/blockchain_htlc_receipt.erl
+++ b/src/blockchain_htlc_receipt.erl
@@ -1,0 +1,116 @@
+%%%-------------------------------------------------------------------
+%% @doc
+%% == Blockchain HTLC Redemption Receipt ==
+%% @end
+%%%-------------------------------------------------------------------
+-module(blockchain_htlc_receipt).
+
+-include("blockchain_json.hrl").
+
+-export([
+    new/7,
+    payer/1, payer/2,
+    payee/1, payee/2,
+    address/1, address/2,
+    balance/1, balance/2,
+    hashlock/1, hashlock/2,
+    timelock/1, timelock/2,
+    redeemed_at/1, redeemed_at/2,
+    serialize/1, deserialize/1,
+    to_json/2
+]).
+
+-record(htlc_receipt, {
+    payee :: libp2p_crypto:pubkey_bin(),
+    payer :: libp2p_crypto:pubkey_bin(),
+    address :: libp2p_crypto:pubkey_bin(),
+    balance :: non_neg_integer(),
+    hashlock :: binary(),
+    timelock :: non_neg_integer(),
+    redeemed_at :: non_neg_integer()
+}).
+
+-type htlc_receipt() :: #htlc_receipt{}.
+
+-export_type([htlc_receipt/0]).
+
+-spec new(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), non_neg_integer(), binary(), non_neg_integer(), non_neg_integer()) -> htlc_receipt().
+new(Payee, Payer, Address, Balance, Hashlock, Timelock, RedeemedAt) ->
+    #htlc_receipt{payee=Payee, payer=Payer, address=Address, balance=Balance, hashlock=Hashlock, timelock=Timelock, redeemed_at=RedeemedAt }.
+
+-spec payer(htlc_receipt()) -> libp2p_crypto:pubkey_bin().
+payer(#htlc_receipt{payer=Payer}) ->
+    Payer.
+
+-spec payer(libp2p_crypto:pubkey_bin(), htlc_receipt()) -> htlc_receipt().
+payer(Payer, HTLCReceipt) ->
+    HTLCReceipt#htlc_receipt{payer=Payer}.
+
+-spec payee(htlc_receipt()) -> libp2p_crypto:pubkey_bin().
+payee(#htlc_receipt{payee=Payee}) ->
+    Payee.
+
+-spec payee(libp2p_crypto:pubkey_bin(), htlc_receipt()) -> htlc_receipt().
+payee(Payee, HTLCReceipt) ->
+    HTLCReceipt#htlc_receipt{payee=Payee}.
+
+-spec address(htlc_receipt()) -> libp2p_crypto:pubkey_bin().
+address(#htlc_receipt{address=Address}) ->
+    Address.
+
+-spec address(libp2p_crypto:pubkey_bin(), htlc_receipt()) -> htlc_receipt().
+address(Address, HTLCReceipt) ->
+    HTLCReceipt#htlc_receipt{address=Address}.
+
+-spec balance(htlc_receipt()) -> non_neg_integer().
+balance(#htlc_receipt{balance=Balance}) ->
+    Balance.
+
+-spec balance(non_neg_integer(), htlc_receipt()) -> htlc_receipt().
+balance(Balance, HTLCReceipt) ->
+    HTLCReceipt#htlc_receipt{balance=Balance}.
+
+-spec hashlock(htlc_receipt()) -> binary().
+hashlock(#htlc_receipt{hashlock=Hashlock}) ->
+    Hashlock.
+
+-spec hashlock(binary(), htlc_receipt()) -> htlc_receipt().
+hashlock(Hashlock, HTLCReceipt) ->
+    HTLCReceipt#htlc_receipt{hashlock=Hashlock}.
+
+-spec timelock(htlc_receipt()) -> non_neg_integer().
+timelock(#htlc_receipt{timelock=Timelock}) ->
+    Timelock.
+
+-spec timelock(non_neg_integer(), htlc_receipt()) -> htlc_receipt().
+timelock(Timelock, HTLCReceipt) ->
+    HTLCReceipt#htlc_receipt{timelock=Timelock}.
+
+-spec redeemed_at(htlc_receipt()) -> non_neg_integer().
+redeemed_at(#htlc_receipt{redeemed_at=RedeemedAt}) ->
+    RedeemedAt.
+
+-spec redeemed_at(non_neg_integer(), htlc_receipt()) -> htlc_receipt().
+redeemed_at(RedeemedAt, HTLCReceipt) ->
+    HTLCReceipt#htlc_receipt{redeemed_at=RedeemedAt}.
+
+-spec serialize(htlc_receipt()) -> binary().
+serialize(HTLCReceipt) ->
+    BinEntry = erlang:term_to_binary(HTLCReceipt, [compressed]),
+    <<1, BinEntry/binary>>.
+
+-spec deserialize(binary()) -> htlc_receipt().
+deserialize(<<_:1/binary, Bin/binary>>) ->
+    erlang:binary_to_term(Bin).
+
+-spec to_json(htlc_receipt(), blockchain_json:opts()) -> blockchain_json:json_object().
+to_json(HTLCReceipt, _Opts) ->
+    #{
+      payer => ?BIN_TO_B58(payer(HTLCReceipt)),
+      payee => ?BIN_TO_B58(payee(HTLCReceipt)),
+      address => ?BIN_TO_B58(address(HTLCReceipt)),
+      balance => balance(HTLCReceipt),
+      hashlock => ?BIN_TO_B64(hashlock(HTLCReceipt)),
+      timelock => timelock(HTLCReceipt),
+      redeemed_at => redeemed_at(HTLCReceipt)
+    }.

--- a/src/blockchain_htlc_receipt.erl
+++ b/src/blockchain_htlc_receipt.erl
@@ -21,8 +21,8 @@
 ]).
 
 -record(htlc_receipt, {
-    payee :: libp2p_crypto:pubkey_bin(),
     payer :: libp2p_crypto:pubkey_bin(),
+    payee :: libp2p_crypto:pubkey_bin(),
     address :: libp2p_crypto:pubkey_bin(),
     balance :: non_neg_integer(),
     hashlock :: binary(),

--- a/src/blockchain_htlc_receipt.erl
+++ b/src/blockchain_htlc_receipt.erl
@@ -35,8 +35,8 @@
 -export_type([htlc_receipt/0]).
 
 -spec new(libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), libp2p_crypto:pubkey_bin(), non_neg_integer(), binary(), non_neg_integer(), non_neg_integer()) -> htlc_receipt().
-new(Payee, Payer, Address, Balance, Hashlock, Timelock, RedeemedAt) ->
-    #htlc_receipt{payee=Payee, payer=Payer, address=Address, balance=Balance, hashlock=Hashlock, timelock=Timelock, redeemed_at=RedeemedAt }.
+new(Payer, Payee, Address, Balance, Hashlock, Timelock, RedeemedAt) ->
+    #htlc_receipt{payer=Payer, payee=Payee, address=Address, balance=Balance, hashlock=Hashlock, timelock=Timelock, redeemed_at=RedeemedAt }.
 
 -spec payer(htlc_receipt()) -> libp2p_crypto:pubkey_bin().
 payer(#htlc_receipt{payer=Payer}) ->

--- a/src/transactions/v1/blockchain_txn_redeem_htlc_v1.erl
+++ b/src/transactions/v1/blockchain_txn_redeem_htlc_v1.erl
@@ -214,7 +214,7 @@ absorb(Txn, Chain) ->
                     Error;
                 {ok, HTLC} ->
                     Payee = blockchain_ledger_htlc_v1:payee(HTLC),
-                    blockchain_ledger_v1:redeem_htlc(Address, Payee, Ledger)
+                    blockchain_ledger_v1:redeem_htlc(Address, Payee, Ledger, Chain)
             end
     end.
 

--- a/test/blockchain_htlc_receipt_SUITE.erl
+++ b/test/blockchain_htlc_receipt_SUITE.erl
@@ -153,7 +153,7 @@ enable_htlc_receipt_test(Config) ->
     ?assertEqual(Amount, blockchain_htlc_receipt:balance(HTLCReceipt)),
     ?assertEqual(Hashlock, blockchain_htlc_receipt:hashlock(HTLCReceipt)),
     ?assertEqual(3, blockchain_htlc_receipt:timelock(HTLCReceipt)),
-    ?assertEqual(1, blockchain_htlc_receipt:redeemed_at(HTLCReceipt)),
+    ?assertEqual(2, blockchain_htlc_receipt:redeemed_at(HTLCReceipt)),
 
     ct:pal("HTLC Receipt: ~p", [HTLCReceipt]),
 

--- a/test/blockchain_htlc_receipt_SUITE.erl
+++ b/test/blockchain_htlc_receipt_SUITE.erl
@@ -1,0 +1,231 @@
+-module(blockchain_htlc_receipt_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include("blockchain_vars.hrl").
+-include("blockchain_txn_fees.hrl").
+
+-export([all/0, init_per_testcase/2, end_per_testcase/2]).
+
+-export([
+         enable_htlc_receipt_test/1,
+         disabled_htlc_receipt_test/1
+        ]).
+
+all() ->
+    [
+     enable_htlc_receipt_test,
+     disabled_htlc_receipt_test
+    ].
+
+-define(MAX_PAYMENTS, 20).
+
+%%--------------------------------------------------------------------
+%% TEST CASE SETUP
+%%--------------------------------------------------------------------
+
+init_per_testcase(TestCase, Config) ->
+    Config0 = blockchain_ct_utils:init_base_dir_config(?MODULE, TestCase, Config),
+    Balance = 5000 * ?BONES_PER_HNT,
+    {ok, Sup, {PrivKey, PubKey}, Opts} = test_utils:init(?config(base_dir, Config0)),
+
+    ExtraVars = extra_vars(TestCase),
+
+    {ok, GenesisMembers, _GenesisBlock, ConsensusMembers, Keys} =
+        test_utils:init_chain(Balance, {PrivKey, PubKey}, true, ExtraVars),
+
+    Chain = blockchain_worker:blockchain(),
+    Swarm = blockchain_swarm:swarm(),
+    N = length(ConsensusMembers),
+
+    % Check ledger to make sure everyone has the right balance
+    Ledger = blockchain:ledger(Chain),
+    Entries = blockchain_ledger_v1:entries(Ledger),
+    _ = lists:foreach(fun(Entry) ->
+                              Balance = blockchain_ledger_entry_v1:balance(Entry),
+                              0 = blockchain_ledger_entry_v1:nonce(Entry)
+                      end, maps:values(Entries)),
+
+    meck:new(blockchain_ledger_v1, [passthrough]),
+
+    [
+     {balance, Balance},
+     {sup, Sup},
+     {pubkey, PubKey},
+     {privkey, PrivKey},
+     {opts, Opts},
+     {chain, Chain},
+     {swarm, Swarm},
+     {n, N},
+     {consensus_members, ConsensusMembers},
+     {genesis_members, GenesisMembers},
+     Keys
+     | Config0
+    ].
+
+%%--------------------------------------------------------------------
+%% TEST CASE TEARDOWN
+%%--------------------------------------------------------------------
+
+end_per_testcase(_, Config) ->
+    meck:unload(blockchain_ledger_v1),
+    Sup = ?config(sup, Config),
+    % Make sure blockchain saved on file = in memory
+    case erlang:is_process_alive(Sup) of
+        true ->
+            true = erlang:exit(Sup, normal),
+            ok = test_utils:wait_until(fun() -> false =:= erlang:is_process_alive(Sup) end);
+        false ->
+            ok
+    end,
+    ok.
+
+%%--------------------------------------------------------------------
+%% TEST CASES
+%%--------------------------------------------------------------------
+
+enable_htlc_receipt_test(Config) ->
+    ConsensusMembers = ?config(consensus_members, Config),
+    Chain = ?config(chain, Config),
+
+    meck:expect(
+        blockchain_ledger_v1,
+        current_oracle_price,
+        fun(_) ->
+                {ok, 15 * ?BONES_PER_HNT}
+        end
+    ),
+
+    %% Set env to store htlc receipts %%
+    ok = application:set_env(blockchain, store_htlc_receipts, true),
+
+    %% Test a payment transaction, add a block and check balances
+    [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
+
+    % Create a Payee
+    #{public := PayeePubKey, secret := PayeePrivKey} = libp2p_crypto:generate_keys(ecc_compact),
+    Payee = libp2p_crypto:pubkey_to_bin(PayeePubKey),
+    Amount = 250 * ?BONES_PER_HNT,
+    % Generate a random address
+    HTLCAddress = crypto:strong_rand_bytes(33),
+    % Create a Hashlock
+    Hashlock = crypto:hash(sha256, <<"wenmoon">>),
+    HTLC0 = blockchain_txn_create_htlc_v1:new(Payer, Payee, HTLCAddress, Hashlock, 3, Amount, 1),
+    Fee0 = blockchain_txn_create_htlc_v1:calculate_fee(HTLC0, Chain),
+    HTLC1 = blockchain_txn_create_htlc_v1:fee(HTLC0, Fee0),
+    SigFun = libp2p_crypto:mk_sig_fun(PayerPrivKey),
+    SignedHTLC1 = blockchain_txn_create_htlc_v1:sign(HTLC1, SigFun),
+
+    ct:pal("~s", [blockchain_txn:print(SignedHTLC1)]),
+
+    % send some money to the payee so they have enough to pay the fee for redeeming
+    Tx0 = blockchain_txn_payment_v1:new(Payer, Payee, 100 * ?BONES_PER_HNT, 2),
+    Fee = blockchain_txn_payment_v1:calculate_fee(Tx0, Chain),
+    Tx1 = blockchain_txn_payment_v1:fee(Tx0, Fee),
+    SigFun = libp2p_crypto:mk_sig_fun(PayerPrivKey),
+    SignedTx = blockchain_txn_payment_v1:sign(Tx1, SigFun),
+
+    ct:pal("~s", [blockchain_txn:print(SignedTx)]),
+
+    %% check both txns are valid, in context
+    ?assertMatch({_, []}, blockchain_txn:validate([SignedHTLC1, SignedTx], Chain)),
+
+    {ok, Block} = test_utils:create_block(ConsensusMembers, [SignedHTLC1, SignedTx]),
+    _ = blockchain_gossip_handler:add_block(Block, Chain, self(), blockchain_swarm:swarm()),
+
+    % Try and redeem
+    RedeemSigFun = libp2p_crypto:mk_sig_fun(PayeePrivKey),
+    RedeemTx0 = blockchain_txn_redeem_htlc_v1:new(Payee, HTLCAddress, <<"wenmoon">>),
+    RedeemFee = blockchain_txn_redeem_htlc_v1:calculate_fee(RedeemTx0, Chain),
+    RedeemTx1 = blockchain_txn_redeem_htlc_v1:fee(RedeemTx0, RedeemFee),
+    SignedRedeemTx = blockchain_txn_redeem_htlc_v1:sign(RedeemTx1, RedeemSigFun),
+    {ok, Block2} = test_utils:create_block(ConsensusMembers, [SignedRedeemTx]),
+    _ = blockchain_gossip_handler:add_block(Block2, Chain, self(), blockchain_swarm:swarm()),
+    timer:sleep(500), %% add block is a cast, need some time for this to happen
+
+    %% Check that there is a htlc receipt
+    {ok, HTLCReceipt} = blockchain:get_htlc_receipt(HTLCAddress, Chain),
+
+    %% Check that the receipt was stored correctly
+    ?assertEqual(Payer, blockchain_htlc_receipt:payer(HTLCReceipt)),
+    ?assertEqual(Payee, blockchain_htlc_receipt:payee(HTLCReceipt)),
+    ?assertEqual(HTLCAddress, blockchain_htlc_receipt:address(HTLCReceipt)),
+    ?assertEqual(Amount, blockchain_htlc_receipt:balance(HTLCReceipt)),
+    ?assertEqual(Hashlock, blockchain_htlc_receipt:hashlock(HTLCReceipt)),
+    ?assertEqual(3, blockchain_htlc_receipt:timelock(HTLCReceipt)),
+    ?assertEqual(1, blockchain_htlc_receipt:redeemed_at(HTLCReceipt)),
+
+    ct:pal("HTLC Receipt: ~p", [HTLCReceipt]),
+
+    ok.
+
+disabled_htlc_receipt_test(Config) ->
+    ConsensusMembers = ?config(consensus_members, Config),
+    Chain = ?config(chain, Config),
+
+    meck:expect(
+        blockchain_ledger_v1,
+        current_oracle_price,
+        fun(_) ->
+                {ok, 15 * ?BONES_PER_HNT}
+        end
+    ),
+
+    %% Set env to NOT store htlc receipts %%
+    ok = application:set_env(blockchain, store_htlc_receipts, false),
+
+    %% Test a payment transaction, add a block and check balances
+    [_, {Payer, {_, PayerPrivKey, _}}|_] = ConsensusMembers,
+
+    % Create a Payee
+    #{public := PayeePubKey, secret := PayeePrivKey} = libp2p_crypto:generate_keys(ecc_compact),
+    Payee = libp2p_crypto:pubkey_to_bin(PayeePubKey),
+    Amount = 250 * ?BONES_PER_HNT,
+    % Generate a random address
+    HTLCAddress = crypto:strong_rand_bytes(33),
+    % Create a Hashlock
+    Hashlock = crypto:hash(sha256, <<"wenmoon">>),
+    HTLC0 = blockchain_txn_create_htlc_v1:new(Payer, Payee, HTLCAddress, Hashlock, 3, Amount, 1),
+    Fee0 = blockchain_txn_create_htlc_v1:calculate_fee(HTLC0, Chain),
+    HTLC1 = blockchain_txn_create_htlc_v1:fee(HTLC0, Fee0),
+    SigFun = libp2p_crypto:mk_sig_fun(PayerPrivKey),
+    SignedHTLC1 = blockchain_txn_create_htlc_v1:sign(HTLC1, SigFun),
+
+    ct:pal("~s", [blockchain_txn:print(SignedHTLC1)]),
+
+    % send some money to the payee so they have enough to pay the fee for redeeming
+    Tx0 = blockchain_txn_payment_v1:new(Payer, Payee, 100 * ?BONES_PER_HNT, 2),
+    Fee = blockchain_txn_payment_v1:calculate_fee(Tx0, Chain),
+    Tx1 = blockchain_txn_payment_v1:fee(Tx0, Fee),
+    SigFun = libp2p_crypto:mk_sig_fun(PayerPrivKey),
+    SignedTx = blockchain_txn_payment_v1:sign(Tx1, SigFun),
+
+    ct:pal("~s", [blockchain_txn:print(SignedTx)]),
+
+    %% check both txns are valid, in context
+    ?assertMatch({_, []}, blockchain_txn:validate([SignedHTLC1, SignedTx], Chain)),
+
+    {ok, Block} = test_utils:create_block(ConsensusMembers, [SignedHTLC1, SignedTx]),
+    _ = blockchain_gossip_handler:add_block(Block, Chain, self(), blockchain_swarm:swarm()),
+
+    % Try and redeem
+    RedeemSigFun = libp2p_crypto:mk_sig_fun(PayeePrivKey),
+    RedeemTx0 = blockchain_txn_redeem_htlc_v1:new(Payee, HTLCAddress, <<"wenmoon">>),
+    RedeemFee = blockchain_txn_redeem_htlc_v1:calculate_fee(RedeemTx0, Chain),
+    RedeemTx1 = blockchain_txn_redeem_htlc_v1:fee(RedeemTx0, RedeemFee),
+    SignedRedeemTx = blockchain_txn_redeem_htlc_v1:sign(RedeemTx1, RedeemSigFun),
+    {ok, Block2} = test_utils:create_block(ConsensusMembers, [SignedRedeemTx]),
+    _ = blockchain_gossip_handler:add_block(Block2, Chain, self(), blockchain_swarm:swarm()),
+    timer:sleep(500), %% add block is a cast, need some time for this to happen
+
+    %% Check that there is NO htlc receipt
+    {error, not_found} = blockchain:get_htlc_receipt(HTLCAddress, Chain),
+
+    ct:pal("Confirmed that htlc receipt has not been stored for ~p", [HTLCAddress]),
+    ok.
+
+%%--------------------------------------------------------------------
+%% HELPERS
+%%--------------------------------------------------------------------
+extra_vars(_) ->
+    #{?txn_fees => true, ?max_payments => ?MAX_PAYMENTS, ?allow_zero_amount => false, ?txn_fee_multiplier => 5000}.


### PR DESCRIPTION
HTLCs are a great tool for facilitating trust minimized cross-chain transactions. As Helium becomes more popular, people are likely to increase their usage of HTLC transactions (create/redeem). As such, HTLCs will likely become an essential transaction that the [Rosetta API](https://github.com/syuan100/rosetta-helium) will need to account for.

## Purpose
There is a fundamental lack of information in the transaction when a payee is redeeming a HTLC. Tracking `blockchain_txn_create_htlc_v1` is not a problem and all necessary information is present in the transaction at the time of creation for accounting purposes (amount, payee, payer, address, hashlock, timelock). However, `blockchain_txn_redeem_htlc_v1` strips out a lot of that information... namely the amount. Without the amount information present in the transaction itself, Rosetta isn't able to know how much HNT was actually redeemed, just that it took place. Unfortunately, this isn't acceptable for a full Rosetta implementation, so this PR aims to enable `blockchain-core` to store receipts of successful HTLC redemptions.

## Implementation
Instead of creating a v2 transaction, I decided to create a new CF in the DB similar to what was done for [implicit burn tracking](https://github.com/helium/blockchain-core/pull/771). If the enabled, then we will store a record in `HTLCReceiptsCF` with the HTLC address as the key.

HTLC information that is stored:
```
"address" - HTLC Address
"balance" - Amount of HNT in HTLC
"hashlock" - Base64 representation of the pre-image hash
"payee" - Receiver Address
"payer" - Sender Address
"redeemed_at" - Blocknheight when the HTLC was redeemed
"timelock" - Original timelock length in # of blocks
```

## Activation
Just like storing implicit burns, storing HTLC receipts is not enabled by default. If you want your build of core to be able to store htlc receipts, you will need to specify it in the build environment where the variable `store_htlc_receipts` is set to `true`. In blockchain-node, this is specified in the build config files.

## Related PRs/Branches
Related branch in [blockchain-node](https://github.com/syuan100/blockchain-node/tree/add-htlc-endpoint). Note: This branch is based off of the `rosetta-api` branch which has not been merged into master yet. This branch enables the JSONRPC method `htlc_get` that takes the HTLC address as a parameter and returns the JSON version of the HTLC or HTLC receipt.

## Questions/concerns
- I was able to take a crack at writing a test this time around. However, a bunch of other tests are failing for me (even on master). Not sure if this is ok for now.
- As always, I'm open to any feedback/suggestions to improve this PR. Thank you!