### PR TITLE
Make JSON decoding configurable

### DIFF
--- a/src/blockchain_httpc.erl
+++ b/src/blockchain_httpc.erl
@@ -1,0 +1,37 @@
+-module(blockchain_httpc).
+
+-define(USER_AGENT, "blockchain-worker-3").
+-define(DEFAULT_OPTIONS, [{body_format, binary, full_result, false}]).
+
+-export([
+         fetch/1,
+         fetch/2,
+         fetch_to_scratch_file/2,
+         json_decode/1
+        ]).
+
+fetch(URL) ->
+    fetch(URL, ?DEFAULT_OPTIONS).
+
+fetch(URL, Options) ->
+    Headers = [
+               {"user-agent", ?USER_AGENT}
+              ],
+    HTTPOptions = [
+                   {timeout, 900000}, % milliseconds, 900 sec overall request timeout
+                   {connect_timeout, 60000} % milliseconds, 60 second connection timeout
+                  ],
+
+    case httpc:request(get, {URL, Headers}, HTTPOptions, Options) of
+        {ok, {200, Data}} -> {ok, Data};
+        {ok, saved_to_file} -> {ok, saved};
+        {ok, {404, _Response}} -> throw({error, {url_not_found, URL}});
+        {ok, {Status, Response}} -> throw({error, {Status, Response}});
+        Other -> throw(Other)
+    end.
+
+fetch_to_scratch_file(URL, Filename) ->
+    fetch(URL, ?DEFAULT_OPTIONS++[{stream, Filename}]).
+
+json_decode(Data) ->
+    jsx:decode(Data, [{return_maps, true}]).


### PR DESCRIPTION
Problem to solve: We are currently hardcoding jsx as the JSON library in core, and that's fine in the context of miner where jsx is already a defined dep - but we use core in other contexts where jsx is not a defined dependency. Additionally, we are copypasta http client code which we ought to centralize for maintenance purposes (everyone knows httpc only gets more complex over time)

Solution: Pull httpc into a common module. Make json decoding configurable in the environment but provide a default method based on jsx.