### PR TITLE
move snapshot lock to point of use

### DIFF
--- a/src/cli/blockchain_cli_snapshot.erl
+++ b/src/cli/blockchain_cli_snapshot.erl
@@ -89,8 +89,10 @@ snapshot_take(_, _, _) ->
 snapshot_take(Filename) ->
     Chain = blockchain_worker:blockchain(),
     Ledger = blockchain:ledger(Chain),
+    ok = blockchain_lock:acquire(),
     Blocks = blockchain_ledger_snapshot_v1:get_blocks(Chain),
     {ok, Snapshot} = blockchain_ledger_snapshot_v1:snapshot(Ledger, Blocks),
+    blockchain_lock:release(),
     BinSnap = blockchain_ledger_snapshot_v1:serialize(Snapshot),
     file:write_file(Filename, BinSnap).
 

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -123,9 +123,7 @@ snapshot(Ledger0, Blocks, Mode) ->
                 Regname = list_to_atom("snapshot_"++integer_to_list(CurrHeight)),
                 try register(Regname, self()) of
                     true ->
-                        ok = blockchain_lock:acquire(),
                         Res = generate_snapshot(Ledger0, Blocks, Mode),
-                        blockchain_lock:release(),
                         %% deliver to the caller
                         Parent ! {Ref, Res},
                         %% deliver to anyone else blocking


### PR DESCRIPTION
the original lock placement isn't safe, as it causes deadlocks when syncing snapshot blocks.  This moves it to a point where it should force consistent blocks and snapshots but not cause deadlock issues.