### PR TITLE
Attach rewards_md to aux ledger and fix hex cache memoization cleanup

### DIFF
--- a/src/blockchain_hex.erl
+++ b/src/blockchain_hex.erl
@@ -35,7 +35,10 @@
 %% calculation.
 destroy_memoization() ->
     try ets:delete(get(?PRE_CLIP_TBL)) catch _:_ -> true end,
-    try ets:delete(get(?PRE_UNCLIP_TBL)) catch _:_ -> true end.
+    try ets:delete(get(?PRE_UNCLIP_TBL)) catch _:_ -> true end,
+    _ = erase(?PRE_CLIP_TBL),
+    _ = erase(?PRE_UNCLIP_TBL),
+    true.
 
 %% @doc This call is for blockchain_etl to use directly
 -spec scale(Location :: h3:h3_index(),

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -19,6 +19,10 @@
     diff_aux_rewards_for/2, diff_aux_rewards/1,
     diff_aux_reward_sums/1,
 
+    set_aux_rewards_md/4,
+    get_aux_rewards_md/1,
+    diff_aux_rewards_md/2,
+
     check_key/2, mark_key/2, unmark_key/2,
 
     new_context/1, new_direct_context/1, delete_context/1, remove_context/1, reset_context/1, commit_context/1,
@@ -304,7 +308,8 @@
           aux :: sub_ledger(),
           %% it provides this extra aux_heights column to differentiate actual
           %% rewards vs aux rewards (for now, but can be extended to show other differences)
-          aux_heights :: rocksdb:cf_handle()
+          aux_heights :: rocksdb:cf_handle(),
+          aux_heights_md :: rocksdb:cf_handle()
          }).
 
 %% This record is for managing validator stake cooldown information in the
@@ -333,6 +338,7 @@
 -define(hex_list, <<"$hex_list">>).
 -define(hex_prefix, "$hex_").
 -define(aux_height_prefix, "aux_height_").
+-define(aux_height_md_prefix, "aux_height_md_").
 
 -define(CACHE_TOMBSTONE, '____ledger_cache_tombstone____').
 
@@ -356,7 +362,9 @@
                                     | blockchain_ledger_state_channel_v2:state_channel_v2()}.
 -type h3dex() :: #{h3:h3_index() => [libp2p_crypto:pubkey_bin()]}. %% these keys are gateway addresses
 -type reward_diff() :: {ActualRewards :: blockchain_txn_reward_v1:rewards(), AuxRewards :: blockchain_txn_reward_v1:rewards()}.
+-type reward_md_diff() :: {ActualRewardsMD :: blockchain_txn_reward_v1:rewards_metadata(), AuxRewardsMD :: blockchain_txn_reward_v1:rewards_metadata()}.
 -type aux_rewards() :: #{Height :: non_neg_integer() => reward_diff()}.
+-type aux_rewards_md() :: #{Height :: non_neg_integer() => reward_md_diff()}.
 -export_type([ledger/0]).
 
 -spec new(file:filename_all()) -> ledger().
@@ -494,11 +502,12 @@ new_aux(Path, Ledger) ->
     GlobalOpts = application:get_env(rocksdb, global_opts, []),
     {ok, DB, CFs} = open_db(aux, Path, false, false, GlobalOpts),
     [DefaultCF, AGwsCF, EntriesCF, DCEntriesCF, HTLCsCF, PoCsCF, SecuritiesCF, RoutingCF,
-     SubnetsCF, SCsCF, H3DexCF, GwDenormCF, ValidatorsCF, AuxHeightsCF] = CFs,
+     SubnetsCF, SCsCF, H3DexCF, GwDenormCF, ValidatorsCF, AuxHeightsCF, AuxHeightsMDCF] = CFs,
     Ledger#ledger_v1{aux=#aux_ledger_v1{
        dir = Path,
        db = DB,
        aux_heights = AuxHeightsCF,
+       aux_heights_md = AuxHeightsMDCF,
        aux = #sub_ledger_v1{
        default=DefaultCF,
        active_gateways=AGwsCF,
@@ -3740,6 +3749,13 @@ aux_heights_cf(Ledger) ->
         true -> Ledger#ledger_v1.aux#aux_ledger_v1.aux_heights
     end.
 
