### PR TITLE
Demote error log spam to debug level

### DIFF
--- a/src/state_channel/blockchain_state_channels_worker.erl
+++ b/src/state_channel/blockchain_state_channels_worker.erl
@@ -239,7 +239,7 @@ offer(
                 "dropping this packet because it will overspend DC ~p, (cost: ~p, total_dcs: ~p)",
                 [DCAmount, NumDCs, TotalDCs]
             ),
-            %% This allow for packets (accepted offer) to come threw 
+            %% This allow for packets (accepted offer) to come through
             _ = erlang:send_after(1000, self(), ?OVERSPENT),
             {noreply, State0};
         false ->
@@ -257,12 +257,12 @@ offer(
                 {error, _Reason} ->
                     lager:warning(
                         "[~p] dropping this packet because: ~p",
-                        [blockchain_state_channel_v1:name(SC), _Reason]
+                        [blockchain_state_channel_v1:id(SC), _Reason]
                     ),
                     ok = send_offer_rejection(HandlerPid, Offer),
                     {noreply, State0};
                 {ok, PurchaseSC} ->
-                    lager:debug("[~p] purchasing offer from ~p", [blockchain_state_channel_v1:name(PurchaseSC), HotspotName]),
+                    lager:debug("[~p] purchasing offer from ~p", [blockchain_state_channel_v1:id(PurchaseSC), HotspotName]),
                     SignedPurchaseSC = blockchain_state_channel_v1:sign(PurchaseSC, OwnerSigFun),
                     PacketHash = blockchain_state_channel_offer_v1:packet_hash(Offer),
                     Region = blockchain_state_channel_offer_v1:region(Offer),

--- a/src/transactions/v2/blockchain_txn_rewards_v2.erl
+++ b/src/transactions/v2/blockchain_txn_rewards_v2.erl
@@ -1202,7 +1202,8 @@ poc_witness_reward(Txn, AccIn,
                 Path)
     catch
         What:Why:ST ->
-            lager:error("failed to calculate poc_witnesses_rewards, error ~p:~p:~p", [What, Why, ST]),
+            lager:error("error: ~p", [What]),
+            lager:debug("failed to calculate poc_witnesses_rewards, error ~p:~p", [Why, ST]),
             AccIn
     end;
 poc_witness_reward(Txn, AccIn, _Chain, Ledger,
@@ -1453,7 +1454,8 @@ legit_witnesses(Txn, Chain, Ledger, Elem, StaticPath, Version) ->
                            %% [[blockchain_utils:addr2name(blockchain_poc_witness_v1:gateway(W)) || W <- ValidWitnesses]]),
                 ValidWitnesses
             catch What:Why:ST ->
-                      lager:debug("failed to calculate poc_challengees_rewards, error ~p:~p:~p", [What, Why, ST]),
+                      lager:error("error: ~p", [What]),
+                      lager:debug("failed to calculate poc_challengees_rewards, error ~p:~p", [Why, ST]),
                       []
             end;
         V when is_integer(V), V > 4 ->

--- a/src/transactions/v2/blockchain_txn_rewards_v2.erl
+++ b/src/transactions/v2/blockchain_txn_rewards_v2.erl
@@ -1202,8 +1202,8 @@ poc_witness_reward(Txn, AccIn,
                 Path)
     catch
         What:Why:ST ->
-            lager:error("error: ~p", [What]),
-            lager:debug("failed to calculate poc_witnesses_rewards, error ~p:~p", [Why, ST]),
+            lager:error("error: ~p", [Why]),
+            lager:debug("failed to calculate poc_witnesses_rewards, error ~p:~p", [What, ST]),
             AccIn
     end;
 poc_witness_reward(Txn, AccIn, _Chain, Ledger,
@@ -1454,8 +1454,8 @@ legit_witnesses(Txn, Chain, Ledger, Elem, StaticPath, Version) ->
                            %% [[blockchain_utils:addr2name(blockchain_poc_witness_v1:gateway(W)) || W <- ValidWitnesses]]),
                 ValidWitnesses
             catch What:Why:ST ->
-                      lager:error("error: ~p", [What]),
-                      lager:debug("failed to calculate poc_challengees_rewards, error ~p:~p", [Why, ST]),
+                      lager:error("error: ~p", [Why]),
+                      lager:debug("failed to calculate poc_challengees_rewards, error ~p:~p", [What, ST]),
                       []
             end;
         V when is_integer(V), V > 4 ->

--- a/src/transactions/v2/blockchain_txn_rewards_v2.erl
+++ b/src/transactions/v2/blockchain_txn_rewards_v2.erl
@@ -1453,7 +1453,7 @@ legit_witnesses(Txn, Chain, Ledger, Elem, StaticPath, Version) ->
                            %% [[blockchain_utils:addr2name(blockchain_poc_witness_v1:gateway(W)) || W <- ValidWitnesses]]),
                 ValidWitnesses
             catch What:Why:ST ->
-                      lager:error("failed to calculate poc_challengees_rewards, error ~p:~p:~p", [What, Why, ST]),
+                      lager:debug("failed to calculate poc_challengees_rewards, error ~p:~p:~p", [What, Why, ST]),
                       []
             end;
         V when is_integer(V), V > 4 ->


### PR DESCRIPTION
Too much error log spam when the region is unknown in POCV11 land, this demotes it to a debug msg if we need to debug it later.