### PR TITLE
Updates for reward metadata diffing

### DIFF
--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -4137,7 +4137,7 @@ get_aux_rewards_md_at(Height, Ledger) ->
         false -> {error, no_aux_ledger};
         true ->
             AuxDB = aux_db(Ledger),
-            AuxHeightsMDCF = aux_heights_cf(Ledger),
+            AuxHeightsMDCF = aux_heights_md_cf(Ledger),
             Key = aux_height_md(Height),
             case rocksdb:get(AuxDB, AuxHeightsMDCF, Key, []) of
                 {ok, BinRes} -> {ok, binary_to_term(BinRes)};


### PR DESCRIPTION
Problem
----
Fetching aux rewards metadata is broken.

Solution
----
- Update `diff_aux_rewards_md_sums/2` function to return the correct aux rewards metadata
- Add `get_aux_rewards_md_for/3` to check gateway specific aux rewards metadata
- Add `diff_aux_rewards_md_sums/1` for a total sum of poc_challengee + poc_witness rewards