### PR TITLE
Mj/evict sc rejected gateway

### DIFF
--- a/src/state_channel/blockchain_state_channels_cache.erl
+++ b/src/state_channel/blockchain_state_channels_cache.erl
@@ -16,6 +16,7 @@
     start_link/1,
     lookup_hotspot/1,
     insert_hotspot/2,
+    delete_hotspot/1,
     delete_pids/1,
     lookup_actives/0,
     insert_actives/1,
@@ -67,6 +68,11 @@ lookup_hotspot(HotspotID) ->
 -spec insert_hotspot(HotspotID :: libp2p_crypto:pubkey_bin(), Pid :: pid()) -> ok.
 insert_hotspot(HotspotID, Pid) ->
     true = ets:insert(?ETS, {HotspotID, Pid}),
+    ok.
+
+-spec delete_hotspot(HotspotID :: libp2p_crypto:pubkey_bin()) -> ok.
+delete_hotspot(HotspotID)->
+    true = ets:delete(?ETS, HotspotID),
     ok.
 
 -spec delete_pids(Pid :: pid()) -> integer().

--- a/src/state_channel/blockchain_state_channels_worker.erl
+++ b/src/state_channel/blockchain_state_channels_worker.erl
@@ -257,7 +257,7 @@ offer(
                 {error, _Reason} ->
                     lager:warning(
                         "dropping this packet because: ~p ~p",
-                        [_Reason, lager:pr(SC, blockchain_state_channel_v1)]
+                        [_Reason, blockchain_state_channel_v1:id(SC)]
                     ),
                     ok = send_offer_rejection(HandlerPid, Offer),
                     {noreply, State0};

--- a/src/state_channel/blockchain_state_channels_worker.erl
+++ b/src/state_channel/blockchain_state_channels_worker.erl
@@ -355,6 +355,8 @@ maybe_update_streams(HotspotID, Handler, #state{handlers=Handlers0}=State) ->
 
 -spec send_offer_rejection(HandlerPid :: pid(), Offer :: blockchain_state_channel_offer_v1:offer()) -> ok.
 send_offer_rejection(HandlerPid, Offer) ->
+    HotspotID = blockchain_state_channel_offer_v1:hotspot(Offer),
+    ok = blockchain_state_channels_cache:delete_hotspot(HotspotID),
     PacketHash = blockchain_state_channel_offer_v1:packet_hash(Offer),
     RejectionMsg = blockchain_state_channel_rejection_v1:new(PacketHash),
     ok = blockchain_state_channel_common:send_rejection(HandlerPid, RejectionMsg).


### PR DESCRIPTION
Still working through some of the state channel tests, it takes a while since they don't all pass when run together. 

**Situation**:
A lightgateway somehow get's hold of a state channel, but the first time it makes an offer the state channel is already full. Whoever owns the state channel sees that they're purchasing the offer, but the state channel worker is trumping the purchaser because there is no space. 
The lightgateway makes another offer, but it goes to the same already full state channel. So, until that state channel closes and the cache for it goes away, no offers will actually be purchased.

This PR evicts a gateway from the state channel cache when it's rejected after the owner has said to purchase.

**Questions**:
- Are there any rejection scenarios from the worker where we wouldn't want to evict the gateway?
- Any tests that should be reconsidered with this new mechanism?