+-spec aux_heights_md_cf(ledger()) -> undefined | rocksdb:cf_handle().
+aux_heights_md_cf(Ledger) ->
+    case has_aux(Ledger) of
+        false -> undefined;
+        true -> Ledger#ledger_v1.aux#aux_ledger_v1.aux_heights_md
+    end.
+
 -spec aux_db(ledger()) -> undefined | rocksdb:db_handle().
 aux_db(Ledger) ->
     case has_aux(Ledger) of
@@ -3765,6 +3781,32 @@ set_aux_rewards(Height, Rewards, AuxRewards, Ledger) ->
                 not_found ->
                     Value = term_to_binary({Rewards, AuxRewards}),
                     rocksdb:put(AuxDB, AuxHeightsCF, Key, Value, []);
+                Error ->
+                    Error
+            end
+    end.
+
+-spec set_aux_rewards_md(
+    Height :: non_neg_integer(),
+    OrigMD :: blockchain_txn_rewards_v2:rewards_metadata(),
+    AuxMD :: blockchain_txn_rewards_v2:rewards_metadata(),
+    Ledger :: ledger()
+) -> ok | {error, any()}.
+set_aux_rewards_md(Height, OrigMD, AuxMD, Ledger) ->
+    case has_aux(Ledger) of
+        false ->
+            {error, no_aux_ledger};
+        true ->
+            AuxDB = aux_db(Ledger),
+            AuxHeightsMDCF = aux_heights_md_cf(Ledger),
+            Key = aux_height_md(Height),
+            case rocksdb:get(AuxDB, AuxHeightsMDCF, Key, []) of
+                {ok, _} ->
+                    %% already exists, don't do anything
+                    ok;
+                not_found ->
+                    Value = term_to_binary({OrigMD, AuxMD}),
+                    rocksdb:put(AuxDB, AuxHeightsMDCF, Key, Value, []);
                 Error ->
                     Error
             end
