### PR TITLE
Add jsx as a dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -32,6 +32,7 @@
     {lager, "3.9.2"},
     {erl_base58, "0.0.1"},
     {base64url, "1.0.1"},
+    {jsx, "3.1.0"},
     {libp2p, ".*", {git, "https://github.com/helium/erlang-libp2p.git", {branch, "master"}}},
     {clique, ".*", {git, "https://github.com/helium/clique.git", {branch, "develop"}}},
     {h3, ".*", {git, "https://github.com/helium/erlang-h3.git", {branch, "master"}}},

--- a/src/blockchain.app.src
+++ b/src/blockchain.app.src
@@ -26,6 +26,7 @@
         exor_filter,
         merkerl,
         base64url,
+        jsx,
         erbloom,
         grpc_client
     ]},


### PR DESCRIPTION
Problem to solve: jsx is called in blockchain_worker but it is _not_ defined as a top level dependency in core - when we reuse core in other contexts, it's possible jsx may or may not exist, which will lead to a crash at start up time.

Solution: Define jsx as a dependency