### PR TITLE
Teardown H3 region cache on var txn absorb

### DIFF
--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -1121,6 +1121,8 @@ save_threshold_txn(Txn, Ledger) ->
     DefaultCF = default_cf(Ledger),
     Bin = term_to_binary(Txn),
     Name = threshold_name(Txn),
+    %% This is done to invalidate the region cache on chain var txn absorption
+    _ = blockchain_region_v1:teardown_h3_to_region_cache(),
     cache_put(Ledger, DefaultCF, Name, Bin).
 
 threshold_name(Txn) ->

--- a/src/region/blockchain_region_v1.erl
+++ b/src/region/blockchain_region_v1.erl
@@ -7,7 +7,7 @@
 
 -include("blockchain_vars.hrl").
 
--export([get_all_regions/1, h3_to_region/2, h3_in_region/3]).
+-export([get_all_regions/1, h3_to_region/2, h3_in_region/3, teardown_h3_to_region_cache/0]).
 
 -type regions() :: [atom()].
 
@@ -107,3 +107,6 @@ h3_in_region_(H3, RegionVar, Ledger) ->
         _ ->
             {error, {region_var_not_set, RegionVar}}
     end.
+
+teardown_h3_to_region_cache() ->
+    e2qc:teardown(?H3_TO_REGION_CACHE).

--- a/src/state_channel/blockchain_state_channels_worker.erl
+++ b/src/state_channel/blockchain_state_channels_worker.erl
@@ -239,7 +239,7 @@ offer(
                 "dropping this packet because it will overspend DC ~p, (cost: ~p, total_dcs: ~p)",
                 [DCAmount, NumDCs, TotalDCs]
             ),
-            %% This allow for packets (accepted offer) to come threw
+            %% This allow for packets (accepted offer) to come through
             _ = erlang:send_after(1000, self(), ?OVERSPENT),
             {noreply, State0};
         false ->

--- a/src/state_channel/blockchain_state_channels_worker.erl
+++ b/src/state_channel/blockchain_state_channels_worker.erl
@@ -239,7 +239,7 @@ offer(
                 "dropping this packet because it will overspend DC ~p, (cost: ~p, total_dcs: ~p)",
                 [DCAmount, NumDCs, TotalDCs]
             ),
-            %% This allow for packets (accepted offer) to come threw 
+            %% This allow for packets (accepted offer) to come threw
             _ = erlang:send_after(1000, self(), ?OVERSPENT),
             {noreply, State0};
         false ->
@@ -257,12 +257,12 @@ offer(
                 {error, _Reason} ->
                     lager:warning(
                         "[~p] dropping this packet because: ~p",
-                        [blockchain_state_channel_v1:name(SC), _Reason]
+                        [blockchain_state_channel_v1:id(SC), _Reason]
                     ),
                     ok = send_offer_rejection(HandlerPid, Offer),
                     {noreply, State0};
                 {ok, PurchaseSC} ->
-                    lager:debug("[~p] purchasing offer from ~p", [blockchain_state_channel_v1:name(PurchaseSC), HotspotName]),
+                    lager:debug("[~p] purchasing offer from ~p", [blockchain_state_channel_v1:id(PurchaseSC), HotspotName]),
                     SignedPurchaseSC = blockchain_state_channel_v1:sign(PurchaseSC, OwnerSigFun),
                     PacketHash = blockchain_state_channel_offer_v1:packet_hash(Offer),
                     Region = blockchain_state_channel_offer_v1:region(Offer),


### PR DESCRIPTION
Problem
----
We need to teardown the H3 region cache whenever a new chain var is absorbed on chain.

Solution
----
I've added the teardown for region cache in `save_threshold_txn` fun in ledger, that's the thing which gets invoked on var txn absorb afaict.

PS: There's some brokenness with the calls to an undefined function, that's fixed here too to make dialyzer happy.