### PR TITLE
fix back compat due to infos issue

### DIFF
--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -373,18 +373,8 @@ serialize_v6(#{version := v6}=Snapshot0, BlocksOrNoBlocks) ->
                 term_to_binary([])
         end,
     Snapshot1 = maps:put(blocks, Blocks, Snapshot0),
-    Snapshot2 =
-        case BlocksOrNoBlocks of
-            blocks -> Snapshot1;
-            noblocks ->
-                case maps:is_key(infos, Snapshot1) of
-                    true ->
-                        maps:put(infos, term_to_binary([]), Snapshot1);
-                    _ -> Snapshot1
-                end
-        end,
 
-    Pairs = lists:keysort(1, maps:to_list(Snapshot2)),
+    Pairs = lists:keysort(1, maps:to_list(Snapshot1)),
     frame(6, serialize_pairs(Pairs)).
 
 -spec serialize_v5(snapshot_v5(), noblocks) -> binary().

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -375,10 +375,13 @@ serialize_v6(#{version := v6}=Snapshot0, BlocksOrNoBlocks) ->
     Snapshot1 = maps:put(blocks, Blocks, Snapshot0),
     Snapshot2 =
         case BlocksOrNoBlocks of
-            blocks ->
-                Snapshot1;
+            blocks -> Snapshot1;
             noblocks ->
-                maps:put(infos, term_to_binary([]), Snapshot1)
+                case maps:is_key(infos, Snapshot1) of
+                    true ->
+                        maps:put(infos, term_to_binary([]), Snapshot1);
+                    _ -> Snapshot1
+                end
         end,
 
     Pairs = lists:keysort(1, maps:to_list(Snapshot2)),


### PR DESCRIPTION
adding the infos stuff for slimming down the blocks did the wrong thing when hashing older snaps.  This should fix the issue.