### PR TITLE
passing -1 into a seek causes a segfault

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -781,7 +781,8 @@ has_block(Block, #blockchain{db=DB, blocks=BlocksCF,
             Error
     end.
 
-find_first_height_after(MinHeight, #blockchain{db=DB, heights=HeightsCF}) ->
+find_first_height_after(MinHeight0, #blockchain{db=DB, heights=HeightsCF}) ->
+    MinHeight = max(0, MinHeight0),
     {ok, Iter} = rocksdb:iterator(DB, HeightsCF, []),
     rocksdb:iterator_move(Iter, {seek, <<(MinHeight):64/integer-unsigned-big>>}),
     case rocksdb:iterator_move(Iter, next) of


### PR DESCRIPTION
node and other follower users have found that on first startup, when there is nothing stored for the follower height, that their instances crash with a seg fault before they can store anything, making it impossible to start new instances.

this is due to an optimization made for existing instances, done a few weeks ago.  see #1053 for details.  

the crash is due to some followers defaulting to -1 instead of 0, which leads to a `seek` to `MAX_LONG_LONG` and a subsequent `next` seek segfaults rocks somehow:

``` 
<<(-1):64/integer-unsigned-big>>.                                             
<<"ÿÿÿÿÿÿÿÿ">>  
```
`<<"ÿÿÿÿÿÿÿÿ">> ` is `0xffffffffffffffff`.


we fix this by making the input safe, and adjusting any negative value to 0.