### PR TITLE
Check for a rewards_metadata in rewards_v2 to_json opts

### DIFF
--- a/src/transactions/v2/blockchain_txn_rewards_v2.erl
+++ b/src/transactions/v2/blockchain_txn_rewards_v2.erl
@@ -343,7 +343,10 @@ to_json(Txn, Opts) ->
             Start = blockchain_txn_rewards_v2:start_epoch(Txn),
             End = ?MODULE:end_epoch(Txn),
             {ok, Ledger} = blockchain:ledger_at(End, Chain),
-            {ok, Metadata} = ?MODULE:calculate_rewards_metadata(Start, End, Chain),
+            {ok, Metadata} = case lists:keyfind(rewards_metadata, 1, Opts) of
+                                {rewards_metadata, M} -> {ok, M};
+                                _ -> ?MODULE:calculate_rewards_metadata(Start, End, Chain)
+                            end,
             maps:fold(
                 fun(overages, Amount, Acc) ->
                         [#{amount => Amount,


### PR DESCRIPTION
This allows for a caller to have precomputed rewards_metadat already to be reused