### PR TITLE
Don't dump entire state channel to log

### DIFF
--- a/src/state_channel/blockchain_state_channels_worker.erl
+++ b/src/state_channel/blockchain_state_channels_worker.erl
@@ -257,12 +257,12 @@ offer(
                 {error, _Reason} ->
                     lager:warning(
                         "dropping this packet because: ~p ~p",
-                        [_Reason, lager:pr(SC, blockchain_state_channel_v1)]
+                        [_Reason, blockchain_state_channel_v1:id(SC)]
                     ),
                     ok = send_offer_rejection(HandlerPid, Offer),
                     {noreply, State0};
                 {ok, PurchaseSC} ->
-                    lager:debug("purchasing offer from ~p ~p", [HotspotName, PurchaseSC]),
+                    lager:debug("purchasing offer from ~p ~p", [HotspotName, blockchain_state_channel_v1:id(PurchaseSC)]),
                     SignedPurchaseSC = blockchain_state_channel_v1:sign(PurchaseSC, OwnerSigFun),
                     PacketHash = blockchain_state_channel_offer_v1:packet_hash(Offer),
                     Region = blockchain_state_channel_offer_v1:region(Offer),


### PR DESCRIPTION
Purchasing is less of a problem because there's less of a chance of
running a full system with debug active, but the warning coming with a
fully formatted 2000 actor state channel can get pretty heavy when you
have the maximu number of state channels all filled up.