### PR TITLE
Add witness reward decay rate as a legal var and add an exclusion count

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -195,6 +195,7 @@
 -define(rewards_txn_version, rewards_txn_version).
 -define(hip15_tx_reward_unit_cap, hip15_tx_reward_unit_cap).
 -define(witness_reward_decay_rate, witness_reward_decay_rate).
+-define(witness_reward_decay_exclusion, witness_reward_decay_exclusion).
 
 %%%
 %%% bundle txn vars

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1012,6 +1012,10 @@ validate_var(?hip15_tx_reward_unit_cap, Value) ->
     %% According to HIP-15, the cap should be set to 2.0
     %% 5.0 is just for future proofing if need be
     validate_float(Value, "hip15_tx_reward_unit_cap", 0.0, 5.0);
+validate_var(?witness_reward_decay_rate, Value) ->
+    validate_float(Value, "witness_reward_decay_rate", 0.0, 5.0);
+validate_var(?witness_reward_decay_exclusion, Value) ->
+    validate_int(Value, "witness_reward_decay_exclusion", 0, 10, false);
 
 %% bundle vars
 validate_var(?max_bundle_size, Value) ->


### PR DESCRIPTION
So for example, setting the exclusion to 4 would mean your first 4
witness events per epoch would be at full value and the exponential
decay woulds only kick in for the 5th reward and above.

Example of reward curve:

```erlang
18> WitnessDecay = fun(Count, Exclusion, DecayRate) -> case Count < Exclusion of true -> 1; false -> math:exp((Count - Exclusion) * -1 * DecayRate) end end.
#Fun<erl_eval.19.126501267>

19> [WitnessDecay(N, 3, 0.08) || N <- lists:seq(0, 14)].
[1,1,1,1.0,0.9231163463866358,0.8521437889662113,
 0.7866278610665535,0.7261490370736909,0.6703200460356393,
 0.6187833918061408,0.5712090638488149,0.5272924240430485,
 0.4867522559599717,0.44932896411722156,0.4147829116815814]

20> lists:sum([WitnessDecay(N, 3, 0.08) || N <- lists:seq(0, 14)]).
11.02650609098551
```

Note that the decay is calculated over the *current* # of witness events in the epoch, so for the initial witness that will be 0. Also note that for an exponential decay curve the first value is 1.0, so an exclusion of 3 protects the first four witness rewards in the epoch from any decay.

For completeness here's some examples with no exclusion:

```erlang
33> [WitnessDecay(N, 0, 0.08) || N <- lists:seq(0, 14)].
[1.0,0.9231163463866358,0.8521437889662113,
 0.7866278610665535,0.7261490370736909,0.6703200460356393,
 0.6187833918061408,0.5712090638488149,0.5272924240430485,
 0.4867522559599717,0.44932896411722156,0.4147829116815814,
 0.38289288597511206,0.35345468195878016,0.32627979462303947]

34> lists:sum([WitnessDecay(N, 0, 0.08) || N <- lists:seq(0, 14)]).
9.08913345354244
```