### PR TITLE
try and speed up syncing

### DIFF
--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -262,7 +262,7 @@ check_is_valid_poc(Txn, Chain) ->
                                             %%
                                             %% Keeping these distinct and using them for their intended purpose is important.
                                             PrePoCBlockHash = blockchain_ledger_poc_v2:block_hash(PoC),
-                                            PoCAbsorbedAtBlockHash  = blockchain_block:hash_block(Block1),
+                                            {ok, PoCAbsorbedAtBlockHash} = blockchain:get_block_hash(LastChallenge, Chain),
                                             Entropy = <<Secret/binary, PoCAbsorbedAtBlockHash/binary, Challenger/binary>>,
                                             maybe_log_duration(prelude, StartPre),
                                             StartLA = erlang:monotonic_time(millisecond),

--- a/src/transactions/v1/blockchain_txn_poc_request_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_request_v1.erl
@@ -183,11 +183,11 @@ is_valid(Txn, Chain) ->
                                                     {error, too_many_challenges};
                                                 true ->
                                                     BlockHash = ?MODULE:block_hash(Txn),
-                                                    case blockchain:get_block(BlockHash, Chain) of
+                                                    case blockchain:get_block_height(BlockHash, Chain) of
                                                         {error, _}=Error ->
                                                             Error;
-                                                        {ok, Block1} ->
-                                                            case (blockchain_block:height(Block1) + PoCInterval) > (Height+1) of
+                                                        {ok, BlockHeight} ->
+                                                            case (BlockHeight + PoCInterval) > (Height+1) of
                                                                 false ->
                                                                     {error, replaying_request};
                                                                 true ->


### PR DESCRIPTION
Requests and Receipts are slower than they need to be, because they're not taking advantage of information that we already have.  This code attempts to use that information.  Two bits:

1. For requests, which are fetching an entire block to get the height, we add a reverse height->hash lookup to the blocks store, with a fallback for older blocks.
2. For receipts, although we already have the block fetched for other reasons, we don't re-hash it, since as blocks get larger that gets more and more expensive, but instead fetch it from the block store.