### PR TITLE
Discard 0.0 freq witnesses behind chain var

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -525,3 +525,7 @@
 %% As an example, blockchain_txn_transfer_hotspot_v2, will get enabled
 %% when this value is set to >= 2.
 -define(transaction_validity_version, transaction_validity_version).    % pos_integer
+
+
+%% Boolean chain variable to discard witnesses with 0.0 frequency
+-define(discard_zero_freq_witness, discard_zero_freq_witness).

--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -1383,6 +1383,8 @@ tagged_witnesses(Element, Channel, Ledger) ->
     %% foldl will re-reverse
     Witnesses = lists:reverse(blockchain_poc_path_element_v1:witnesses(Element)),
 
+    DiscardZeroFreq = blockchain_ledger_v1:config(?discard_zero_freq_witness, Ledger),
+
     lists:foldl(fun(Witness, Acc) ->
                          DstPubkeyBin = blockchain_poc_witness_v1:gateway(Witness),
                          {ok, Destination} = blockchain_ledger_v1:find_gateway_info(DstPubkeyBin, Ledger),
@@ -1392,90 +1394,95 @@ tagged_witnesses(Element, Channel, Ledger) ->
                          {ok, ParentRes} = blockchain_ledger_v1:config(?poc_v4_parent_res, Ledger),
                          SourceParentIndex = h3:parent(SourceLoc, ParentRes),
                          DestinationParentIndex = h3:parent(DestinationLoc, ParentRes),
+                         Freq = blockchain_poc_witness_v1:frequency(Witness),
 
-                        case is_same_region(Ledger, SourceLoc, DestinationLoc) of
-                            false ->
-                                lager:debug("Not in the same region!~nSrcPubkeyBin: ~p, DstPubkeyBin: ~p, SourceLoc: ~p, DestinationLoc: ~p",
-                                            [blockchain_utils:addr2name(SrcPubkeyBin),
-                                             blockchain_utils:addr2name(DstPubkeyBin),
-                                             SourceLoc, DestinationLoc]),
-                                [{false, <<"witness_not_same_region">>, Witness} | Acc];
-                            true ->
-                                case is_too_far(Ledger, SourceLoc, DestinationLoc) of
-                                    {true, Distance} ->
-                                        lager:debug("Src too far from destination!~nSrcPubkeyBin: ~p, DstPubkeyBin: ~p, SourceLoc: ~p, DestinationLoc: ~p, Distance: ~p",
-                                                    [blockchain_utils:addr2name(SrcPubkeyBin),
-                                                     blockchain_utils:addr2name(DstPubkeyBin),
-                                                     SourceLoc, DestinationLoc, Distance]),
-                                        [{false, <<"witness_too_far">>, Witness} | Acc];
-                                    {false, _Distance} ->
-                                         try h3:grid_distance(SourceParentIndex, DestinationParentIndex) of
-                                             Dist when Dist >= ExclusionCells ->
-                                                 RSSI = blockchain_poc_witness_v1:signal(Witness),
-                                                 SNR = blockchain_poc_witness_v1:snr(Witness),
-                                                 Freq = blockchain_poc_witness_v1:frequency(Witness),
-                                                 MinRcvSig = min_rcv_sig(blockchain_poc_path_element_v1:receipt(Element),
-                                                                         Ledger,
-                                                                         SourceLoc,
-                                                                         DstPubkeyBin,
-                                                                         DestinationLoc,
-                                                                         Freq),
+                         case {DiscardZeroFreq, Freq} of
+                             {{ok, true}, 0.0} ->
+                                [{false, <<"witness_zero_freq">>, Witness} | Acc];
+                             _ ->
+                                 case is_same_region(Ledger, SourceLoc, DestinationLoc) of
+                                     false ->
+                                         lager:debug("Not in the same region!~nSrcPubkeyBin: ~p, DstPubkeyBin: ~p, SourceLoc: ~p, DestinationLoc: ~p",
+                                                     [blockchain_utils:addr2name(SrcPubkeyBin),
+                                                      blockchain_utils:addr2name(DstPubkeyBin),
+                                                      SourceLoc, DestinationLoc]),
+                                         [{false, <<"witness_not_same_region">>, Witness} | Acc];
+                                     true ->
+                                         case is_too_far(Ledger, SourceLoc, DestinationLoc) of
+                                             {true, Distance} ->
+                                                 lager:debug("Src too far from destination!~nSrcPubkeyBin: ~p, DstPubkeyBin: ~p, SourceLoc: ~p, DestinationLoc: ~p, Distance: ~p",
+                                                             [blockchain_utils:addr2name(SrcPubkeyBin),
+                                                              blockchain_utils:addr2name(DstPubkeyBin),
+                                                              SourceLoc, DestinationLoc, Distance]),
+                                                 [{false, <<"witness_too_far">>, Witness} | Acc];
+                                             {false, _Distance} ->
+                                                 try h3:grid_distance(SourceParentIndex, DestinationParentIndex) of
+                                                     Dist when Dist >= ExclusionCells ->
+                                                         RSSI = blockchain_poc_witness_v1:signal(Witness),
+                                                         SNR = blockchain_poc_witness_v1:snr(Witness),
+                                                         MinRcvSig = min_rcv_sig(blockchain_poc_path_element_v1:receipt(Element),
+                                                                                 Ledger,
+                                                                                 SourceLoc,
+                                                                                 DstPubkeyBin,
+                                                                                 DestinationLoc,
+                                                                                 Freq),
 
-                                                 case RSSI < MinRcvSig of
-                                                     false ->
-                                                         %% RSSI is impossibly high discard this witness
-                                                         lager:debug("witness ~p -> ~p rejected at height ~p for RSSI ~p above FSPL ~p with SNR ~p",
-                                                                       [?TO_ANIMAL_NAME(blockchain_poc_path_element_v1:challengee(Element)),
-                                                                        ?TO_ANIMAL_NAME(blockchain_poc_witness_v1:gateway(Witness)),
-                                                                        element(2, blockchain_ledger_v1:current_height(Ledger)),
-                                                                        RSSI, MinRcvSig, SNR]),
-                                                         [{false, <<"witness_rssi_too_high">>, Witness} | Acc];
-                                                     true ->
-                                                         case check_valid_frequency(SourceLoc, Freq, Ledger) of
+                                                         case RSSI < MinRcvSig of
+                                                             false ->
+                                                                 %% RSSI is impossibly high discard this witness
+                                                                 lager:debug("witness ~p -> ~p rejected at height ~p for RSSI ~p above FSPL ~p with SNR ~p",
+                                                                             [?TO_ANIMAL_NAME(blockchain_poc_path_element_v1:challengee(Element)),
+                                                                              ?TO_ANIMAL_NAME(blockchain_poc_witness_v1:gateway(Witness)),
+                                                                              element(2, blockchain_ledger_v1:current_height(Ledger)),
+                                                                              RSSI, MinRcvSig, SNR]),
+                                                                 [{false, <<"witness_rssi_too_high">>, Witness} | Acc];
                                                              true ->
-                                                                case blockchain:config(?data_aggregation_version, Ledger) of
-                                                                    {ok, DataAggVsn} when DataAggVsn > 1 ->
-                                                                        case check_rssi_snr(Ledger, RSSI, SNR) of
-                                                                            true ->
-                                                                                case blockchain_poc_witness_v1:channel(Witness) == Channel of
-                                                                                    true ->
-                                                                                        lager:debug("witness ok"),
-                                                                                        [{true, <<"ok">>, Witness} | Acc];
-                                                                                    false ->
-                                                                                        lager:debug("witness ~p -> ~p rejected at height ~p for channel ~p /= ~p RSSI ~p SNR ~p",
-                                                                                                    [?TO_ANIMAL_NAME(blockchain_poc_path_element_v1:challengee(Element)),
-                                                                                                        ?TO_ANIMAL_NAME(blockchain_poc_witness_v1:gateway(Witness)),
-                                                                                                        element(2, blockchain_ledger_v1:current_height(Ledger)),
-                                                                                                        blockchain_poc_witness_v1:channel(Witness), Channel,
-                                                                                                        RSSI, SNR]),
-                                                                                        [{false, <<"witness_on_incorrect_channel">>, Witness} | Acc]
-                                                                                end;
-                                                                            {false, LowerBound} ->
-                                                                                lager:debug("witness ~p -> ~p rejected at height ~p for RSSI ~p below lower bound ~p with SNR ~p",
-                                                                                            [?TO_ANIMAL_NAME(blockchain_poc_path_element_v1:challengee(Element)),
-                                                                                                ?TO_ANIMAL_NAME(blockchain_poc_witness_v1:gateway(Witness)),
-                                                                                                element(2, blockchain_ledger_v1:current_height(Ledger)),
-                                                                                                RSSI, LowerBound, SNR]),
-                                                                                [{false, <<"witness_rssi_below_lower_bound">>, Witness} | Acc]
-                                                                        end;
-                                                                    _ ->
-                                                                        %% SNR+Freq+Channels not collected, nothing else we can check
-                                                                        [{true, <<"insufficient_data">>, Witness} | Acc]
-                                                                end;
-                                                             _ ->
-                                                                 [{false, <<"incorrect_frequency">>, Witness} | Acc]
-                                                         end
-                                                 end;
-                                             _ ->
-                                                 %% too close
-                                                 [{false, <<"witness_too_close">>, Witness} | Acc]
-                                         catch _:_ ->
-                                                   %% pentagonal distortion
-                                                   [{false, <<"pentagonal_distortion">>, Witness} | Acc]
-                                         end
+                                                                 case check_valid_frequency(SourceLoc, Freq, Ledger) of
+                                                                     true ->
+                                                                         case blockchain:config(?data_aggregation_version, Ledger) of
+                                                                             {ok, DataAggVsn} when DataAggVsn > 1 ->
+                                                                                 case check_rssi_snr(Ledger, RSSI, SNR) of
+                                                                                     true ->
+                                                                                         case blockchain_poc_witness_v1:channel(Witness) == Channel of
+                                                                                             true ->
+                                                                                                 lager:debug("witness ok"),
+                                                                                                 [{true, <<"ok">>, Witness} | Acc];
+                                                                                             false ->
+                                                                                                 lager:debug("witness ~p -> ~p rejected at height ~p for channel ~p /= ~p RSSI ~p SNR ~p",
+                                                                                                             [?TO_ANIMAL_NAME(blockchain_poc_path_element_v1:challengee(Element)),
+                                                                                                              ?TO_ANIMAL_NAME(blockchain_poc_witness_v1:gateway(Witness)),
+                                                                                                              element(2, blockchain_ledger_v1:current_height(Ledger)),
+                                                                                                              blockchain_poc_witness_v1:channel(Witness), Channel,
+                                                                                                              RSSI, SNR]),
+                                                                                                 [{false, <<"witness_on_incorrect_channel">>, Witness} | Acc]
+                                                                                         end;
+                                                                                     {false, LowerBound} ->
+                                                                                         lager:debug("witness ~p -> ~p rejected at height ~p for RSSI ~p below lower bound ~p with SNR ~p",
+                                                                                                     [?TO_ANIMAL_NAME(blockchain_poc_path_element_v1:challengee(Element)),
+                                                                                                      ?TO_ANIMAL_NAME(blockchain_poc_witness_v1:gateway(Witness)),
+                                                                                                      element(2, blockchain_ledger_v1:current_height(Ledger)),
+                                                                                                      RSSI, LowerBound, SNR]),
+                                                                                         [{false, <<"witness_rssi_below_lower_bound">>, Witness} | Acc]
+                                                                                 end;
+                                                                             _ ->
+                                                                                 %% SNR+Freq+Channels not collected, nothing else we can check
+                                                                                 [{true, <<"insufficient_data">>, Witness} | Acc]
+                                                                         end;
+                                                                     _ ->
+                                                                         [{false, <<"incorrect_frequency">>, Witness} | Acc]
+                                                                 end
+                                                         end;
+                                                     _ ->
+                                                         %% too close
+                                                         [{false, <<"witness_too_close">>, Witness} | Acc]
+                                                 catch _:_ ->
+                                                           %% pentagonal distortion
+                                                           [{false, <<"pentagonal_distortion">>, Witness} | Acc]
+                                                 end
 
-                                end
-                        end
+                                         end
+                                 end
+                         end
                  end, [], Witnesses).
 
 scale_unknown_snr(UnknownSNR) ->

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1326,6 +1326,12 @@ validate_var(?regulatory_regions, Value) when is_binary(Value) ->
     end;
 validate_var(?regulatory_regions, Value) ->
     throw({error, {invalid_regulatory_regions_not_binary, Value}});
+validate_var(?discard_zero_freq_witness, Value) ->
+    case Value of
+        true -> ok;
+        false -> ok;
+        _ -> throw({error, {invalid_discard_zero_freq_witness, Value}})
+    end;
 
 validate_var(Var, Value) ->
     %% check if these are dynamic region vars


### PR DESCRIPTION
Problem
----
ETL crashes when `to_json` is invoked and there are witnesses with `0.0` frequency when calculating free_space_path_loss in poc_receipt txn's `tagged_witnesses` function.

Solution
----
This introduces a new chain variable `discard_zero_freq_witness` (boolean) which when set to true will falsify the validity of the witness having `0.0` frequency and subsequently allow `to_json` to pass.