### PR TITLE
HIP 17 performance and correctness update

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -474,3 +474,6 @@
 -define(penalty_history_limit, penalty_history_limit). % blocks
 -define(dkg_penalty, dkg_penalty). % float
 -define(tenure_penalty, tenure_penalty). % float
+
+%% hex version for performance changes and bug fixes for scaling
+-define(blockchain_hex_version, blockchain_hex_version). % version

--- a/src/blockchain_hex_v1.erl
+++ b/src/blockchain_hex_v1.erl
@@ -1,0 +1,378 @@
+-module(blockchain_hex_v1).
+
+-export([var_map/1,
+         scale/2, scale/4,
+         destroy_memoization/0]).
+
+-ifdef(TEST).
+-export([densities/3]).
+-endif.
+
+-include("blockchain_vars.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-define(SCALE_MEMO_TBL, '__blockchain_hex_scale_memoization_tbl').
+-define(DENSITY_MEMO_TBL, '__blockchain_hex_density_memoization_tbl').
+-define(ETS_OPTS, [named_table, public]).
+
+-type density_map() :: #{h3:h3_index() => non_neg_integer()}.
+-type densities() :: {UnclippedDensities :: density_map(), ClippedDensities :: density_map()}.
+-type var_map() :: #{0..12 => map()}.
+-type locations() :: #{h3:h3_index() => [libp2p_crypto:pubkey_bin(), ...]}.
+-type h3_indices() :: [h3:h3_index()].
+-type tblnames() :: ?SCALE_MEMO_TBL|?DENSITY_MEMO_TBL.
+
+-export_type([var_map/0]).
+
+%%--------------------------------------------------------------------
+%% Public functions
+%%--------------------------------------------------------------------
+-spec destroy_memoization() -> true.
+%% @doc This call will destroy the memoization context used during a rewards
+%% calculation.
+destroy_memoization() ->
+    try ets:delete(?SCALE_MEMO_TBL) catch _:_ -> true end,
+    try ets:delete(?DENSITY_MEMO_TBL) catch _:_ -> true end.
+
+%% @doc This call is for blockchain_etl to use directly
+-spec scale(Location :: h3:h3_index(),
+            Ledger :: blockchain_ledger_v1:ledger()) -> {error, any()} | {ok, float()}.
+scale(Location, Ledger) ->
+    case var_map(Ledger) of
+        {error, _}=E -> E;
+        {ok, VarMap} ->
+            case get_target_res(Ledger) of
+                {error, _}=E -> E;
+                {ok, TargetRes} ->
+                    try
+                        S = scale(Location, VarMap, TargetRes, Ledger),
+                        {ok, S}
+                    catch What:Why:ST ->
+                        {ok, CurHeight} = blockchain_ledger_v1:current_height(Ledger),
+                        lager:error("failed to calculate scale for location: ~p, ~p:~p:~p", [Location, What, Why, ST]),
+                        {error, {failed_scale_calc, Location, CurHeight}}
+                    end
+            end
+    end.
+
+-spec scale(
+    Location :: h3:h3_index(),
+    VarMap :: var_map(),
+    TargetRes :: 0..12,
+    Ledger :: blockchain_ledger_v1:ledger()
+) -> float().
+%% @doc Given a hex location, return the rewards scaling factor. This call is
+%% memoized.
+scale(Location, VarMap, TargetRes, Ledger) ->
+    case lookup(Location, ?SCALE_MEMO_TBL) of
+        {ok, Scale} -> Scale;
+        not_found ->
+            memoize(?SCALE_MEMO_TBL, Location,
+                    calculate_scale(Location, VarMap, TargetRes, Ledger))
+    end.
+
+-spec var_map(Ledger :: blockchain_ledger_v1:ledger()) -> {error, any()} | {ok, var_map()}.
+%% @doc This function returns a map of hex resolutions mapped to hotspot density targets and
+%% maximums. These numbers are used during PoC witness and challenge rewards calculations.
+var_map(Ledger) ->
+    ResolutionVars = [
+        ?hip17_res_0,
+        ?hip17_res_1,
+        ?hip17_res_2,
+        ?hip17_res_3,
+        ?hip17_res_4,
+        ?hip17_res_5,
+        ?hip17_res_6,
+        ?hip17_res_7,
+        ?hip17_res_8,
+        ?hip17_res_9,
+        ?hip17_res_10,
+        ?hip17_res_11,
+        ?hip17_res_12
+    ],
+
+    {_I, Errors, M} = lists:foldl(
+        fun(A, {I, Errors, Acc}) ->
+            case get_density_var(A, Ledger) of
+                {error, _} = E ->
+                    {I + 1, [{A, E} | Errors], Acc};
+                {ok, [N, Tgt, Max]} ->
+                    {I + 1, Errors,
+                        maps:put(
+                            I,
+                            #{
+                                n => N,
+                                tgt => Tgt,
+                                max => Max
+                            },
+                            Acc
+                        )}
+            end
+        end,
+        {0, [], #{}},
+        ResolutionVars
+    ),
+
+    case Errors of
+        [] -> {ok, M};
+        Errors -> {error, Errors}
+    end.
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+-spec lookup(Key :: term(),
+             TblName :: tblnames()) ->
+    {ok, Result :: term()} | not_found.
+lookup(Key, TblName) ->
+    try
+        case ets:lookup(TblName, Key) of
+            [{_Key, Res}] -> {ok, Res};
+            [] -> not_found
+        end
+    catch
+        %% if the table doesn't exist yet, create it and return `not_found'
+        error:badarg ->
+            _ = maybe_start(TblName),
+            not_found
+    end.
+
+-spec maybe_start(TblName :: tblnames()) -> tblnames().
+maybe_start(TblName) ->
+    try
+        _TblName = ets:new(TblName, ?ETS_OPTS)
+    catch
+        error:badarg -> TblName
+    end.
+
+-spec memoize(TblName :: tblnames(),
+              Key :: term(),
+              Result :: term()) -> Result :: term().
+memoize(TblName, Key, Result) ->
+    true = ets:insert(TblName, {Key, Result}),
+    Result.
+
+-spec calculate_scale(
+    Location :: h3:h3_index(),
+    VarMap :: var_map(),
+    TargetRes :: 0..12,
+    Ledger :: blockchain_ledger_v1:ledger() ) -> float().
+calculate_scale(Location, VarMap, TargetRes, Ledger) ->
+    %% hip0017 states to go from R -> 0 and take a product of the clipped(parent)/unclipped(parent)
+    %% however, we specify the lower bound instead of going all the way down to 0
+
+    R = h3:get_resolution(Location),
+
+    %% Calculate densities at the outermost hex
+    OuterMostParent = h3:parent(Location, TargetRes),
+    {UnclippedDensities, ClippedDensities} = densities(OuterMostParent, VarMap, Ledger),
+
+    lists:foldl(fun(Res, Acc) ->
+                        Parent = h3:parent(Location, Res),
+                        case maps:get(Parent, UnclippedDensities) of
+                            0 -> Acc;
+                            Unclipped -> Acc * (maps:get(Parent, ClippedDensities) / Unclipped)
+                        end
+                end, 1.0, lists:seq(R, TargetRes, -1)).
+
+
+-spec densities(
+    H3Index :: h3:h3_index(),
+    VarMap :: var_map(),
+    Ledger :: blockchain_ledger_v1:ledger()
+) -> densities().
+densities(H3Index, VarMap, Ledger) ->
+    case lookup(H3Index, ?DENSITY_MEMO_TBL) of
+        {ok, Densities} -> Densities;
+        not_found -> memoize(?DENSITY_MEMO_TBL, H3Index,
+                            calculate_densities(H3Index, VarMap, Ledger))
+    end.
+
+-spec calculate_densities(
+    H3Index :: h3:h3_index(),
+    VarMap :: var_map(),
+    Ledger :: blockchain_ledger_v1:ledger()
+) -> densities().
+calculate_densities(H3Index, VarMap, Ledger) ->
+    InteractiveBlocks = case blockchain_ledger_v1:config(?hip17_interactivity_blocks, Ledger) of
+                            {ok, V} -> V;
+                            {error, not_found} -> 0 % XXX what should this value be?
+                        end,
+    Locations = blockchain_ledger_v1:lookup_gateways_from_hex(h3:k_ring(H3Index, 2), Ledger),
+
+    Interactive = case application:get_env(blockchain, hip17_test_mode, false) of
+                      true ->
+                          %% HIP17 test mode, no interactive filtering
+                          Locations;
+                      false ->
+                          maps:map(
+                            fun(_K, V) ->
+                                    filter_interactive_gws(V, InteractiveBlocks, Ledger)
+                            end, Locations)
+                  end,
+
+    %% Calculate clipped and unclipped densities
+    densities(H3Index, VarMap, Interactive, Ledger).
+
+-spec densities(
+    H3Root :: h3:h3_index(),
+    VarMap :: var_map(),
+    Locations :: locations(),
+    Ledger :: blockchain_ledger_v1:ledger()
+) -> densities().
+densities(H3Root, VarMap, Locations, Ledger) ->
+    case maps:size(Locations) of
+        0 ->
+            {#{}, #{}};
+        _ ->
+            UpperBoundRes = lists:max([h3:get_resolution(H3) || H3 <- maps:keys(Locations)]),
+            LowerBoundRes = h3:get_resolution(H3Root),
+
+            [Head | Tail] = lists:seq(UpperBoundRes, LowerBoundRes, -1),
+
+            %% find parent hexes to all hotspots at highest resolution in chain variables
+            {ParentHexes, InitialDensities} =
+                maps:fold(
+                    fun(Hex, GWs, {HAcc, MAcc}) ->
+                        ParentHex = h3:parent(Hex, Head),
+                        case maps:find(ParentHex, MAcc) of
+                            error ->
+                                {[ParentHex | HAcc], maps:put(ParentHex, length(GWs), MAcc)};
+                            {ok, OldCount} ->
+                                {HAcc, maps:put(ParentHex, OldCount + length(GWs), MAcc)}
+                        end
+                    end,
+                    {[], #{}},
+                    Locations
+                ),
+
+            build_densities(
+                H3Root,
+                Ledger,
+                VarMap,
+                ParentHexes,
+                {InitialDensities, InitialDensities},
+                Tail
+            )
+    end.
+
+-spec build_densities(
+    h3:h3_index(),
+    blockchain_ledger_v1:ledger(),
+    var_map(),
+    h3_indices(),
+    densities(),
+    [0..15]
+) -> densities().
+build_densities(_H3Root, _Ledger, _VarMap, _ParentHexes, {UAcc, Acc}, []) ->
+    {UAcc, Acc};
+build_densities(H3Root, Ledger, VarMap, ChildHexes, {UAcc, Acc}, [Res | Tail]) ->
+    UD = unclipped_densities(ChildHexes, Res, Acc), %% should be UAcc, fixed in v2
+    UM0 = maps:merge(UAcc, UD),
+    M0 = maps:merge(Acc, UD),
+
+    OccupiedHexesThisRes = maps:keys(UD),
+
+    DensityTarget = maps:get(tgt, maps:get(Res, VarMap)),
+
+    M1 = lists:foldl(
+        fun(ThisResHex, Acc3) ->
+            OccupiedCount = occupied_count(DensityTarget, ThisResHex, UD),
+            Limit = limit(Res, VarMap, OccupiedCount),
+            maps:put(ThisResHex, min(Limit, maps:get(ThisResHex, M0)), Acc3)
+        end,
+        M0,
+        OccupiedHexesThisRes
+    ),
+
+    build_densities(H3Root, Ledger, VarMap, OccupiedHexesThisRes, {UM0, M1}, Tail).
+
+-spec filter_interactive_gws( GWs :: [libp2p_crypto:pubkey_bin(), ...],
+                              InteractiveBlocks :: pos_integer(),
+                              Ledger :: blockchain_ledger_v1:ledger()) ->
+    [libp2p_crypto:pubkey_bin(), ...].
+%% @doc This function filters a list of gateway addresses which are considered
+%% "interactive" for the purposes of HIP17 based on the last block when it
+%% responded to a POC challenge compared to the current chain height.
+filter_interactive_gws(GWs, InteractiveBlocks, Ledger) ->
+    {ok, CurrentHeight} = blockchain_ledger_v1:current_height(Ledger),
+    lists:filter(fun(GWAddr) ->
+                         case blockchain_ledger_v1:find_gateway_last_challenge(GWAddr, Ledger) of
+                             {ok, undefined} -> false;
+                             {ok, LastChallenge} ->
+                                 (CurrentHeight - LastChallenge) =< InteractiveBlocks;
+                             {error, not_found} -> false
+                         end
+                    end, GWs).
+
+-spec limit(
+    Res :: 0..12,
+    VarMap :: var_map(),
+    OccupiedCount :: non_neg_integer()
+) -> non_neg_integer().
+limit(Res, VarMap, OccupiedCount) ->
+    VarAtRes = maps:get(Res, VarMap),
+    DensityMax = maps:get(max, VarAtRes),
+    DensityTgt = maps:get(tgt, VarAtRes),
+    N = maps:get(n, VarAtRes),
+    Max = max(((OccupiedCount - N) + 1), 1),
+    min(DensityMax, DensityTgt * Max).
+
+-spec occupied_count(
+    DensityTarget :: 0..12,
+    ThisResHex :: h3:h3_index(),
+    DensityMap :: density_map()
+) -> non_neg_integer().
+occupied_count(DensityTarget, ThisResHex, DensityMap) ->
+    H3Neighbors = h3:k_ring(ThisResHex, 1),
+
+    lists:foldl(
+        fun(Neighbor, Acc) ->
+            case maps:get(Neighbor, DensityMap, 0) >= DensityTarget of
+                false -> Acc;
+                true -> Acc + 1
+            end
+        end,
+        0,
+        H3Neighbors
+    ).
+
+-spec unclipped_densities(h3_indices(), 0..12, density_map()) -> density_map().
+unclipped_densities(ChildToParents, Res, Acc) ->
+    lists:foldl(
+        fun(ChildHex, Acc2) ->
+            ThisParentHex = h3:parent(ChildHex, Res),
+            maps:update_with(
+                ThisParentHex,
+                fun(V) -> V + maps:get(ChildHex, Acc, 0) end,
+                maps:get(ChildHex, Acc, 0),
+                Acc2
+            )
+        end,
+        #{},
+        ChildToParents
+    ).
+
+-spec get_density_var(
+    Var :: atom(),
+    Ledger :: blockchain_ledger_v1:ledger()
+) -> {error, any()} | {ok, [pos_integer()]}.
+get_density_var(Var, Ledger) ->
+    case blockchain:config(Var, Ledger) of
+        {error, _} = E ->
+            E;
+        {ok, Bin} ->
+            [N, Tgt, Max] = [
+                list_to_integer(I)
+                || I <- string:tokens(binary:bin_to_list(Bin), ",")
+            ],
+            {ok, [N, Tgt, Max]}
+    end.
+
+-spec get_target_res(Ledger :: blockchain_ledger_v1:ledger()) -> {error, any()} | {ok, non_neg_integer()}.
+get_target_res(Ledger) ->
+    case blockchain:config(?density_tgt_res, Ledger) of
+        {error, _}=E -> E;
+        {ok, V} -> {ok, V}
+    end.
+

--- a/src/blockchain_hex_v2.bak
+++ b/src/blockchain_hex_v2.bak
@@ -1,4 +1,4 @@
--module(blockchain_hex).
+-module(blockchain_hex_v2).
 
 -export([var_map/1,
          scale/2, scale/4,
@@ -169,9 +169,9 @@ calculate_scale(Location, VarMap, TargetRes, Ledger) ->
 
     lists:foldl(fun(Res, Acc) ->
                         Parent = h3:parent(Location, Res),
-                        case maps:get(Parent, UnclippedDensities) of
+                        case elookup(Parent, UnclippedDensities) of
                             0 -> Acc;
-                            Unclipped -> Acc * (maps:get(Parent, ClippedDensities) / Unclipped)
+                            Unclipped -> Acc * (elookup(Parent, ClippedDensities) / Unclipped)
                         end
                 end, 1.0, lists:seq(R, TargetRes, -1)).
 
@@ -214,6 +214,12 @@ calculate_densities(H3Index, VarMap, Ledger) ->
     %% Calculate clipped and unclipped densities
     densities(H3Index, VarMap, Interactive, Ledger).
 
+inc(Key, Inc, Tab) ->
+    ets:update_counter(Tab, Key, Inc, {Key, 0}).
+
+set(Key, Inc, Tab) ->
+    ets:insert(Tab, {Key, Inc}).
+
 -spec densities(
     H3Root :: h3:h3_index(),
     VarMap :: var_map(),
@@ -223,7 +229,7 @@ calculate_densities(H3Index, VarMap, Ledger) ->
 densities(H3Root, VarMap, Locations, Ledger) ->
     case maps:size(Locations) of
         0 ->
-            {#{}, #{}};
+            {ets:new(foo, []), ets:new(bar, [])};
         _ ->
             UpperBoundRes = lists:max([h3:get_resolution(H3) || H3 <- maps:keys(Locations)]),
             LowerBoundRes = h3:get_resolution(H3Root),
@@ -234,24 +240,22 @@ densities(H3Root, VarMap, Locations, Ledger) ->
             {ParentHexes, InitialDensities} =
                 maps:fold(
                     fun(Hex, GWs, {HAcc, MAcc}) ->
-                        ParentHex = h3:parent(Hex, Head),
-                        case maps:find(ParentHex, MAcc) of
-                            error ->
-                                {[ParentHex | HAcc], maps:put(ParentHex, length(GWs), MAcc)};
-                            {ok, OldCount} ->
-                                {HAcc, maps:put(ParentHex, OldCount + length(GWs), MAcc)}
-                        end
+                            ParentHex = h3:parent(Hex, Head),
+                            inc(ParentHex, length(GWs), MAcc),
+                            {[ParentHex | HAcc], MAcc}
                     end,
-                    {[], #{}},
+                    {[], ets:new(densities, [])},
                     Locations
                 ),
 
+            Clipped = ets:new(clipped, []),
+            ets:insert(Clipped, ets:tab2list(InitialDensities)),
             build_densities(
                 H3Root,
                 Ledger,
                 VarMap,
                 ParentHexes,
-                {InitialDensities, InitialDensities},
+                {InitialDensities, Clipped},
                 Tail
             )
     end.
@@ -267,25 +271,20 @@ densities(H3Root, VarMap, Locations, Ledger) ->
 build_densities(_H3Root, _Ledger, _VarMap, _ParentHexes, {UAcc, Acc}, []) ->
     {UAcc, Acc};
 build_densities(H3Root, Ledger, VarMap, ChildHexes, {UAcc, Acc}, [Res | Tail]) ->
-    UD = unclipped_densities(ChildHexes, Res, Acc),
-    UM0 = maps:merge(UAcc, UD),
-    M0 = maps:merge(Acc, UD),
-
-    OccupiedHexesThisRes = maps:keys(UD),
+    OccupiedHexesThisRes = unclipped_densities(ChildHexes, Res, UAcc, Acc),
 
     DensityTarget = maps:get(tgt, maps:get(Res, VarMap)),
 
-    M1 = lists:foldl(
-        fun(ThisResHex, Acc3) ->
-            OccupiedCount = occupied_count(DensityTarget, ThisResHex, UD),
+    lists:foreach(
+        fun(ThisResHex) ->
+            OccupiedCount = occupied_count(DensityTarget, ThisResHex, UAcc),
             Limit = limit(Res, VarMap, OccupiedCount),
-            maps:put(ThisResHex, min(Limit, maps:get(ThisResHex, M0)), Acc3)
+            set(ThisResHex, min(Limit, elookup(ThisResHex, UAcc)), Acc)
         end,
-        M0,
         OccupiedHexesThisRes
     ),
 
-    build_densities(H3Root, Ledger, VarMap, OccupiedHexesThisRes, {UM0, M1}, Tail).
+    build_densities(H3Root, Ledger, VarMap, OccupiedHexesThisRes, {UAcc, Acc}, Tail).
 
 -spec filter_interactive_gws( GWs :: [libp2p_crypto:pubkey_bin(), ...],
                               InteractiveBlocks :: pos_integer(),
@@ -328,7 +327,7 @@ occupied_count(DensityTarget, ThisResHex, DensityMap) ->
 
     lists:foldl(
         fun(Neighbor, Acc) ->
-            case maps:get(Neighbor, DensityMap, 0) >= DensityTarget of
+            case elookup(Neighbor, DensityMap) >= DensityTarget of
                 false -> Acc;
                 true -> Acc + 1
             end
@@ -337,21 +336,27 @@ occupied_count(DensityTarget, ThisResHex, DensityMap) ->
         H3Neighbors
     ).
 
--spec unclipped_densities(h3_indices(), 0..12, density_map()) -> density_map().
-unclipped_densities(ChildToParents, Res, Acc) ->
-    lists:foldl(
-        fun(ChildHex, Acc2) ->
-            ThisParentHex = h3:parent(ChildHex, Res),
-            maps:update_with(
-                ThisParentHex,
-                fun(V) -> V + maps:get(ChildHex, Acc, 0) end,
-                maps:get(ChildHex, Acc, 0),
-                Acc2
-            )
+elookup(Key, Tab) ->
+    case ets:lookup(Tab, Key) of
+        [{_K, Ct}] ->
+            Ct;
+        [] -> 0
+    end.
+
+-spec unclipped_densities(h3_indices(), 0..12, any(), density_map()) -> density_map().
+unclipped_densities(ChildToParents, Res, UAcc, Acc) ->
+    lists:usort(
+      lists:foldl(
+        fun(ChildHex, A) ->
+                ThisParentHex = h3:parent(ChildHex, Res),
+                Ct = elookup(ChildHex, Acc),
+                inc(ChildHex, Ct, Acc),
+                inc(ChildHex, Ct, UAcc),
+                [ThisParentHex | A]
         end,
-        #{},
+        [],
         ChildToParents
-    ).
+    )).
 
 -spec get_density_var(
     Var :: atom(),

--- a/src/blockchain_hex_v2.erl
+++ b/src/blockchain_hex_v2.erl
@@ -1,0 +1,195 @@
+-module(blockchain_hex_v2).
+
+-export([
+         scale/2, scale/4,
+         destroy_memoization/0
+        ]).
+
+-ifdef(TEST).
+%% -export([densities/3]).
+-endif.
+
+-include("blockchain_vars.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-define(PRE_UNCLIP_TBL, '__blockchain_hex_unclipped_tbl').
+-define(PRE_CLIP_TBL, '__blockchain_hex_clipped_tbl').
+
+-define(ETS_OPTS, [named_table, public]).
+
+%%--------------------------------------------------------------------
+%% Public functions
+%%--------------------------------------------------------------------
+-spec destroy_memoization() -> true.
+%% @doc This call will destroy the memoization context used during a rewards
+%% calculation.
+destroy_memoization() ->
+    try ets:delete(?PRE_CLIP_TBL) catch _:_ -> true end,
+    try ets:delete(?PRE_UNCLIP_TBL) catch _:_ -> true end.
+
+%% @doc This call is for blockchain_etl to use directly
+-spec scale(Location :: h3:h3_index(),
+            Ledger :: blockchain_ledger_v1:ledger()) -> {error, any()} | {ok, float()}.
+scale(Location, Ledger) ->
+    case blockchain_hex_v1:var_map(Ledger) of
+        {error, _}=E -> E;
+        {ok, VarMap} ->
+            case get_target_res(Ledger) of
+                {error, _}=E -> E;
+                {ok, TargetRes} ->
+                    try
+                        S = scale(Location, VarMap, TargetRes, Ledger),
+                        {ok, S}
+                    catch What:Why:ST ->
+                        {ok, CurHeight} = blockchain_ledger_v1:current_height(Ledger),
+                        lager:error("failed to calculate scale for location: ~p, ~p:~p:~p", [Location, What, Why, ST]),
+                        {error, {failed_scale_calc, Location, CurHeight}}
+                    end
+            end
+    end.
+
+-spec scale(
+    Location :: h3:h3_index(),
+    VarMap :: blockhain_hex_v1:var_map(),
+    TargetRes :: 0..12,
+    Ledger :: blockchain_ledger_v1:ledger()
+) -> float().
+%% @doc Given a hex location, return the rewards scaling factor. This call is
+%% memoized.
+scale(Location, _VarMap, TargetRes, Ledger) ->
+    maybe_precalc(Ledger),
+    %% hip0017 states to go from R -> 0 and take a product of the clipped(parent)/unclipped(parent)
+    %% however, we specify the lower bound instead of going all the way down to 0
+
+    R = h3:get_resolution(Location),
+
+    lists:foldl(fun(Res, Acc) ->
+                        Parent = h3:parent(Location, Res),
+                        case ulookup(Parent) of
+                            0 -> Acc;
+                            Unclipped -> Acc * (clookup(Parent) / Unclipped)
+                        end
+                end, 1.0, lists:seq(R, TargetRes, -1)).
+
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
+ulookup(Key) ->
+    case ets:lookup(?PRE_UNCLIP_TBL, Key) of
+        [{_Key, Res}] -> Res;
+        [] -> 0
+    end.
+
+clookup(Key) ->
+    case ets:lookup(?PRE_CLIP_TBL, Key) of
+        [{_Key, Res}] -> Res;
+        [] -> 0
+    end.
+
+maybe_precalc(Ledger) ->
+    case ets:info(?PRE_UNCLIP_TBL) of
+        undefined ->
+            precalc(Ledger);
+        _ ->
+            ok
+    end.
+
+precalc(Ledger) ->
+    {ok, VarMap} = blockchain_hex_v1:var_map(Ledger),
+    Start = erlang:monotonic_time(millisecond),
+    InteractiveBlocks =
+        case blockchain_ledger_v1:config(?hip17_interactivity_blocks, Ledger) of
+            {ok, V} -> V;
+            {error, not_found} -> 0 % XXX what should this value be?
+        end,
+    {ok, CurrentHeight} = blockchain_ledger_v1:current_height(Ledger),
+    ets:new(?PRE_UNCLIP_TBL, [named_table, public]),
+    ets:new(?PRE_CLIP_TBL, [named_table, public]),
+    UsedResolutions = [N || N <- lists:seq(0, 12), maps:get(tgt, maps:get(N, VarMap)) /= 100000],
+    TCt =
+        blockchain_ledger_v1:cf_fold(
+          active_gateways,
+          fun({_Addr, BinGw}, Acc) ->
+                  G = blockchain_ledger_gateway_v2:deserialize(BinGw),
+              L = blockchain_ledger_gateway_v2:location(G),
+                  LastChallenge = blockchain_ledger_gateway_v2:last_poc_challenge(G),
+                  case LastChallenge /= undefined andalso
+                      (CurrentHeight - LastChallenge) =< InteractiveBlocks of
+                      true ->
+                          case L of
+                              undefined -> Acc;
+                              _ ->
+                                  lists:foreach(
+                                    fun(H) ->
+                                            ets:update_counter(?PRE_UNCLIP_TBL, H, 1, {H, 0})
+                                end,
+                                    %% dropping this to 10 is a big speedup, but perhaps unsafe?
+                                    [h3:parent(L, N) || N <- UsedResolutions]),
+                                  Acc + 1
+                          end;
+                      _ -> Acc
+                  end
+          end, 0, Ledger),
+    %% pre-unfold these because we access them a lot.
+    Vars0 =
+        [begin
+             VarAtRes = maps:get(Res, VarMap),
+             N = maps:get(n, VarAtRes),
+             Tgt = maps:get(tgt, VarAtRes),
+             Max = maps:get(max, VarAtRes),
+             {N, Tgt, Max}
+         end
+         || Res <- lists:seq(1, 12)],  %% use the whole thing here for numbering
+    Vars = list_to_tuple(Vars0),
+    ets:foldl(fun({Hex, Ct}, _) ->
+                      Res = h3:get_resolution(Hex),
+                      DensityTarget = element(2, element(Res, Vars)),
+                      OccupiedCount = occupied_count(DensityTarget, Hex),
+                      Limit = limit(Res, Vars, OccupiedCount),
+                      Actual = min(Limit, Ct),
+                      ets:update_counter(?PRE_CLIP_TBL, Hex, Actual, {Hex, 0})
+              end, foo, ?PRE_UNCLIP_TBL),
+
+    End = erlang:monotonic_time(millisecond),
+    lager:info("ets ~p ~p ~p ~p", [ets:info(?PRE_UNCLIP_TBL, size), TCt, InteractiveBlocks, End-Start]).
+
+-spec limit(
+    Res :: 0..12,
+    VarMap :: blockchain_hex_v1:var_map(),
+    OccupiedCount :: non_neg_integer()
+) -> non_neg_integer().
+limit(Res, Vars, OccupiedCount) ->
+    VarAtRes = element(Res, Vars),
+    N = element(1, VarAtRes),
+    DensityTgt = element(2, VarAtRes),
+    DensityMax = element(3, VarAtRes),
+    Max = max(((OccupiedCount - N) + 1), 1),
+    min(DensityMax, DensityTgt * Max).
+
+-spec occupied_count(
+    DensityTarget :: 0..12,
+    ThisResHex :: h3:h3_index()
+) -> non_neg_integer().
+occupied_count(DensityTarget, ThisResHex) ->
+    H3Neighbors = h3:k_ring(ThisResHex, 1),
+
+    lists:foldl(
+        fun(Neighbor, Acc) ->
+            case ulookup(Neighbor) >= DensityTarget of
+                false -> Acc;
+                true -> Acc + 1
+            end
+        end,
+        0,
+        H3Neighbors
+    ).
+
+-spec get_target_res(Ledger :: blockchain_ledger_v1:ledger()) -> {error, any()} | {ok, non_neg_integer()}.
+get_target_res(Ledger) ->
+    case blockchain:config(?density_tgt_res, Ledger) of
+        {error, _}=E -> E;
+        {ok, V} -> {ok, V}
+    end.
+

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1281,6 +1281,14 @@ validate_var(?penalty_history_limit, Value) ->
     %% also low end cannot be 0
     validate_int(Value, "penalty_history_limit", 10, 100000, false);
 
+validate_var(?blockchain_hex_version, Value) ->
+    case Value of
+        1 -> ok;
+        2 -> ok;
+        _ ->
+            throw({error, {invalid_validator_version, Value}})
+    end;
+
 validate_var(Var, Value) ->
     %% something we don't understand, crash
     invalid_var(Var, Value).

--- a/test/blockchain_reward_perf_SUITE.erl
+++ b/test/blockchain_reward_perf_SUITE.erl
@@ -61,11 +61,17 @@ init_per_testcase(_TestCase, Config) ->
     NewDir = PrivDir ++ "/ledger/",
     ok = filelib:ensure_dir(NewDir),
 
-    os:cmd("wget https://blockchain-core.s3-us-west-1.amazonaws.com/snap-591841"),
+    Filename = Dir ++ "/snap-933121",
 
-    Filename = Dir ++ "/snap-591841",
-
-    {ok, BinSnap} = file:read_file(Filename),
+    {ok, BinSnap} =
+        try
+            {ok, BinSnap1} = file:read_file(Filename),
+            {ok, BinSnap1}
+        catch _:_ ->
+                os:cmd("wget https://snapshots.helium.wtf/mainnet/snap-933121"),
+                {ok, BinSnap2} = file:read_file(Filename),
+                {ok, BinSnap2}
+        end,
 
     {ok, Snapshot} = blockchain_ledger_snapshot_v1:deserialize(BinSnap),
     SHA = blockchain_ledger_snapshot_v1:hash(Snapshot),
@@ -79,6 +85,18 @@ init_per_testcase(_TestCase, Config) ->
 
     Ledger1 = blockchain_ledger_snapshot_v1:import(Chain, SHA, Snapshot),
     {ok, Height} = blockchain_ledger_v1:current_height(Ledger1),
+
+    CLedger = blockchain_ledger_v1:new_context(Ledger1),
+    blockchain_ledger_v1:cf_fold(
+      active_gateways,
+      fun({Addr, BG}, _) ->
+              G = blockchain_ledger_gateway_v2:deserialize(BG),
+              blockchain_ledger_v1:update_gateway(G, Addr, CLedger)
+      end, foo, CLedger),
+
+    ok = blockchain_ledger_v1:vars(#{hip17_resolution_limit => 4}, [], CLedger),
+
+    _ = blockchain_ledger_v1:commit_context(CLedger),
 
     ct:pal("loaded ledger at height ~p", [Height]),
 
@@ -98,45 +116,15 @@ reward_perf_test(Config) ->
 
     {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
 
-    {Time, _} =
+    {Time, R} =
         timer:tc(
           fun() ->
-                  {ok, _} = blockchain_txn_rewards_v1:calculate_rewards(Height - 15, Height, Chain)
+                  {ok, Rewards} = blockchain_txn_rewards_v1:calculate_rewards(Height - 15, Height, Chain),
+                  Rewards
           end),
-    ct:pal("basic calc took: ~p ms", [Time div 1000]),
+    ct:pal("basic calc took: ~p ms hash ~p", [Time div 1000, erlang:phash2(R)]),
 
-    Vars = maps:merge(blockchain_reward_perf_SUITE:hip15_vars(), blockchain_reward_perf_SUITE:hip17_vars()),
-    Ledger2 = blockchain_ledger_v1:new_context(Ledger),
-    ok = blockchain_ledger_v1:vars(Vars, [], Ledger2),
-    blockchain:bootstrap_h3dex(Ledger2),
-    blockchain_ledger_v1:commit_context(Ledger2),
-     
-    [erlang:garbage_collect(P) || P <- processes()],
-    timer:sleep(3000),
-    
-    {Time2, _} =
-        timer:tc(
-          fun() ->
-                  blockchain_txn_rewards_v1:calculate_rewards(Height - 15, Height, Chain)
-          end),
-    ct:pal("basic calc 2 took: ~p ms", [Time2 div 1000]),
-
-    [erlang:garbage_collect(P) || P <- processes()],
-    timer:sleep(3000),
-
-    {Time3, _} =
-        timer:tc(
-          fun() ->
-                  blockchain_txn_rewards_v1:calculate_rewards(Height - 15, Height, Chain)
-          end),
-    ct:pal("hip 17 calc took: ~p ms", [Time3 div 1000]),
-
-    Vars = maps:merge(blockchain_reward_perf_SUITE:hip15_vars(), blockchain_reward_perf_SUITE:hip17_vars()),
-    Ledger1 = blockchain_ledger_v1:new_context(Ledger),
-    blockchain_ledger_v1:bootstrap_gw_denorm(Ledger1),
-    blockchain_ledger_v1:commit_context(Ledger1),
-
-    %% error(print),
+    error(print),
     ok.
 
 


### PR DESCRIPTION
HIP17 as currently implemented is very, very slow.  It's also dramatically sensitive to starting location.  I noticed that if one is to calculate the `unclipped density` of a level from the `unclipped density` of the level below it, instead of the `clipped density` as is done currently, the start location sensitivity goes away and makes the entire process amenable to bulk precalcuation of the entire set of clipped and unclipped densities, which ends up being quite a lot faster and produced identical results to the existing implementation with unclipped densities fixed. 