@@ -3838,6 +3880,77 @@ diff_aux_rewards(Ledger) ->
             maps:fold(DiffFun, #{}, OverallAuxRewards)
     end.
 
+-spec diff_aux_rewards_md(Type :: witnesses | challengees, Ledger :: ledger()) -> map().
+diff_aux_rewards_md(witnesses, Ledger) ->
+    diff_aux_rewards_md_(witnesses, Ledger);
+diff_aux_rewards_md(challengees, Ledger) ->
+    diff_aux_rewards_md_(challengees, Ledger).
+
+-spec diff_aux_rewards_md_(Type :: witnesses | challengees, Ledger :: ledger()) -> map().
+diff_aux_rewards_md_(Type, Ledger) ->
+    case has_aux(Ledger) of
+        false ->
+            #{};
+        true ->
+            OverallAuxRewardsMD = get_aux_rewards_md(Ledger),
+            {TallyFun, MDRewardKey} =
+                case Type of
+                    witnesses ->
+                        {tally_md_fun(witnesses), poc_witness};
+                    challengees ->
+                        {tally_md_fun(challengees), poc_challengee}
+                end,
+
+            DiffFun = fun(Height, {OrigMD, AuxMD}, Acc) ->
+                OrigWitnessMD = maps:fold(TallyFun, #{}, maps:get(MDRewardKey, OrigMD)),
+                AuxWitnessMD = maps:fold(TallyFun, #{}, maps:get(MDRewardKey, AuxMD)),
+                Combined = maps:merge(AuxWitnessMD, OrigWitnessMD),
+                Res = maps:fold(
+                    fun(K, V, Acc2) ->
+                        V2 = maps:get(K, AuxWitnessMD, #{amount => 0}),
+                        case V == V2 of
+                            true ->
+                                %% check this is not missing in actual balances
+                                case maps:is_key(K, OrigWitnessMD) of
+                                    false ->
+                                        maps:put(K, {#{amount => 0}, V}, Acc2);
+                                    true ->
+                                        %% no difference
+                                        Acc2
+                                end;
+                            false ->
+                                maps:put(K, {V, V2}, Acc2)
+                        end
+                    end,
+                    #{},
+                    Combined
+                ),
+                maps:put(Height, Res, Acc)
+            end,
+
+            maps:fold(DiffFun, #{}, OverallAuxRewardsMD)
+    end.
+
+-spec tally_md_fun(witnesses | challengees) -> fun().
+tally_md_fun(witnesses) ->
+    fun({gateway, poc_witnesses, GWPubkeyBin}, Amount, AccIn) ->
+        maps:update_with(
+            GWPubkeyBin,
+            fun(V) -> V#{amount => maps:get(amount, V, 0) + Amount} end,
+            #{amount => Amount},
+            AccIn
+        )
+    end;
+tally_md_fun(challengees) ->
+    fun({gateway, poc_challengees, GWPubkeyBin}, Amount, AccIn) ->
+        maps:update_with(
+            GWPubkeyBin,
+            fun(V) -> V#{amount => maps:get(amount, V, 0) + Amount} end,
+            #{amount => Amount},
+            AccIn
+        )
+    end.
+
 -spec tally_fun_v1() -> fun().
 tally_fun_v1() ->
     fun(Reward, Acc0) ->
@@ -3906,6 +4019,38 @@ get_aux_rewards_(Itr, {ok, Key, BinRes}, Acc) ->
                 Acc
         end,
     get_aux_rewards_(Itr, rocksdb:iterator_move(Itr, next), NewAcc).
+
+-spec get_aux_rewards_md(Ledger :: ledger()) -> aux_rewards_md().
+get_aux_rewards_md(Ledger) ->
+    case has_aux(Ledger) of
+        false -> #{};
+        true -> get_aux_rewards_md_(Ledger)
+    end.
+
+get_aux_rewards_md_(Ledger) ->
+    {ok, Itr} = rocksdb:iterator(aux_db(Ledger), aux_heights_md_cf(Ledger), []),
+    Res = get_aux_rewards_md_(Itr, rocksdb:iterator_move(Itr, first), #{}),
+    catch rocksdb:iterator_close(Itr),
+    Res.
+
+get_aux_rewards_md_(_Itr, {error, _}, Acc) ->
+    Acc;
+get_aux_rewards_md_(Itr, {ok, Key, BinRes}, Acc) ->
+    NewAcc =
+        try binary_to_term(BinRes) of
+            {OrigMD, AuxMD} ->
+                <<"aux_height_md_", Height/binary>> = Key,
+                maps:put(binary_to_integer(Height), {OrigMD, AuxMD}, Acc)
+        catch
+            What:Why ->
+                lager:warning("error when deserializing plausible block at key ~p: ~p ~p", [
+                    Key,
+                    What,
+                    Why
+                ]),
+                Acc
+        end,
+    get_aux_rewards_md_(Itr, rocksdb:iterator_move(Itr, next), NewAcc).
 
 -spec validators_cf(ledger()) -> rocksdb:cf_handle().
 validators_cf(Ledger) ->
@@ -4126,7 +4271,7 @@ delayed_cfs() ->
 
 -spec aux_cfs() -> list().
 aux_cfs() ->
-    ["aux_heights"].
+    ["aux_heights", "aux_heights_md"].
 
 -spec maybe_use_snapshot(ledger(), list()) -> list().
 maybe_use_snapshot(#ledger_v1{snapshot=Snapshot}, Options) ->
@@ -4198,6 +4343,9 @@ hex_name(Hex) ->
 
 aux_height(Height) ->
     <<?aux_height_prefix, (integer_to_binary(Height))/binary>>.
+
+aux_height_md(Height) ->
+    <<?aux_height_md_prefix, (integer_to_binary(Height))/binary>>.
 
 add_to_hex(Hex, Gateway, Ledger) ->
     Hexes = case get_hexes(Ledger) of

--- a/src/transactions/v2/blockchain_txn_rewards_v2.erl
+++ b/src/transactions/v2/blockchain_txn_rewards_v2.erl
@@ -204,26 +204,53 @@ absorb_rewards(Rewards, Ledger) ->
         Rewards
     ).
 
--spec aux_absorb(Txn :: txn_rewards_v2(),
-                 AuxLedger :: blockchain_ledger_v1:ledger(),
-                 Chain :: blockchain:blockchain()) -> ok | {error, any()}.
+-spec aux_absorb(
+    Txn :: txn_rewards_v2(),
+    AuxLedger :: blockchain_ledger_v1:ledger(),
+    Chain :: blockchain:blockchain()
+) -> ok | {error, any()}.
 aux_absorb(Txn, AuxLedger, Chain) ->
     Start = ?MODULE:start_epoch(Txn),
     End = ?MODULE:end_epoch(Txn),
     %% NOTE: This is an aux ledger, we don't use rewards(txn) here, instead we calculate them manually
     %% and do 0 verification for absorption
     case calculate_rewards_(Start, End, AuxLedger, Chain) of
-        {error, _}=E -> E;
-        {ok, AuxRewards} ->
+        {error, _} = E ->
+            E;
+        {ok, AuxMD, AuxRewards} ->
             TxnRewards = rewards(Txn),
             %% absorb the rewards attached to the txn (real)
             absorb_rewards(TxnRewards, AuxLedger),
             %% set auxiliary rewards in the aux ledger also
-            lager:info("are aux rewards equal?: ~p", [lists:sort(TxnRewards) == lists:sort(AuxRewards)]),
+            lager:info("are aux rewards equal?: ~p", [
+                lists:sort(TxnRewards) == lists:sort(AuxRewards)
+            ]),
             %% rewards appear in (End + 1) block
-            blockchain_ledger_v1:set_aux_rewards(End + 1, TxnRewards, AuxRewards, AuxLedger)
+            case application:get_env(blockchain, aux_cmp_md, false) of
+                false ->
+                    %% only set aux rewards by default
+                    blockchain_ledger_v1:set_aux_rewards(
+                        End + 1,
+                        TxnRewards,
+                        AuxRewards,
+                        AuxLedger
+                    );
+                true ->
+                    %% calculate original rewards metadata using chain
+                    case calculate_rewards_metadata(Start, End, Chain) of
+                        {error, _} = E -> E;
+                        {ok, MD} ->
+                            blockchain_ledger_v1:set_aux_rewards(
+                                End + 1,
+                                TxnRewards,
+                                AuxRewards,
+                                AuxLedger
+                            ),
+                            %% also set original and aux metadata for comparisons
+                            blockchain_ledger_v1:set_aux_rewards_md(End + 1, MD, AuxMD, AuxLedger)
+                    end
+            end
     end.
-
 
 -spec calculate_rewards(non_neg_integer(), non_neg_integer(), blockchain:blockchain()) ->
     {ok, rewards()} | {error, any()}.
@@ -232,17 +259,21 @@ aux_absorb(Txn, AuxLedger, Chain) ->
 %% ordering will depend on (binary) account information.
 calculate_rewards(Start, End, Chain) ->
     {ok, Ledger} = blockchain:ledger_at(End, Chain),
-    calculate_rewards_(Start, End, Ledger, Chain).
+    case calculate_rewards_(Start, End, Ledger, Chain) of
+        {ok, _MD, Rewards} -> {ok, Rewards};
+        E -> E
+    end.
 
 -spec calculate_rewards_(
         Start :: non_neg_integer(),
         End :: non_neg_integer(),
         Ledger :: blockchain_ledger_v1:ledger(),
-        Chain :: blockchain:blockchain()) -> {error, any()} | {ok, rewards()}.
+        Chain :: blockchain:blockchain()) -> {error, any()} | {ok, rewards_metadata(), rewards()}.
 calculate_rewards_(Start, End, Ledger, Chain) ->
     {ok, Results} = calculate_rewards_metadata(Start, End, blockchain:ledger(Ledger, Chain)),
     try
-        {ok, prepare_rewards_v2_txns(Results, Ledger)}
+        Prepared = prepare_rewards_v2_txns(Results, Ledger),
+        {ok, Results, Prepared}
     catch
         C:Error:Stack ->
             lager:error("Caught ~p; couldn't prepare rewards txn because: ~p~n~p", [C, Error, Stack]),


### PR DESCRIPTION
Problem: We do not currently have a good way to actually determine hotspot specific reward distribution when running an aux ledger. Specifically poc_witness and poc_challengee rewards.

Solution: Rewards metadata contains individual breakdown of reward distribution, we will attach that to the aux ledger on a need basis. The new behavior is guarded behind a new blockchain config variable `aux_cmp_md` (boolean), set it to `true` in miner config (accompanied with the usual aux ledger activation configuration).

 This PR aims to expose the following:
- `blockchain_ledger_v1:set_aux_rewards_md/4` Invoked only in `rewards_v2` if `aux_cmp_md` is set to true. Attaches rewards metadata (both original and aux) to its own column family `aux_height_md` column family. This CF is only available in the aux ledger (similar to existing `aux_heights` CF). 
- `blockchain_ledger_v1:get_aux_rewards_md/2` Invoked manually on remote_console like so: `blockchain_ledger_v1:get_aux_rewards_md(witnesses, Ledger)`. Replace `witnesses` -> `challengees` for challengee rewards.
- `blockchain_ledger_v1:diff_aux_rewards_md_sums/2`. This is added to sum witness | challengee rewards over the course of aux ledger.

TODO:
- [x] Fix diffing when rewards metadata is attached to the aux rewards