### PR TITLE
don't let validation continue if it cannot succeed

### DIFF
--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -258,7 +258,7 @@ check_is_valid_poc(Txn, Chain) ->
                                          time = BlockTime,
                                          pocs = BlockPoCs}} ->
                             PoCInterval = blockchain_utils:challenge_interval(Ledger),
-                            case LastChallenge + PoCInterval >= Height of
+                            case LastChallenge + PoCInterval >= Height orelse Height - BlockHeight < 50 of
                                 false ->
                                     lager:info("challenge too old ~p ~p", [Challenger, LastChallenge]),
                                     {error, challenge_too_old};


### PR DESCRIPTION
sometimes we get receipts that we cannot possibly validate, since they would require fetching ledgers past the trailing ledger.  this causes noisy crashes in the logs, and we should handle it better.