### PR TITLE
bump proto to pull in latest grpc gateway service additions

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -66,7 +66,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"3349cee093116253416da8472e5676c2003c1ea2"}},
+       {ref,"331ae0f043b3d0279dc22bab92b125ba1e8aca27"}},
   0},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},2},
  {<<"inert">>,{pkg,<<"inert">>,<<"1.0.2">>},2},


### PR DESCRIPTION
includes additional fields as part of the attestation:
block_age
block_time