### PR TITLE
pull block gossip

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -66,7 +66,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"53a1d37329a5f530d69db55be5f0c35fd47f4809"}},
+       {ref,"3a1f0a304cdb01e70b61c34e8e64955b38652253"}},
   0},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},2},
  {<<"inert">>,{pkg,<<"inert">>,<<"1.0.2">>},2},

--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -33,6 +33,8 @@
     compact/1,
 
     is_block_plausible/2,
+    get_plausible_block/2,
+    have_plausible_block/2,
 
     last_block_add_time/1,
 
@@ -994,6 +996,8 @@ get_key_or_keys(Ledger) ->
     end.
 
 add_block_(Block, Blockchain, Syncing) ->
+    %% TODO: we know that swarm calls can block, it would be nice if we had all the pubkey bin and
+    %% tid calls threaded through from the top
     Ledger = blockchain:ledger(Blockchain),
     {ok, LedgerHeight} = blockchain_ledger_v1:current_height(Ledger),
     {ok, BlockchainHeight} = blockchain:height(Blockchain),
@@ -1006,6 +1010,7 @@ add_block_(Block, Blockchain, Syncing) ->
                     Hash = blockchain_block:hash_block(Block),
                     Sigs = blockchain_block:signatures(Block),
                     MyAddress = try blockchain_swarm:pubkey_bin() catch _:_ -> nomatch end,
+                    SwarmTID = blockchain_swarm:tid(),
                     BeforeCommit = fun(FChain, FHash) ->
                                            lager:debug("adding block ~p", [Height]),
                                            ok = ?save_block(Block, Blockchain),
@@ -1041,10 +1046,16 @@ add_block_(Block, Blockchain, Syncing) ->
                             end,
                             Error;
                         ok ->
+                            blockchain_gossip_handler:regossip_block(Block, Height, Hash, SwarmTID),
                             run_absorb_block_hooks(Syncing, Hash, Blockchain)
                     end;
                 plausible ->
-                    case save_plausible_block(Block, Blockchain) of
+                    %% regossip plausible blocks
+                    Height = blockchain_block:height(Block),
+                    Hash = blockchain_block:hash_block(Block),
+                    SwarmTID = blockchain_swarm:tid(),
+                    blockchain_gossip_handler:regossip_block(Block, Height, Hash, SwarmTID),
+                    case save_plausible_block(Block, Hash, Blockchain) of
                         exists -> ok; %% already have it
                         ok -> plausible %% tell the gossip handler
                     end;
@@ -2533,9 +2544,8 @@ is_block_plausible(Block, Chain) ->
     end.
 
 
