### PR TITLE
revert var cache

### DIFF
--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -620,8 +620,8 @@ get_vars(VarList, Ledger) ->
       end, #{}, VarList).
 
 -spec get_var_(VarName :: atom(),
-               HasAux :: boolean(),
-               VarsNonce :: non_neg_integer(),
+               IsAux :: atom(),         % XXX: Temporary
+               VarsNonce :: atom(),     % XXX: Temporary
                Ledger :: blockchain_ledger_v1:ledger()) -> {ok, any()} | {error, any()}.
 get_var_(VarName, _HasAux, _VarsNonce, Ledger) ->
     get_var_(VarName, Ledger).


### PR DESCRIPTION
this PR turns the var cache into a noop, retaining the poc var selection and list->map stuff that came in with #1030 rather than reverting it.

I think that a cache is a good idea, and have some ideas for making it safer/faster than this one.