### PR TITLE
Fix plausible block tests and don't delete plausible blocks

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -2526,9 +2526,14 @@ check_plausible_blocks(#blockchain{db=DB, plausible_blocks=CF}=Chain) ->
                                   %% set the sync flag to true as we've already gossiped these blocks on
                                   add_block_(Block, Chain, true),
                                   rocksdb:batch_delete(Batch, CF, blockchain_block:hash_block(Block));
-                              plausible ->
-                                  %% still plausible, leave it alone
-                                  ok;
+                              exists ->
+                                  case is_block_plausible(Block, Chain) of
+                                      true ->
+                                          %% still plausible, leave it alone
+                                          ok;
+                                      false ->
+                                          rocksdb:batch_delete(Batch, CF, blockchain_block:hash_block(Block))
+                                  end;
                               _Error ->
                                   rocksdb:batch_delete(Batch, CF, blockchain_block:hash_block(Block))
                           end

--- a/test/plausible_block_SUITE.erl
+++ b/test/plausible_block_SUITE.erl
@@ -54,7 +54,7 @@ basic(Config) ->
     %% check we return the plausible message to the caller
     plausible = blockchain:add_block(LastBlock, Chain),
     %% don't return the plausible message more than once
-    ok = blockchain:add_block(LastBlock, Chain),
+    exists = blockchain:add_block(LastBlock, Chain),
     ?assertEqual({ok, 1}, blockchain:height(Chain)),
     ?assertEqual({ok, 1}, blockchain:sync_height(Chain)),
     [LastBlock] = blockchain:get_plausible_blocks(Chain),
@@ -198,7 +198,7 @@ ultimately_invalid(Config) ->
     %% check we return the plausible message to the caller
     plausible = blockchain:add_block(LastBlock, Chain),
     %% don't return the plausible message more than once
-    ok = blockchain:add_block(LastBlock, Chain),
+    exists = blockchain:add_block(LastBlock, Chain),
     %% try to add a block that should be invalid right away
     {error, disjoint_chain} = blockchain:add_block(hd(Blocks1), Chain),
     ?assertEqual({ok, 1}, blockchain:height(Chain)),
@@ -250,7 +250,7 @@ valid(Config) ->
     %% check we return the plausible message to the caller
     plausible = blockchain:add_block(LastBlock, Chain),
     %% don't return the plausible message more than once
-    ok = blockchain:add_block(LastBlock, Chain),
+    exists = blockchain:add_block(LastBlock, Chain),
     ?assertEqual({ok, 1}, blockchain:height(Chain)),
     ?assertEqual({ok, 1}, blockchain:sync_height(Chain)),
     [LastBlock] = blockchain:get_plausible_blocks(Chain),
@@ -258,6 +258,7 @@ valid(Config) ->
     ok = blockchain:add_block(hd(Blocks), Chain),
     ?assertEqual({ok, 2}, blockchain:height(Chain)),
     ?assertEqual({ok, 2}, blockchain:sync_height(Chain)),
+    true = blockchain:has_block(LastBlock, Chain),
     [LastBlock] = blockchain:get_plausible_blocks(Chain),
     %% add all the rest of the blocks (emulate a sync)
     ok = blockchain:add_blocks(Blocks -- [LastBlock], Chain),


### PR DESCRIPTION
We were incorrectly deleting plausible blocks because of the bugfix in #1005 . This corrects the check for when to delete plausible blocks and updates the tests.