-save_plausible_block(Block, #blockchain{db=DB, plausible_blocks=PlausibleBlocks}) ->
+save_plausible_block(Block, Hash, #blockchain{db=DB, plausible_blocks=PlausibleBlocks}) ->
     true = blockchain_lock:check(), %% we need the lock for this
-    Hash = blockchain_block:hash_block(Block),
     case rocksdb:get(DB, PlausibleBlocks, Hash, []) of
         {ok, _} ->
             %% already got it, thanks
@@ -2543,6 +2553,23 @@ save_plausible_block(Block, #blockchain{db=DB, plausible_blocks=PlausibleBlocks}
         _ ->
             rocksdb:put(DB, PlausibleBlocks, Hash, blockchain_block:serialize(Block), [{sync, true}])
     end.
+
+-spec have_plausible_block(Hash :: blockchain_block:hash(), Chain :: blockchain()) -> boolean().
+have_plausible_block(Hash, #blockchain{db=DB, plausible_blocks=CF}) ->
+    case rocksdb:get(DB, CF, Hash, []) of
+        {ok, _} -> true;
+        _ -> false
+    end.
+
+-spec get_plausible_block(Hash :: blockchain_block:hash(), Chain :: blockchain()) -> {ok, blockchain_block:block()} | {error, term()}.
+get_plausible_block(Hash, #blockchain{db=DB, plausible_blocks=CF}) ->
+    case rocksdb:get(DB, CF, Hash, []) of
+        {ok, BinBlock} ->
+            Block = blockchain_block:deserialize(BinBlock),
+            {ok, Block};
+        Error -> Error
+    end.
+
 
 check_plausible_blocks(#blockchain{db=DB, plausible_blocks=CF}=Chain) ->
     true = blockchain_lock:check(), %% we need the lock for this

--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -31,6 +31,7 @@
     load/2,
 
     maybe_sync/0,
+    target_sync/1, target_sync/2,
     sync/0,
     cancel_sync/0,
     pause_sync/0,
@@ -146,6 +147,12 @@ pause_sync() ->
 
 maybe_sync() ->
     gen_server:cast(?SERVER, maybe_sync).
+
+target_sync(Target) ->
+    target_sync(Target, []).
+
+target_sync(Target, Heights) ->
+    gen_server:cast(?SERVER, {target_sync, Target, Heights}).
 
 sync_paused() ->
     try
@@ -549,6 +556,8 @@ handle_cast({set_resyncing, _Block, _Blockchain, _Syncing}, State) ->
 
 handle_cast(maybe_sync, State) ->
     {noreply, maybe_sync(State)};
+handle_cast({target_sync, Target, Heights}, State) ->
+    {noreply, target_sync(Target, Heights, State)};
 handle_cast({submit_txn, Txn}, State) ->
     ok = send_txn(Txn),
     {noreply, State};
@@ -755,6 +764,17 @@ maybe_sync(#state{mode = snapshot, blockchain = Chain, sync_pid = Pid} = State) 
             reset_sync_timer(State)
     end.
 
+target_sync(_Target, _Heights, #state{sync_paused = true} = State) ->
+    State;
+target_sync(_Target, _Heights, #state{sync_pid = Pid} = State) when Pid /= undefined ->
+    State;
+target_sync(Target0, Heights, #state{blockchain = Chain, swarm_tid = SwarmTID} = State) ->
+    Target = libp2p_crypto:pubkey_bin_to_p2p(Target0),
+    {Pid, Ref} = start_block_sync(SwarmTID, Chain, Target, Heights),
+    lager:info("targeted block sync starting with Pid: ~p, Ref: ~p, Peer: ~p",
+               [Pid, Ref, Target]),
+    State#state{sync_pid = Pid, sync_ref = Ref}.
+
 maybe_sync_blocks(#state{sync_paused = true} = State) ->
     State;
 maybe_sync_blocks(#state{sync_pid = Pid} = State) when Pid /= undefined ->
@@ -810,7 +830,7 @@ start_sync(#state{blockchain = Chain, swarm_tid = SwarmTID} = State) ->
             %% try again later when there's peers
             schedule_sync(State);
         RandomPeer ->
-            {Pid, Ref} = start_block_sync(SwarmTID, Chain, RandomPeer),
+            {Pid, Ref} = start_block_sync(SwarmTID, Chain, RandomPeer, []),
             lager:info("new block sync starting with Pid: ~p, Ref: ~p, Peer: ~p",
                        [Pid, Ref, RandomPeer]),
             State#state{sync_pid = Pid, sync_ref = Ref}
@@ -857,7 +877,7 @@ add_handlers(SwarmTID, Blockchain) ->
     Ref = erlang:monitor(process, GossipPid),
     %% add the gossip handler
     ok = libp2p_group_gossip:add_handler(GossipPid, ?GOSSIP_PROTOCOL_V1,
-                            {blockchain_gossip_handler, [SwarmTID, Blockchain]}),
+                                         {blockchain_gossip_handler, [SwarmTID, Blockchain]}),
 
     %% add the sync handlers, sync handlers support multiple versions so we need to add for each
     SyncAddFun = fun(ProtocolVersion) ->
@@ -901,12 +921,13 @@ remove_handlers(SwarmTID) ->
 -spec start_block_sync(
         SwarmTID :: ets:tab(),
         Chain :: blockchain:blockchain(),
-        Peer :: libp2p_crypto:pubkey_bin()
+        Peer :: libp2p_crypto:pubkey_bin(),
+        Heights :: [pos_integer()]
 ) -> {pid(), reference()} | ok.
-start_block_sync(SwarmTID, Chain, Peer) ->
+start_block_sync(SwarmTID, Chain, Peer, Heights) ->
     DialFun =
         fun() ->
-                case blockchain_sync_handler:dial(SwarmTID, Chain, Peer) of
+                case blockchain_sync_handler:dial(SwarmTID, Chain, Peer, Heights) of
                     {ok, Stream} ->
                         {ok, HeadHash} = blockchain:sync_hash(Chain),
                         Stream ! {hash, HeadHash},
@@ -939,7 +960,7 @@ start_block_sync(SwarmTID, Chain, Peer) ->
 grab_snapshot(Height, Hash) ->
     Chain = blockchain_worker:blockchain(),
     Swarm = blockchain_swarm:swarm(),
-    SwarmTID = libp2p_swarm:tid(Swarm),
+    SwarmTID = blockchain_swarm:tid(),
 
     case get_random_peer(SwarmTID) of
         no_peers -> {error, no_peers};

--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -959,7 +959,6 @@ start_block_sync(SwarmTID, Chain, Peer, Heights) ->
 
 grab_snapshot(Height, Hash) ->
     Chain = blockchain_worker:blockchain(),
-    Swarm = blockchain_swarm:swarm(),
     SwarmTID = blockchain_swarm:tid(),
 
     case get_random_peer(SwarmTID) of

--- a/src/handlers/blockchain_gossip_handler.erl
+++ b/src/handlers/blockchain_gossip_handler.erl
@@ -19,7 +19,9 @@
 -export([
          init_gossip_data/1,
          handle_gossip_data/3,
-         gossip_data/2
+         gossip_data_v1/2,
+         gossip_data_v2/3,
+         regossip_block/2, regossip_block/4
         ]).
 
 -ifdef(TEST).
@@ -28,52 +30,108 @@
 
 init_gossip_data([SwarmTID, Blockchain]) ->
     lager:debug("gossiping init"),
-    {ok, Block} = blockchain:head_block(Blockchain),
     lager:debug("gossiping block to peers on init"),
-    {send, gossip_data(SwarmTID, Block)};
+    case application:get_env(blockchain, gossip_version, 1) of
+        1 ->
+            {ok, Block} = blockchain:head_block(Blockchain),
+            {send, gossip_data_v1(SwarmTID, Block)};
+        2 ->
+            {ok, Height} = blockchain_ledger_v1:current_height(blockchain:ledger(Blockchain)),
+            {ok, #block_info{hash = Hash}} = blockchain:get_block_info(Height, Blockchain),
+            lager:debug("gossiping block to peers on init"),
+            {send, gossip_data_v2(SwarmTID, Hash, Height)}
+    end;
 init_gossip_data(WAT) ->
     lager:info("WAT ~p", [WAT]),
     {send, <<>>}.
 
 handle_gossip_data(_StreamPid, Data, [SwarmTID, Blockchain]) ->
     try
-        #blockchain_gossip_block_pb{from=From, block=BinBlock} =
-            blockchain_gossip_handler_pb:decode_msg(Data, blockchain_gossip_block_pb),
-        Block = blockchain_block:deserialize(BinBlock),
-        case blockchain_block:type(Block) of
-            undefined ->
-                lager:notice("gossip_handler unknown block: ~p", [Block]);
-            _ ->
-                case blockchain:has_block(Block, Blockchain) of
-                    true ->
-                        %% already got this block, just return
+        case blockchain_gossip_handler_pb:decode_msg(Data, blockchain_gossip_block_pb) of
+            #blockchain_gossip_block_pb{from = From, hash = Hash, height = Height, block = <<>>} ->
+                %% try to cheaply check if we have the block already
+                case blockchain:get_block_hash(Height, Blockchain) of
+                    {ok, Hash} -> ok;
+                    {ok, OtherHash} when is_binary(OtherHash) ->
+                        lager:warning("got non-matching hash ~p for height ~p from ~p",
+                                      [Hash, Height, blockchain_utils:addr2name(From)]),
                         ok;
-                    _ ->
-                        case blockchain:is_block_plausible(Block, Blockchain) of
+                    {error, not_found} ->
+                        %% don't appear to have the block, do we have a plausible block?
+                        case blockchain:have_plausible_block(Hash, Blockchain) of
                             true ->
-                                lager:debug("Got block: ~p from: ~p", [Block, From]),
-                                %% don't block the gossip server
-                                spawn(fun() -> add_block(Block, Blockchain, From, SwarmTID) end),
-                                ok;
+                                case find_missing_blocks(Hash, Blockchain) of
+                                    [] -> ok;
+                                    Missing ->
+                                        blockchain_worker:target_sync(From, Missing)
+                                end;
                             false ->
-                                blockchain_worker:maybe_sync(),
-                                ok
+                                %% don't have it in plausible either, try to sync it from the sender.
+                                blockchain_worker:target_sync(From)
+                        end
+                end;
+            #blockchain_gossip_block_pb{from=From, block=BinBlock} ->
+                Block = blockchain_block:deserialize(BinBlock),
+                case blockchain_block:type(Block) of
+                    undefined ->
+                        lager:notice("gossip_handler unknown block: ~p", [Block]);
+                    _ ->
+                        case blockchain:has_block(Block, Blockchain) of
+                            true ->
+                                %% already got this block, just return
+                                ok;
+                            _ ->
+                                case blockchain:is_block_plausible(Block, Blockchain) of
+                                    true ->
+                                        lager:debug("Got block: ~p from: ~p", [Block, From]),
+                                        %% don't block the gossip server
+                                        spawn(fun() -> add_block(Block, Blockchain, From, SwarmTID) end),
+                                        ok;
+                                    false ->
+                                        blockchain_worker:maybe_sync(),
+                                        ok
+                                end
                         end
                 end
         end
     catch
         _What:Why:Stack ->
             lager:notice("gossip handler got bad data: ~p", [Why]),
-            lager:debug("stack: ~p", [Stack])
+            lager:info("stack: ~p", [Stack])
     end,
     noreply.
+
+
+find_missing_blocks(Hash, Chain) ->
+    {ok, Block} = blockchain:get_plausible_block(Hash, Chain),
+    find_missing_blocks(blockchain_block:prev_hash(Block), blockchain_block:height(Block), Chain).
+
+
+find_missing_blocks(Hash, LastHeight, Chain) ->
+    case blockchain:get_plausible_block(Hash, Chain) of
+        {ok, Block} ->
+            BlockHeight = blockchain_block:height(Block),
+            case BlockHeight == LastHeight - 1 of
+                 true ->
+                    find_missing_blocks(blockchain_block:prev_hash(Block), BlockHeight, Chain);
+                false ->
+                    %% some kind of wacky chain break, ignore the plausible block that does not fit
+                    {ok, ChainHeight} = blockchain:height(Chain),
+                    lists:seq(ChainHeight+1, LastHeight - 1)
+            end;
+        _ ->
+            %% found a break in the plausible chain, so now we know we need any
+            %% missing heights between this block and the chain's HEAD block
+            {ok, ChainHeight} = blockchain:height(Chain),
+            lists:seq(ChainHeight+1, LastHeight - 1)
+    end.
 
 add_block(Block, Chain, Sender, SwarmTID) ->
     lager:debug("Sender: ~p, MyAddress: ~p", [Sender, blockchain_swarm:pubkey_bin()]),
     case blockchain:has_block(Block, Chain) == false andalso blockchain:is_block_plausible(Block, Chain) of
         true ->
             %% eagerly re-gossip plausible blocks we don't have
-            regossip_block(Block, SwarmTID);
+            ok = regossip_block(Block, SwarmTID);
         false ->
             ok
     end,
@@ -115,16 +173,40 @@ add_block(Block, Chain, Sender, SwarmTID) ->
             end
     end.
 
--spec gossip_data(libp2p_swarm:swarm(), blockchain_block:block()) -> binary().
-gossip_data(SwarmTID, Block) ->
+-spec gossip_data_v1(libp2p_swarm:swarm(), blockchain_block:block()) -> binary().
+gossip_data_v1(SwarmTID, Block) ->
     PubKeyBin = libp2p_swarm:pubkey_bin(SwarmTID),
     BinBlock = blockchain_block:serialize(Block),
     Msg = #blockchain_gossip_block_pb{from=PubKeyBin, block=BinBlock},
     blockchain_gossip_handler_pb:encode_msg(Msg).
 
+-spec gossip_data_v2(libp2p_swarm:swarm(), binary(), pos_integer()) -> binary().
+gossip_data_v2(SwarmTID, Hash, Height) ->
+    PubKeyBin = libp2p_swarm:pubkey_bin(SwarmTID),
+    Msg = #blockchain_gossip_block_pb{from=PubKeyBin, hash=Hash, height=Height},
+    blockchain_gossip_handler_pb:encode_msg(Msg).
+
 regossip_block(Block, SwarmTID) ->
+        case application:get_env(blockchain, gossip_version, 1) of
+            1 ->
+                %% this is awful but safe
+                regossip_block(Block, height, hash, SwarmTID);
+            2 ->
+                %% should be impossible to hit this?
+                {error, bad_gossip_version}
+        end.
+
+regossip_block(Block, Height, Hash, SwarmTID) ->
+    Data =
+        case application:get_env(blockchain, gossip_version, 1) of
+            1 ->
+                gossip_data_v1(SwarmTID, Block);
+            2 ->
+                gossip_data_v2(SwarmTID, Hash, Height)
+        end,
     libp2p_group_gossip:send(
       libp2p_swarm:gossip_group(SwarmTID),
       ?GOSSIP_PROTOCOL_V1,
-      blockchain_gossip_handler:gossip_data(SwarmTID, Block)
-     ).
+      Data
+     ),
+    ok.

--- a/src/handlers/blockchain_gossip_handler.erl
+++ b/src/handlers/blockchain_gossip_handler.erl
@@ -38,7 +38,7 @@ init_gossip_data([SwarmTID, Blockchain]) ->
         2 ->
             {ok, Height} = blockchain_ledger_v1:current_height(blockchain:ledger(Blockchain)),
             {ok, #block_info{hash = Hash}} = blockchain:get_block_info(Height, Blockchain),
-            lager:debug("gossiping block to peers on init"),
+            lager:debug("gossiping block @ ht: ~p to peers on init", [Height]),
             {send, gossip_data_v2(SwarmTID, Hash, Height)}
     end;
 init_gossip_data(WAT) ->
@@ -102,6 +102,7 @@ handle_gossip_data(_StreamPid, Data, [SwarmTID, Blockchain]) ->
     noreply.
 
 
+-spec find_missing_blocks(Hash :: blockchain_block:hash(), Chain :: blockchain:blockchain()) -> [pos_integer()].
 find_missing_blocks(Hash, Chain) ->
     {ok, Block} = blockchain:get_plausible_block(Hash, Chain),
     find_missing_blocks(blockchain_block:prev_hash(Block), blockchain_block:height(Block), Chain).

--- a/src/handlers/blockchain_sync_handler.erl
+++ b/src/handlers/blockchain_sync_handler.erl
@@ -82,15 +82,15 @@ dial(SwarmTID, Chain, Peer, Heights) ->
         end,
     DialFun(?SUPPORTED_SYNC_PROTOCOLS).
 
--spec dial(Swarm :: pid(),
+-spec dial(SwarmTID :: ets:tab(),
            Chain :: blockchain:blockchain(),
            Peer :: libp2p_crypto:pubkey_bin(),
            ProtocolVersion :: string(),
            Requested :: [pos_integer()]) ->
           {ok, pid()} | {error, any()}.
-dial(Swarm, Chain, Peer, ProtocolVersion, Requested)->
+dial(SwarmTID, Chain, Peer, ProtocolVersion, Requested)->
     libp2p_swarm:dial_framed_stream(
-      Swarm,
+      SwarmTID,
       Peer,
       ProtocolVersion,
       ?MODULE,

--- a/src/handlers/blockchain_sync_handler.erl
+++ b/src/handlers/blockchain_sync_handler.erl
@@ -18,7 +18,7 @@
     server/4,
     client/2,
     dial/3,
-    dial/4
+    dial/4, dial/5
 ]).
 
 %% ------------------------------------------------------------------
@@ -36,7 +36,8 @@
     batch_size :: pos_integer(),
     batch_limit :: pos_integer(),
     batches_sent = 0 :: non_neg_integer(),
-    path :: string()
+    path :: string(),
+    requested = [] :: [pos_integer()]
 }).
 
 %% ------------------------------------------------------------------
@@ -50,19 +51,24 @@ server(Connection, _Path, _TID, Args) ->
     %% When spawning a server its handled only in libp2p_framed_stream
     libp2p_framed_stream:server(?MODULE, Connection, [Args]).
 
--spec dial(
-        SwarmTID :: ets:tab(),
-        Chain :: blockchain:blockchain(),
-        Peer :: libp2p_crypto:pubkey_bin()
-) -> {ok, pid()} | {error, any()}.
+-spec dial(SwarmTID :: ets:tab(), Chain::blockchain:blockchain(), Peer::libp2p_crypto:pubkey_bin())->
+        {ok, pid()} | {error, any()}.
 dial(SwarmTID, Chain, Peer) ->
+    dial(SwarmTID, Chain, Peer, []).
+
+-spec dial(SwarmTID :: ets:tab(),
+           Chain::blockchain:blockchain(),
+           Peer::libp2p_crypto:pubkey_bin(),
+           Heights::[pos_integer()])->
+        {ok, pid()} | {error, any()}.
+dial(SwarmTID, Chain, Peer, Heights) ->
     DialFun =
         fun
             Dial([])->
                 lager:debug("dialing Sync stream failed, no compatible protocol versions",[]),
                 {error, no_supported_protocols};
             Dial([ProtocolVersion | Rest]) ->
-                case blockchain_sync_handler:dial(SwarmTID, Chain, Peer, ProtocolVersion) of
+                case blockchain_sync_handler:dial(SwarmTID, Chain, Peer, ProtocolVersion, Heights) of
                         {ok, Stream} ->
                             lager:debug("dialing Sync stream successful, stream pid: ~p, protocol version: ~p", [Stream, ProtocolVersion]),
                             {ok, Stream};
@@ -76,23 +82,24 @@ dial(SwarmTID, Chain, Peer) ->
         end,
     DialFun(?SUPPORTED_SYNC_PROTOCOLS).
 
--spec dial(
-        SwarmTID :: ets:tab(),
-        Chain :: blockchain:blockchain(),
-        Peer :: libp2p_crypto:pubkey_bin(),
-        ProtocolVersion :: string()
-) -> {ok, pid()} | {error, any()}.
-dial(SwarmTID, Chain, Peer, ProtocolVersion)->
-    libp2p_swarm:dial_framed_stream(SwarmTID,
-                                    Peer,
-                                    ProtocolVersion,
-                                    ?MODULE,
-                                    [ProtocolVersion, Chain]).
+-spec dial(Swarm :: pid(),
+           Chain :: blockchain:blockchain(),
+           Peer :: libp2p_crypto:pubkey_bin(),
+           ProtocolVersion :: string(),
+           Requested :: [pos_integer()]) ->
+          {ok, pid()} | {error, any()}.
+dial(Swarm, Chain, Peer, ProtocolVersion, Requested)->
+    libp2p_swarm:dial_framed_stream(
+      Swarm,
+      Peer,
+      ProtocolVersion,
+      ?MODULE,
+      [ProtocolVersion, Requested, Chain]).
 
 %% ------------------------------------------------------------------
 %% libp2p_framed_stream Function Definitions
 %% ------------------------------------------------------------------
-init(client, _Conn, [Path, Blockchain]) ->
+init(client, _Conn, [Path, Requested, Blockchain]) ->
     case blockchain_worker:sync_paused() of
         true ->
             {stop, normal};
@@ -100,7 +107,7 @@ init(client, _Conn, [Path, Blockchain]) ->
             BatchSize = application:get_env(blockchain, block_sync_batch_size, 5),
             BatchLimit = application:get_env(blockchain, block_sync_batch_limit, 40),
             {ok, #state{blockchain=Blockchain, batch_size=BatchSize, batch_limit=BatchLimit,
-                        path=Path}}
+                        path=Path, requested=Requested}}
     end;
 init(server, _Conn, [_, _HandlerModule, [Path, Blockchain]] = _Args) ->
     BatchSize = application:get_env(blockchain, block_sync_batch_size, 5),
@@ -139,47 +146,87 @@ handle_data(client, Data0, #state{blockchain=Chain, path=Path}=State) ->
     end;
 handle_data(server, Data, #state{blockchain=Blockchain, batch_size=BatchSize,
                                  batches_sent=Sent, batch_limit=Limit,
-                                 path=Path}=State) ->
+                                 path=Path, requested=StRequested}=State) ->
     case blockchain_sync_handler_pb:decode_msg(Data, blockchain_sync_req_pb) of
-        #blockchain_sync_req_pb{msg={hash, #blockchain_sync_hash_pb{hash=Hash}}} ->
-            case blockchain:get_block(Hash, Blockchain) of
-                {ok, StartingBlock} ->
-                    case blockchain:build(StartingBlock, Blockchain, BatchSize) of
-                        [] ->
-                            {stop, normal, State};
-                        Blocks ->
-                            Msg1 = #blockchain_sync_blocks_pb{blocks=[blockchain_block:serialize(B) || B <- Blocks]},
-                            Msg0 = blockchain_sync_handler_pb:encode_msg(Msg1),
-                            Msg = case Path of
-                                      ?SYNC_PROTOCOL_V1 -> Msg0;
-                                      ?SYNC_PROTOCOL_V2 -> zlib:compress(Msg0)
-                                  end,
-                            {noreply, State#state{batches_sent=Sent+1, block=lists:last(Blocks)}, Msg}
-                    end;
-                {error, _Reason} ->
-                    {stop, normal, State}
+        #blockchain_sync_req_pb{msg={hash,
+                                     #blockchain_sync_hash_pb{hash = Hash,
+                                                              heights = Requested}}} ->
+            {Blocks, Requested1} =
+                build_blocks(Requested, Hash, Blockchain, BatchSize),
+            case Blocks of
+                [] ->
+                    {stop, normal, State};
+                [_|_] ->
+                    Msg = mk_msg(Blocks, Path),
+                    case Requested1 == [] andalso Requested /= [] of
+                        true ->
+                            {stop, normal, State, Msg};
+                        _ ->
+                            {noreply, State#state{batches_sent=Sent+1,
+                                                  block=lists:last(Blocks),
+                                                  requested = Requested1},
+                             Msg}
+                    end
             end;
         #blockchain_sync_req_pb{msg={response, true}} when Sent < Limit, State#state.block /= undefined ->
             StartingBlock = State#state.block,
-            case blockchain:build(StartingBlock, Blockchain, BatchSize) of
+            {Blocks, Requested1} =
+                build_blocks(StRequested, StartingBlock, Blockchain, BatchSize),
+            case Blocks of
                 [] ->
                     {stop, normal, State};
-                Blocks ->
-                    Msg1 = #blockchain_sync_blocks_pb{blocks=[blockchain_block:serialize(B) || B <- Blocks]},
-                    Msg0 = blockchain_sync_handler_pb:encode_msg(Msg1),
-                    Msg = case Path of
-                              ?SYNC_PROTOCOL_V1 -> Msg0;
-                              ?SYNC_PROTOCOL_V2 -> zlib:compress(Msg0)
-                          end,
-                    {noreply, State#state{batches_sent=Sent+1, block=lists:last(Blocks)}, Msg}
+                _ ->
+                    Msg = mk_msg(Blocks, Path),
+                    case Requested1 == [] andalso StRequested /= [] of
+                        true ->
+                            {stop, normal, State, Msg};
+                        _ ->
+                            {noreply, State#state{batches_sent=Sent+1,
+                                                  block=lists:last(Blocks),
+                                                  requested = Requested1},
+                             Msg}
+                    end
             end;
         _ ->
             %% ack was false, block was undefined, limit was hit or the message was not understood
             {stop, normal, State}
     end.
 
-handle_info(client, {hash, Hash}, State) ->
-    Msg = #blockchain_sync_req_pb{msg={hash, #blockchain_sync_hash_pb{hash=Hash}}},
+handle_info(client, {hash, Hash}, #state{requested = Requested} = State) ->
+    Msg = #blockchain_sync_req_pb{msg={hash, #blockchain_sync_hash_pb{hash = Hash,
+                                                                      heights = Requested}}},
     {noreply, State, blockchain_sync_handler_pb:encode_msg(Msg)};
 handle_info(_Type, _Msg, State) ->
     {noreply, State}.
+
+build_blocks([], Hash, Blockchain, BatchSize) when is_binary(Hash) ->
+    case blockchain:get_block(Hash, Blockchain) of
+        {ok, StartingBlock} ->
+            {blockchain:build(StartingBlock, Blockchain, BatchSize), []};
+        {error, _Reason} ->
+            {[], []}
+    end;
+build_blocks([], StartingBlock, Blockchain, BatchSize) when is_tuple(StartingBlock) ->
+    {blockchain:build(StartingBlock, Blockchain, BatchSize), []};
+build_blocks(R, _Hash, Blockchain, BatchSize) when is_list(R) ->
+    %% just send these.  if there are more of them than the batch size, then just
+    %% send the batch and remove them from the list
+    R2 = lists:sublist(R, BatchSize),
+    {lists:flatmap(
+       fun(Height) ->
+               case blockchain:get_block(Height, Blockchain) of
+                   {ok, B} -> [B];
+                   _ -> []
+               end
+       end,
+       R2),
+     R -- R2}.
+
+mk_msg(Blocks, Path) ->
+    Msg1 = #blockchain_sync_blocks_pb{blocks=[blockchain_block:serialize(B) || B <- Blocks]},
+    Msg0 = blockchain_sync_handler_pb:encode_msg(Msg1),
+    Msg = case Path of
+              ?SYNC_PROTOCOL_V1 -> Msg0;
+              ?SYNC_PROTOCOL_V2 -> zlib:compress(Msg0)
+          end,
+    Msg.


### PR DESCRIPTION
currently, we send a lot more blocks out than we need to.  this costs a lot in terms of bandwidth, especially as blocks grow larger and larger.  this PR attempts to move gossip from push to pull, where network nodes only pull blocks that they're unfamiliar with.

depends on: https://github.com/helium/proto/pull/94