### PR TITLE
Add `has_witnesses` check to `filter_interactive_gws` 

### DIFF
--- a/src/blockchain_hex.erl
+++ b/src/blockchain_hex.erl
@@ -199,7 +199,6 @@ calculate_densities(H3Index, VarMap, Ledger) ->
                             {error, not_found} -> 0 % XXX what should this value be?
                         end,
     Locations = blockchain_ledger_v1:lookup_gateways_from_hex(h3:k_ring(H3Index, 2), Ledger),
-
     Interactive = case application:get_env(blockchain, hip17_test_mode, false) of
                       true ->
                           %% HIP17 test mode, no interactive filtering
@@ -293,7 +292,8 @@ build_densities(H3Root, Ledger, VarMap, ChildHexes, {UAcc, Acc}, [Res | Tail]) -
     [libp2p_crypto:pubkey_bin(), ...].
 %% @doc This function filters a list of gateway addresses which are considered
 %% "interactive" for the purposes of HIP17 based on the last block when it
-%% responded to a POC challenge compared to the current chain height.
+%% responded to a POC challenge compared to the current chain height and if it
+%% has valid witnesses or not.
 filter_interactive_gws(GWs, InteractiveBlocks, Ledger) ->
     {ok, CurrentHeight} = blockchain_ledger_v1:current_height(Ledger),
     lists:filter(fun(GWAddr) ->
@@ -306,7 +306,7 @@ filter_interactive_gws(GWs, InteractiveBlocks, Ledger) ->
                         HasWitnesses = case blockchain_ledger_v1:find_gateway_has_witnesses(GWAddr) of
                             {ok, undefined} -> false;
                             {ok, HasWitnesses} -> 
-                                HasWitnesses; %% Just trying to keep the same format as above ... not sure of importance
+                                HasWitnesses;
                             {error, not_found} -> false
                         end,
                         IsInteractive and HasWitnesses

--- a/src/blockchain_hex.erl
+++ b/src/blockchain_hex.erl
@@ -297,12 +297,19 @@ build_densities(H3Root, Ledger, VarMap, ChildHexes, {UAcc, Acc}, [Res | Tail]) -
 filter_interactive_gws(GWs, InteractiveBlocks, Ledger) ->
     {ok, CurrentHeight} = blockchain_ledger_v1:current_height(Ledger),
     lists:filter(fun(GWAddr) ->
-                         case blockchain_ledger_v1:find_gateway_last_challenge(GWAddr, Ledger) of
-                             {ok, undefined} -> false;
-                             {ok, LastChallenge} ->
-                                 (CurrentHeight - LastChallenge) =< InteractiveBlocks;
-                             {error, not_found} -> false
-                         end
+                        IsInteractive = case blockchain_ledger_v1:find_gateway_last_challenge(GWAddr, Ledger) of
+                            {ok, undefined} -> false;
+                            {ok, LastChallenge} ->
+                                (CurrentHeight - LastChallenge) =< InteractiveBlocks;
+                            {error, not_found} -> false
+                        end,
+                        HasWitnesses = case blockchain_ledger_v1:find_gateway_has_witnesses(GWAddr) of
+                            {ok, undefined} -> false;
+                            {ok, HasWitnesses} -> 
+                                HasWitnesses; %% Just trying to keep the same format as above ... not sure of importance
+                            {error, not_found} -> false
+                        end,
+                        IsInteractive and HasWitnesses
                     end, GWs).
 
 -spec limit(

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -1549,7 +1549,7 @@ find_gateway_has_witnesses(Address, Ledger) ->
                 {ok, BinGw} ->
                     Gw = blockchain_ledger_gateway_v2:deserialize(BinGw),
                     Witnesses = blockchain_ledger_gateway_v2:witnesses(Gw),
-                    HasWitnesses = map_size(Witnesses) > 0, %% Not sure if this "waterfall" is the right way todo this
+                    HasWitnesses = map_size(Witnesses) > 1, %% Not sure if this "waterfall" is the right way todo this
                     {ok, HasWitnesses};
                 not_found ->
                     {error, not_found};


### PR DESCRIPTION
# The Issue

With the current system it's possible to adversely affect another hotspot by remotely asserting one hotspot directly ontop of a target hotspot. This results in the ability to lower the target hotspots transmit reward scale by a factor equal to the number of hotspots used to target the area.

This PR will not permenantly fix the issue if someone was determined enough to attempt this while being close to the target hotspots location. However, this will help protect against the scenario where the hotspot is located in a different state/country and would be still able to adversely affect the transmit reward scale of the target.

This could allow "bad actors" the ability to reduce the top performing hotspots on the network by 50% while not doing anything aside from remotely asserting cannon fodder to do it.

# The Proof

After reviewing the code, I noticed that it could be possible for a hotspot that is physically located in a different geographical location than it's `assert_location` could be considered interactive due to the fact that the `last_poc_challenge` variable was used to validate this state. The issue is that `last_poc_challenge` is updated on the creation of a `poc_request` which is all done network side as long as the hotspot meets 3 requirements. 1) Has an asserted location, 2) is synced to the blockchain, 3) and is outside it's `poc_interval` number of blocks from their last submission.

To put this theory to practice;
1) I was able to take 2 hotspots one with an antenna attached and one without an antenna and asserted them next to my lone wolf hotspot. These two hotspots were physically located in a completely different state, the one with the antenna was still collecting witnesses (zero of these witnesses being valid), but both still were considered interactive in regards to HIP17.
2) After the hotspots `assert_locations` were accepted and they met the above 3 conditions they successfully scaled my lone wolf hotspot from a transmit reward scale of 1.0 => 0.33.

# The Solution

Upon further review of the code and how the blockchain handles current witnesses and PoC receipts, I decided the best bandaid for now would be to add an additional check to ensure that to be considered an interactive hotspot, it has to have valid witnesses. The current system wipes the witnesses upon `assert_locations` and they are only added to the witness list if they are valid in regards to RSSI/SNR. This will ensure that a hotspot wouldn't be considered interactive unless they've recently created a PoC request and have valid witnesses for that location.