### PR TITLE
explicitly purge dups from cache whilst purging mined txns.  dont leave until validation run

### DIFF
--- a/src/transactions/blockchain_txn_mgr.erl
+++ b/src/transactions/blockchain_txn_mgr.erl
@@ -309,7 +309,7 @@ purge_block_txns_from_cache(Block)->
                     ok = blockchain_txn_mgr_sup:stop_dialers(Dialers),
                     Acc;
                 {false, _} ->
-                    noop
+                    Acc
             end
         end, [], sorted_cached_txns()),
     ok.


### PR DESCRIPTION
Be more explicit about identifying dups when purging mined txns from the txn mgr cache.

Previously we only purged a mined txn from the cache if we had seen at least 1 accept.  This may have been somewhat fragile, for example if a CG member accepted the txn and the dialer connection broke/crashed before the "accept" msg was sent to the txn mgr.

The new approach will explicitly identify any dup of a mined txn, irrespective of the dialer and CG responses and proceed to reject those dups

This is a somewhat speculative fix for the intermittent problem of a txn showing in the pending txn list as rejected but yet appearing in a block.
