### PR TITLE
Use default timeout for getting state channel form worker

### DIFF
--- a/src/state_channel/blockchain_state_channels_worker.erl
+++ b/src/state_channel/blockchain_state_channels_worker.erl
@@ -66,7 +66,7 @@ start(Args) ->
 
 -spec get(Pid :: pid()) -> blockchain_state_channel_v1:state_channel().
 get(Pid) ->
-    gen_server:call(Pid, get, infinity).
+    gen_server:call(Pid, get).
 
 -spec handle_offer(
     Pid :: pid(),


### PR DESCRIPTION
This is called from the sc_server mostly when getting counts of state
channels to decide if new ones should be opened. If something happens to
one of the workers that it never responds, the server will hang forever.

It's also called in `select_best_active` for when an unknown gateway
enters the picture. In that case, hanging forever is also a problem.

Questions:
- If the server dies from a badmatch, what happens to the workers?
- If this times out, will the caller fail and be able to retry? or will
  the process still be attempting to process, so when the og caller comes
  back, it just builds up the queue.