### PR TITLE
add a fall-back path for getting v1 gossip while running v2 code

### DIFF
--- a/src/handlers/blockchain_gossip_handler.erl
+++ b/src/handlers/blockchain_gossip_handler.erl
@@ -193,8 +193,10 @@ regossip_block(Block, SwarmTID) ->
                 %% this is awful but safe
                 regossip_block(Block, height, hash, SwarmTID);
             2 ->
-                %% should be impossible to hit this?
-                {error, bad_gossip_version}
+                %% this is not super efficient but the cost should tail off over time.
+                Height = blockchain_block:height(Block),
+                Hash = blockchain_block:hash_block(Block),
+                regossip_block(Block, Height, Hash, SwarmTID)
         end.
 
 regossip_block(Block, Height, Hash, SwarmTID) ->


### PR DESCRIPTION
this was crashing and taking down the add block process after it had updated the ledger but before it could trigger the add_block event, which was keeping the heartbeat from updating.  This fixes the v1 -> v2 path, and allows validators to heartbeat again.