### PR TITLE
Ensure open_db paths are always deduplicated

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -2165,7 +2165,7 @@ assert_loc_txn(H3String, OwnerB58, PayerB58, Nonce) ->
 %%--------------------------------------------------------------------
 -spec open_db(file:filename_all()) -> {ok, rocksdb:db_handle(), [rocksdb:cf_handle()]} | {error, any()}.
 open_db(Dir) ->
-    DBDir = filename:join(Dir, ?DB_FILE),
+    DBDir = blockchain_utils:dedup_path(filename:join(Dir, ?DB_FILE)),
     ok = filelib:ensure_dir(DBDir),
 
     case filelib:is_file(filename:join(Dir, "blockchain-open-failed")) andalso follow_mode() of
@@ -2181,7 +2181,7 @@ open_db(Dir) ->
 
     GlobalOpts = application:get_env(rocksdb, global_opts, []),
     DBOptions = [{create_if_missing, true}, {atomic_flush, true}] ++ GlobalOpts,
-    DefaultCFs = ["default", "blocks", "heights", "temp_blocks", 
+    DefaultCFs = ["default", "blocks", "heights", "temp_blocks",
                   "plausible_blocks", "snapshots", "implicit_burns", "info", "htlc_receipts"],
     ExistingCFs =
         case rocksdb:list_column_families(DBDir, DBOptions) of

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -3791,13 +3791,13 @@ process_fun(ToProcess, Cache, CF,
               Dir :: file:filename_all(),
               HasDelayed :: boolean(), ReadOnly :: boolean(), Options :: rocksdb:cf_options()) -> {ok, rocksdb:db_handle(), [rocksdb:cf_handle()]} | {error, any()}.
 open_db(active, Dir, true, ReadOnly, Options) ->
-    DBDir = filename:join(Dir, ?DB_FILE),
+    DBDir = blockchain_utils:dedup_path(filename:join(Dir, ?DB_FILE)),
     ok = filelib:ensure_dir(DBDir),
     DBOptions = lists:keymerge(1, lists:ukeysort(1, Options), lists:ukeysort(1, [{create_if_missing, true}, {atomic_flush, true}])),
     DefaultCFs = default_cfs() ++ delayed_cfs(),
     open_db_(DBDir, DBOptions, DefaultCFs, Options, ReadOnly, false);
 open_db(aux, Dir, false, ReadOnly, Options) ->
-    DBDir = filename:join(Dir, ?DB_FILE),
+    DBDir = blockchain_utils:dedup_path(filename:join(Dir, ?DB_FILE)),
     ok = filelib:ensure_dir(DBDir),
     DBOptions = lists:keymerge(1, lists:ukeysort(1, Options), lists:ukeysort(1, [{create_if_missing, true}, {atomic_flush, true}])),
     DefaultCFs = default_cfs() ++ aux_cfs(),

--- a/src/state_channel/blockchain_state_channels_db_owner.erl
+++ b/src/state_channel/blockchain_state_channels_db_owner.erl
@@ -147,7 +147,7 @@ terminate(_Reason, #state{db=DB,
                                       {error, any()}.
 open_db(Dir, CFNames) ->
     ok = filelib:ensure_dir(Dir),
-    DBDir = filename:join(Dir, ?DB_FILE),
+    DBDir = blockchain_utils:dedup_path(filename:join(Dir, ?DB_FILE)),
     GlobalOpts = application:get_env(rocksdb, global_opts, []),
     DBOptions = [{create_if_missing, true}, {atomic_flush, true}] ++ GlobalOpts,
     ExistingCFs =


### PR DESCRIPTION
Problem
----
It ever so happens that when we invoke `open_db` (I noticed this with aux ledger), there's a possibility that we end up with paths like: `/foo/bar/ledger.db/ledger.db`. This causes strange issues when looking for checkpoints for example.

Solution
----
This adds a `dedup_path` function which gets invoked in most (all) `open_db` functions (I found three, each in ledger, state_channels and blockchain). 