### PR TITLE
speed up absorb

### DIFF
--- a/include/blockchain.hrl
+++ b/include/blockchain.hrl
@@ -31,7 +31,8 @@
     <<"h3dex">>,
     <<"h3dex2">>,
     <<"gateway_lg3">>,
-    <<"clear_witnesses">>
+    <<"clear_witnesses">>,
+    <<"clear_scores">>
 ]).
 
 -define(bones(HNT), HNT * 100000000).

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -1677,7 +1677,18 @@ fixup_neighbors(Addr, Gateways, Neighbors, Ledger) ->
 -spec update_gateway(Gw :: blockchain_ledger_gateway_v2:gateway(),
                      GwAddr :: libp2p_crypto:pubkey_bin(),
                      Ledger :: ledger()) -> ok | {error, _}.
-update_gateway(Gw, GwAddr, Ledger) ->
+update_gateway(Gw0, GwAddr, Ledger) ->
+    %% we have to do this each time to make sure that we have ledger convergence for snapshots, but
+    %% it feels relatively cheap in comparison to continuing to update scores.
+    Gw =
+        case blockchain:config(?election_version, Ledger) of
+            %% election v4 removed score from consideration
+            {ok, EV} when EV >= 4 ->
+                blockchain_ledger_gateway_v2:set_alpha_beta_delta(0.0, 0.0, 0, Gw0);
+            _ ->
+                Gw0
+        end,
+
     Bin = blockchain_ledger_gateway_v2:serialize(Gw),
     AGwsCF = active_gateways_cf(Ledger),
     GwDenormCF = gw_denorm_cf(Ledger),

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -442,7 +442,12 @@ absorb_and_commit(Block, Chain0, BeforeCommit, Rescue) ->
                             ok = blockchain_ledger_v1:commit_context(Ledger2),
                             End2 = erlang:monotonic_time(millisecond),
                             ok = absorb_delayed(Block, Chain0),
-                            ok = absorb_aux(Block, Chain0),
+                            case absorb_aux(Block, Chain0) of
+                                ok -> ok;
+                                Err ->
+                                    lager:info("aux absorb failed with: ~p", [Err]),
+                                    ok
+                            end,
                             End3 = erlang:monotonic_time(millisecond),
                             lager:info("validation took ~p absorb took ~p post took ~p ms height ~p",
                                        [End - Start, End2 - End, End3 - End2, Height]),

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -449,7 +449,7 @@ absorb_and_commit(Block, Chain0, BeforeCommit, Rescue) ->
                                     ok
                             end,
                             End3 = erlang:monotonic_time(millisecond),
