### PR TITLE
Fix performance of snapshot loads in direct mode

### DIFF
--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -403,6 +403,8 @@ import(Chain, SHA, #{version := v6}=Snapshot) ->
 
     %% open ledger with compaction disabled so
     %% we can bulk load
+    {ok, Cache} = rocksdb:new_cache(lru, 10 * 8 * 1024 * 1024),
+    {ok, BufferMgr} = rocksdb:new_write_buffer_manager(10 * 8 * 1024 * 1024, Cache),
     Ledger0 = blockchain_ledger_v1:new(
                 Dir,
                 false,
@@ -422,7 +424,8 @@ import(Chain, SHA, #{version := v6}=Snapshot) ->
                     {max_compaction_bytes, 1 bsl 60},
                     {target_file_size_base, 8388608},
                     {atomic_flush, false},
-                    {write_buffer_size, 8388608}
+                    {write_buffer_size, 8388608},
+                    {write_buffer_manager, BufferMgr}
                 ]
                ),
 
@@ -450,6 +453,8 @@ import(Chain, SHA, #{version := v6}=Snapshot) ->
     end,
     %% re-open the ledger with the normal options
     blockchain_ledger_v1:close(Ledger0),
+    rocksdb:release_write_buffer_manager(BufferMgr),
+    rocksdb:release_cache(Cache),
     Ledger1 = blockchain_ledger_v1:new(
       Dir,
       blockchain:db_handle(Chain),

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -410,7 +410,20 @@ import(Chain, SHA, #{version := v6}=Snapshot) ->
                 blockchain:blocks_cf(Chain),
                 blockchain:heights_cf(Chain),
                 %% these options taken from rocksdb's PrepareForBulkLoad()
-                [{disable_auto_compactions, true}, {num_levels, 2}, {max_write_buffer_number, 10}, {min_write_buffer_number_to_merge, 1}, {max_background_flushes, 4}, {level0_file_num_compaction_trigger, 1 bsl 30}, {level0_slowdown_writes_trigger, 1 bsl 30}, {level0_stop_writes_trigger, 1 bsl 30}, {max_compaction_bytes, 1 bsl 60}, {target_file_size_base, 8388608}, {atomic_flush, false}, {write_buffer_size, 8388608}]
+                [
+                    {disable_auto_compactions, true},
+                    {num_levels, 2},
+                    {max_write_buffer_number, 10},
+                    {min_write_buffer_number_to_merge, 1},
+                    {max_background_flushes, 4},
+                    {level0_file_num_compaction_trigger, 1 bsl 30},
+                    {level0_slowdown_writes_trigger, 1 bsl 30},
+                    {level0_stop_writes_trigger, 1 bsl 30},
+                    {max_compaction_bytes, 1 bsl 60},
+                    {target_file_size_base, 8388608},
+                    {atomic_flush, false},
+                    {write_buffer_size, 8388608}
+                ]
                ),
 
     %% we load up both with the same snapshot here, then sync the next N

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -392,20 +392,27 @@ deserialize(DigestOpt, <<Bin0/binary>>) ->
 import(Chain, SHA, #{version := v6}=Snapshot) ->
     CLedger = blockchain:ledger(Chain),
     Dir = blockchain:dir(Chain),
-    Ledger0 =
-        case catch blockchain_ledger_v1:current_height(CLedger) of
-            %% nothing in there, proceed
-            {ok, 1} ->
-                CLedger;
-            _ ->
-                blockchain_ledger_v1:clean(CLedger),
-                blockchain_ledger_v1:new(
-                    Dir,
-                    blockchain:db_handle(Chain),
-                    blockchain:blocks_cf(Chain),
-                    blockchain:heights_cf(Chain)
-                )
-        end,
+    %% check if we need to wipe the ledger
+    case catch blockchain_ledger_v1:current_height(CLedger) of
+        %% nothing in there, proceed
+        {ok, 1} ->
+            blockchain_ledger_v1:close(CLedger);
+        _ ->
+            blockchain_ledger_v1:clean(CLedger)
+    end,
+
+    %% open ledger with compaction disabled so
+    %% we can bulk load
+    Ledger0 = blockchain_ledger_v1:new(
+                Dir,
+                false,
+                blockchain:db_handle(Chain),
+                blockchain:blocks_cf(Chain),
+                blockchain:heights_cf(Chain),
+                %% these options taken from rocksdb's PrepareForBulkLoad()
+                [{disable_auto_compactions, true}, {num_levels, 2}, {max_write_buffer_number, 10}, {min_write_buffer_number_to_merge, 1}, {max_background_flushes, 4}, {level0_file_num_compaction_trigger, 1 bsl 30}, {level0_slowdown_writes_trigger, 1 bsl 30}, {level0_stop_writes_trigger, 1 bsl 30}, {max_compaction_bytes, 1 bsl 60}, {target_file_size_base, 8388608}, {atomic_flush, false}, {write_buffer_size, 8388608}]
+               ),
+
     %% we load up both with the same snapshot here, then sync the next N
     %% blocks and check that we're valid.
     [load_into_ledger(Snapshot, Ledger0, Mode)
@@ -428,7 +435,18 @@ import(Chain, SHA, #{version := v6}=Snapshot) ->
         {error, _} ->
             blockchain:add_snapshot(Snapshot, Chain)
     end,
-    Ledger0.
+    %% re-open the ledger with the normal options
+    blockchain_ledger_v1:close(Ledger0),
+    Ledger1 = blockchain_ledger_v1:new(
+      Dir,
+      blockchain:db_handle(Chain),
+      blockchain:blocks_cf(Chain),
+      blockchain:heights_cf(Chain)
+     ),
+    %% and then compact the ledger
+    blockchain_ledger_v1:compact(Ledger1),
+    Ledger1.
+
 
 -spec load_into_ledger(snapshot(), L, M) -> ok when
     L :: blockchain_ledger_v1:ledger(),

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -403,8 +403,6 @@ import(Chain, SHA, #{version := v6}=Snapshot) ->
 
     %% open ledger with compaction disabled so
     %% we can bulk load
-    {ok, Cache} = rocksdb:new_cache(lru, 10 * 8 * 1024 * 1024),
-    {ok, BufferMgr} = rocksdb:new_write_buffer_manager(10 * 8 * 1024 * 1024, Cache),
     Ledger0 = blockchain_ledger_v1:new(
                 Dir,
                 false,
@@ -424,8 +422,7 @@ import(Chain, SHA, #{version := v6}=Snapshot) ->
                     {max_compaction_bytes, 1 bsl 60},
                     {target_file_size_base, 8388608},
                     {atomic_flush, false},
-                    {write_buffer_size, 8388608},
-                    {write_buffer_manager, BufferMgr}
+                    {write_buffer_size, 8388608}
                 ]
                ),
 
@@ -453,8 +450,6 @@ import(Chain, SHA, #{version := v6}=Snapshot) ->
     end,
     %% re-open the ledger with the normal options
     blockchain_ledger_v1:close(Ledger0),
-    rocksdb:release_write_buffer_manager(BufferMgr),
-    rocksdb:release_cache(Cache),
     Ledger1 = blockchain_ledger_v1:new(
       Dir,
       blockchain:db_handle(Chain),

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -3478,7 +3478,10 @@ clean(#ledger_v1{dir=Dir, db=DB}=L) ->
     catch ok = rocksdb:close(DB),
     rocksdb:destroy(DBDir, []),
     clean_checkpoints(L),
-    clean_aux(L).
+    clean_aux(L);
+clean(Dir) ->
+    DBDir = filename:join(Dir, ?DB_FILE),
+    rocksdb:destroy(DBDir, []).
 
 clean_aux(L) ->
     case has_aux(L) of

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -3818,7 +3818,7 @@ validators_cf(Ledger) ->
 cache_put(Ledger, {Name, _DB, _CF}, Key, Value) ->
     case context_cache(Ledger) of
         {direct, _GwCache} ->
-            rocksdb:put(Ledger#ledger_v1.db, _CF, Key, Value, [{disable_wal, true}, {sync, false}]);
+            rocksdb:put(db(Ledger), _CF, Key, Value, [{disable_wal, true}, {sync, false}]);
         {Cache, _GwCache} ->
             true = ets:insert(Cache, {{Name, Key}, Value})
     end,
@@ -3849,7 +3849,7 @@ cache_delete(Ledger, {Name, _DB, _CF}, Key) ->
     %% we never delete gateways now
     case context_cache(Ledger) of
         {direct, _GWCache} ->
-            rocksdb:delete(Ledger#ledger_v1.db, _CF, Key, []);
+            rocksdb:delete(db(Ledger), _CF, Key, []);
         {Cache, _GwCache} ->
             true = ets:insert(Cache, {{Name, Key}, ?CACHE_TOMBSTONE})
     end,

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -5044,7 +5044,7 @@ snapshot_h3dex(Ledger) ->
 
 -spec load_h3dex([{binary(), binary()}], ledger()) -> ok.
 load_h3dex(H3DexList, Ledger) ->
-    H3CF = h3dex_cf(Ledger),
+    {_Name, DB, H3CF} = h3dex_cf(Ledger),
     {ok, Batch0} = rocksdb:batch(),
     BatchSize = application:get_env(blockchain, snapshot_load_batch_size, 100),
     FinalBatch = lists:foldl(fun({Loc, Gateways}, Batch) ->
@@ -5053,7 +5053,7 @@ load_h3dex(H3DexList, Ledger) ->
                          rocksdb:batch_put(Batch, H3CF, BinLoc, BinGWs),
                          case rocksdb:batch_count(Batch) > BatchSize of
                              true ->
-                                 rocksdb:write_batch(db(Ledger), Batch, []),
+                                 rocksdb:write_batch(DB, Batch, []),
                                  {ok, NewBatch} = rocksdb:batch(),
                                  NewBatch;
                              false ->
@@ -5061,7 +5061,7 @@ load_h3dex(H3DexList, Ledger) ->
                          end
                  end, Batch0, H3DexList),
 
-    rocksdb:write_batch(db(Ledger), FinalBatch, []),
+    rocksdb:write_batch(DB, FinalBatch, []),
     ok.
 
 -spec get_sc_mod( Entry :: blockchain_ledger_state_channel_v1:state_channel() |

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -4821,7 +4821,7 @@ load_raw(KVL, {_Name, DB, CF}, _Ledger) ->
     {ok, Batch0} = rocksdb:batch(),
     FinalBatch = lists:foldl(fun({K, V}, Batch) ->
                         rocksdb:batch_put(Batch, CF, K, V),
-                        case rocksdb:batch_count(Batch) > 100 of
+                        case rocksdb:batch_count(Batch) > BatchSize of
                             true ->
                                 rocksdb:write_batch(DB, Batch, []),
                                 {ok, NewBatch} = rocksdb:batch(),

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -5,7 +5,7 @@
 -module(blockchain_ledger_v1).
 
 -export([
-    new/1, new/4, new/5,
+    new/1, new/4, new/5, new/6,
     new_aux/1,
     bootstrap_aux/2,
     mode/1, mode/2,
@@ -356,11 +356,15 @@ new(Dir) ->
 
 -spec new(file:filename_all(), rocksdb:db_handle(), rocksdb:cf_handle(), rocksdb:cf_handle()) -> ledger().
 new(Dir, BlocksDB, BlocksCF, HeightsCF) ->
-    new(Dir, false, BlocksDB, BlocksCF, HeightsCF).
+    new(Dir, false, BlocksDB, BlocksCF, HeightsCF, []).
 
 -spec new(file:filename_all(), boolean(), rocksdb:db_handle(), rocksdb:cf_handle(), rocksdb:cf_handle()) -> ledger().
 new(Dir, ReadOnly, BlocksDB, BlocksCF, HeightsCF) ->
-    L = new(Dir, ReadOnly),
+    new(Dir, ReadOnly, BlocksDB, BlocksCF, HeightsCF, []).
+
+-spec new(file:filename_all(), boolean(), rocksdb:db_handle(), rocksdb:cf_handle(), rocksdb:cf_handle(), rocksdb:cf_options()) -> ledger().
+new(Dir, ReadOnly, BlocksDB, BlocksCF, HeightsCF, Options) ->
+    L = new(Dir, ReadOnly, Options),
 
     %% allow config-set commit hooks in case we're worried about something being racy
     Hooks =
@@ -376,8 +380,8 @@ new(Dir, ReadOnly, BlocksDB, BlocksCF, HeightsCF) ->
     sweep_old_checkpoints(Ledger),
     Ledger.
 
-new(Dir, ReadOnly) ->
-    {ok, DB, CFs} = open_db(active, Dir, true, ReadOnly),
+new(Dir, ReadOnly, Options) ->
+    {ok, DB, CFs} = open_db(active, Dir, true, ReadOnly, Options),
 
     [DefaultCF, AGwsCF, EntriesCF, DCEntriesCF, HTLCsCF, PoCsCF, SecuritiesCF, RoutingCF,
      SubnetsCF, SCsCF, H3DexCF, GwDenormCF, ValidatorsCF,
@@ -476,7 +480,7 @@ new_aux(Ledger) ->
     end.
 
 new_aux(Path, Ledger) ->
-    {ok, DB, CFs} = open_db(aux, Path, false, false),
+    {ok, DB, CFs} = open_db(aux, Path, false, false, []),
     [DefaultCF, AGwsCF, EntriesCF, DCEntriesCF, HTLCsCF, PoCsCF, SecuritiesCF, RoutingCF,
      SubnetsCF, SCsCF, H3DexCF, GwDenormCF, ValidatorsCF, AuxHeightsCF] = CFs,
     Ledger#ledger_v1{aux=#aux_ledger_v1{
@@ -785,7 +789,7 @@ context_snapshot(#ledger_v1{db=DB, snapshots=Cache, mode=Mode} = Ledger) ->
                                             ok
                                     end,
                                     %% open the checkpoint read-write and commit the changes in the ETS table into it
-                                    Ledger2 = new(filename:dirname(TmpDir), false),
+                                    Ledger2 = new(filename:dirname(TmpDir), false, []),
                                     Ledger3 = blockchain_ledger_v1:mode(Mode, Ledger2),
                                     #sub_ledger_v1{cache=ECache, gateway_cache=GwCache} = subledger(Ledger),
                                     lager:info("dumping ~p elements to checkpoint in ~p mode", [length(ets:tab2list(ECache)), Mode]),
@@ -865,7 +869,7 @@ has_snapshot(Height, #ledger_v1{snapshots=Cache} = Ledger, Retries) ->
                             try
                                 lager:info("loading checkpoint from disk with ledger mode ~p", [Mode]),
                                 %% new/2 wants to add on the ledger.db part itself
-                                NewLedger = new(filename:dirname(CheckpointDir), true),
+                                NewLedger = new(filename:dirname(CheckpointDir), true, []),
                                 %% share the snapshot cache with the new ledger
                                 NewLedger2 = blockchain_ledger_v1:mode(Mode,
                                                                        NewLedger#ledger_v1{
@@ -3814,7 +3818,7 @@ validators_cf(Ledger) ->
 cache_put(Ledger, {Name, _DB, _CF}, Key, Value) ->
     case context_cache(Ledger) of
         {direct, _GwCache} ->
-            rocksdb:put(Ledger#ledger_v1.db, _CF, Key, Value, []);
+            rocksdb:put(Ledger#ledger_v1.db, _CF, Key, Value, [{disable_wal, true}, {sync, false}]);
         {Cache, _GwCache} ->
             true = ets:insert(Cache, {{Name, Key}, Value})
     end,
@@ -3952,26 +3956,26 @@ process_fun(ToProcess, Cache, CF,
 
 -spec open_db(Mode :: mode(),
               Dir :: file:filename_all(),
-              HasDelayed :: boolean(), ReadOnly :: boolean()) -> {ok, rocksdb:db_handle(), [rocksdb:cf_handle()]} | {error, any()}.
-open_db(active, Dir, true, ReadOnly) ->
+              HasDelayed :: boolean(), ReadOnly :: boolean(), Options :: rocksdb:cf_options()) -> {ok, rocksdb:db_handle(), [rocksdb:cf_handle()]} | {error, any()}.
+open_db(active, Dir, true, ReadOnly, Options) ->
     DBDir = filename:join(Dir, ?DB_FILE),
     ok = filelib:ensure_dir(DBDir),
     GlobalOpts = application:get_env(rocksdb, global_opts, []),
-    DBOptions = [{create_if_missing, true}, {atomic_flush, true}] ++ GlobalOpts,
+    DBOptions = lists:keymerge(1, lists:ukeysort(1, Options), lists:ukeysort(1, [{create_if_missing, true}, {atomic_flush, true}] ++ GlobalOpts)),
     CFOpts = GlobalOpts,
     DefaultCFs = default_cfs() ++ delayed_cfs(),
-    open_db_(DBDir, DBOptions, DefaultCFs, CFOpts, ReadOnly, false);
-open_db(aux, Dir, false, ReadOnly) ->
+    open_db_(DBDir, DBOptions, DefaultCFs, lists:keymerge(1, lists:ukeysort(1, Options), lists:ukeysort(1, CFOpts)), ReadOnly, false);
+open_db(aux, Dir, false, ReadOnly, Options) ->
     DBDir = filename:join(Dir, ?DB_FILE),
     ok = filelib:ensure_dir(DBDir),
     GlobalOpts = application:get_env(rocksdb, global_opts, []),
-    DBOptions = [{create_if_missing, true}, {atomic_flush, true}] ++ GlobalOpts,
+    DBOptions = lists:keymerge(1, lists:ukeysort(1, Options), lists:ukeysort(1, [{create_if_missing, true}, {atomic_flush, true}] ++ GlobalOpts)),
     CFOpts = GlobalOpts,
     DefaultCFs = default_cfs() ++ aux_cfs(),
-    open_db_(DBDir, DBOptions, DefaultCFs, CFOpts, ReadOnly, false);
-open_db(active, _Dir, false, _) ->
+    open_db_(DBDir, DBOptions, DefaultCFs, lists:keymerge(1, lists:ukeysort(1, Options), lists:ukeysort(1, CFOpts)), ReadOnly, false);
+open_db(active, _Dir, false, _, _) ->
     {error, not_opening_active_without_delayed};
-open_db(aux, _Dir, true, _) ->
+open_db(aux, _Dir, true, _, _) ->
     {error, not_opening_aux_with_delayed}.
 
 open_db_(DBDir, DBOptions, DefaultCFs, CFOpts, ReadOnly, Retry) ->
@@ -4811,8 +4815,23 @@ snapshot_raw(CF, L) ->
     lists:reverse(cache_fold(L, CF, fun({_, _}=KV, KVs) -> [KV | KVs] end, [])).
 
 -spec load_raw([{binary(), binary()}], rocksdb:cf_handle(), ledger()) -> ok.
-load_raw(KVL, CF, Ledger) ->
-    lists:foreach(fun({K, V}) -> cache_put(Ledger, CF, K, V) end, KVL).
+load_raw(KVL, {_Name, DB, CF}, _Ledger) ->
+    %% you can probably make this much larger on larger machines
+    BatchSize = application:get_env(blockchain, snapshot_load_batch_size, 100),
+    {ok, Batch0} = rocksdb:batch(),
+    FinalBatch = lists:foldl(fun({K, V}, Batch) ->
+                        rocksdb:batch_put(Batch, CF, K, V),
+                        case rocksdb:batch_count(Batch) > 100 of
+                            true ->
+                                rocksdb:write_batch(DB, Batch, []),
+                                {ok, NewBatch} = rocksdb:batch(),
+                                NewBatch;
+                            false ->
+                                Batch
+                        end
+                end, Batch0, KVL),
+    rocksdb:write_batch(DB, FinalBatch, []),
+    ok.
 
 -spec snapshot_raw_pocs(ledger()) -> [{binary(), binary()}].
 snapshot_raw_pocs(Ledger) ->


### PR DESCRIPTION
The performance of direct loading snapshots was terrible because rocksdb
rapidly got stuck doing compactions constantly. This change both tunes
rocksdb for bulk loading while loading snapshots as well as uses a
configurable sized rocksdb batch in ledger:load_raw.