-                            lager:info("validation took ~p absorb took ~p post took ~p ms height ~p",
+                            lager:info("validation took ~p absorb took ~p post took ~p ms for block height ~p",
                                        [End - Start, End2 - End, End3 - End2, Height]),
                             ok;
                         Any ->

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -433,7 +433,6 @@ absorb_and_commit(Block, Chain0, BeforeCommit, Rescue) ->
     case ?MODULE:validate(Transactions, Chain1, Rescue) of
         {_ValidTxns, []} ->
             End = erlang:monotonic_time(millisecond),
-            lager:info("took ~p ms for block height ~p", [End - Start, Height]),
             case ?MODULE:absorb_block(Block, Rescue, Chain1) of
                 {ok, Chain2} ->
                     Ledger2 = blockchain:ledger(Chain2),
@@ -441,8 +440,13 @@ absorb_and_commit(Block, Chain0, BeforeCommit, Rescue) ->
                     case BeforeCommit(Chain2, Hash) of
                         ok ->
                             ok = blockchain_ledger_v1:commit_context(Ledger2),
-                            absorb_delayed(Block, Chain0),
-                            absorb_aux(Block, Chain0);
+                            End2 = erlang:monotonic_time(millisecond),
+                            ok = absorb_delayed(Block, Chain0),
+                            ok = absorb_aux(Block, Chain0),
+                            End3 = erlang:monotonic_time(millisecond),
+                            lager:info("validation took ~p absorb took ~p post took ~p ms height ~p",
+                                       [End - Start, End2 - End, End3 - End2, Height]),
+                            ok;
                         Any ->
                             Any
                     end;
@@ -525,13 +529,21 @@ absorb_block(Block, Rescue, Chain) ->
 -spec absorb(txn(),blockchain:blockchain()) -> ok | {error, any()}.
 absorb(Txn, Chain) ->
     Type = ?MODULE:type(Txn),
+    Start = erlang:monotonic_time(millisecond),
+
     try Type:absorb(Txn, Chain) of
         {error, _Reason}=Error ->
             lager:info("failed to absorb ~p ~p ~s",
                        [Type, _Reason, ?MODULE:print(Txn)]),
             Error;
         ok ->
-            ok
+            End = erlang:monotonic_time(millisecond),
+            case (End - Start) >= 5 of
+                true ->
+                    lager:info("took ~p ms to absorb ~p", [End - Start, Type]),
+                    ok;
+                _ -> ok
+            end
     catch
         What:Why:Stack ->
             lager:warning("crash during absorb: ~p ~p", [Why, Stack]),

--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -705,30 +705,31 @@ tagged_path_elements_fold(Fun, Acc0, Txn, Ledger, Chain) ->
         {error, request_block_hash_not_found} -> []
     end.
 
+%% again this is broken because of the current witness situation
 
 %% Iterate over all poc_path elements and for each path element calls a given
 %% callback function with the valid witnesses and valid receipt.
-valid_path_elements_fold(Fun, Acc0, Txn, Ledger, Chain) ->
-    Path = ?MODULE:path(Txn),
-    try get_channels(Txn, Chain) of
-        {ok, Channels} ->
-            lists:foldl(fun({ElementPos, Element}, Acc) ->
-                                {PreviousElement, ReceiptChannel, WitnessChannel} =
-                                case ElementPos of
-                                    1 ->
-                                        {undefined, 0, hd(Channels)};
-                                    _ ->
-                                        {lists:nth(ElementPos - 1, Path), lists:nth(ElementPos - 1, Channels), lists:nth(ElementPos, Channels)}
-                                end,
+%% valid_path_elements_fold(Fun, Acc0, Txn, Ledger, Chain) ->
+%%     Path = ?MODULE:path(Txn),
+%%     try get_channels(Txn, Chain) of
+%%         {ok, Channels} ->
+%%             lists:foldl(fun({ElementPos, Element}, Acc) ->
+%%                                 {PreviousElement, ReceiptChannel, WitnessChannel} =
+%%                                 case ElementPos of
+%%                                     1 ->
+%%                                         {undefined, 0, hd(Channels)};
+%%                                     _ ->
+%%                                         {lists:nth(ElementPos - 1, Path), lists:nth(ElementPos - 1, Channels), lists:nth(ElementPos, Channels)}
+%%                                 end,
 
-                                FilteredReceipt = valid_receipt(PreviousElement, Element, ReceiptChannel, Ledger),
-                                FilteredWitnesses = valid_witnesses(Element, WitnessChannel, Ledger),
+%%                                 FilteredReceipt = valid_receipt(PreviousElement, Element, ReceiptChannel, Ledger),
+%%                                 FilteredWitnesses = valid_witnesses(Element, WitnessChannel, Ledger),
 
-                                Fun(Element, {FilteredWitnesses, FilteredReceipt}, Acc)
-                        end, Acc0, lists:zip(lists:seq(1, length(Path)), Path))
-    catch _:_ ->
-              Acc0
-    end.
+%%                                 Fun(Element, {FilteredWitnesses, FilteredReceipt}, Acc)
+%%                         end, Acc0, lists:zip(lists:seq(1, length(Path)), Path))
+%%     catch _:_ ->
+%%               Acc0
+%%     end.
 
 
 %%--------------------------------------------------------------------
@@ -772,16 +773,20 @@ absorb(Txn, Chain) ->
                         %% Older poc version, don't add witnesses
                         ok;
                     {ok, POCVersion} when POCVersion >= 9 ->
-                        %% Add filtered witnesses with poc-v9
-                        ok = valid_path_elements_fold(fun(Element, {FilteredWitnesses, FilteredReceipt}, _) ->
-                                                              Challengee = blockchain_poc_path_element_v1:challengee(Element),
-                                                              case FilteredReceipt of
-                                                                  undefined ->
-                                                                      ok = blockchain_ledger_v1:insert_witnesses(Challengee, FilteredWitnesses, Ledger);
-                                                                  FR ->
-                                                                      ok = blockchain_ledger_v1:insert_witnesses(Challengee, FilteredWitnesses ++ [FR], Ledger)
-                                                              end
-                                                      end, ok, Txn, Ledger, Chain);
+                        %% get rid of this for the time being, we will need to restore it later when
+                        %% the clean witness restore thing lands
+
+                        %% %% Add filtered witnesses with poc-v9
+                        %% ok = valid_path_elements_fold(fun(Element, {FilteredWitnesses, FilteredReceipt}, _) ->
+                        %%                                       Challengee = blockchain_poc_path_element_v1:challengee(Element),
+                        %%                                       case FilteredReceipt of
+                        %%                                           undefined ->
+                        %%                                               ok = blockchain_ledger_v1:insert_witnesses(Challengee, FilteredWitnesses, Ledger);
+                        %%                                           FR ->
+                        %%                                               ok = blockchain_ledger_v1:insert_witnesses(Challengee, FilteredWitnesses ++ [FR], Ledger)
+                        %%                                       end
+                        %%                               end, ok, Txn, Ledger, Chain);
+                        ok;
                     {ok, POCVersion} when POCVersion > 1 ->
                         %% Find upper and lower time bounds for this poc txn and use those to clamp
                         %% witness timestamps being inserted in the ledger


### PR DESCRIPTION
we're doing a lot of silly stuff that's slowing absorb down.
- we don't use score anymore but we continue to update it
- we validate witnesses that we're not going to score

this PR:
- clears all scores (for snapshot ledger convergence) and stops updating them
- removes witness validation during absorb until we can land #919 