### PR TITLE
Catch unknown_region explicitly

### DIFF
--- a/src/transactions/v2/blockchain_txn_rewards_v2.erl
+++ b/src/transactions/v2/blockchain_txn_rewards_v2.erl
@@ -1202,10 +1202,11 @@ poc_witness_reward(Txn, AccIn,
                 Path)
     catch
         throw:{error, {unknown_region, Region}}:_ST ->
-            lager:error("Reported unknown_region: ~p", [Region]);
+            lager:error("Reported unknown_region: ~p", [Region]),
+            AccIn;
         What:Why:ST ->
             lager:error("failed to calculate poc_witness_rewards, error ~p:~p:~p", [What, Why, ST]),
-            []
+            AccIn
     end;
 poc_witness_reward(Txn, AccIn, _Chain, Ledger,
                    #{ poc_version := POCVersion } = Vars) when is_integer(POCVersion)
@@ -1456,7 +1457,8 @@ legit_witnesses(Txn, Chain, Ledger, Elem, StaticPath, Version) ->
                 ValidWitnesses
             catch
                 throw:{error, {unknown_region, Region}}:_ST ->
-                    lager:error("Reported unknown_region: ~p", [Region]);
+                    lager:error("Reported unknown_region: ~p", [Region]),
+                    [];
                 What:Why:ST ->
                     lager:error("failed to calculate poc_challengees_rewards, error ~p:~p:~p", [What, Why, ST]),
                     []

--- a/src/transactions/v2/blockchain_txn_rewards_v2.erl
+++ b/src/transactions/v2/blockchain_txn_rewards_v2.erl
@@ -1201,10 +1201,11 @@ poc_witness_reward(Txn, AccIn,
                 AccIn,
                 Path)
     catch
+        throw:{error, {unknown_region, Region}}:_ST ->
+            lager:error("Reported unknown_region: ~p", [Region]);
         What:Why:ST ->
-            lager:error("error: ~p", [Why]),
-            lager:debug("failed to calculate poc_witnesses_rewards, error ~p:~p", [What, ST]),
-            AccIn
+            lager:error("failed to calculate poc_witness_rewards, error ~p:~p:~p", [What, Why, ST]),
+            []
     end;
 poc_witness_reward(Txn, AccIn, _Chain, Ledger,
                    #{ poc_version := POCVersion } = Vars) when is_integer(POCVersion)
@@ -1453,10 +1454,12 @@ legit_witnesses(Txn, Chain, Ledger, Elem, StaticPath, Version) ->
                 %% lager:info("ValidWitnesses: ~p",
                            %% [[blockchain_utils:addr2name(blockchain_poc_witness_v1:gateway(W)) || W <- ValidWitnesses]]),
                 ValidWitnesses
-            catch What:Why:ST ->
-                      lager:error("error: ~p", [Why]),
-                      lager:debug("failed to calculate poc_challengees_rewards, error ~p:~p", [What, ST]),
-                      []
+            catch
+                throw:{error, {unknown_region, Region}}:_ST ->
+                    lager:error("Reported unknown_region: ~p", [Region]);
+                What:Why:ST ->
+                    lager:error("failed to calculate poc_challengees_rewards, error ~p:~p:~p", [What, Why, ST]),
+                    []
             end;
         V when is_integer(V), V > 4 ->
             blockchain_txn_poc_receipts_v1:good_quality_witnesses(Elem, Ledger);


### PR DESCRIPTION
This catches the following reported errors explicitly but slightly less verbosely, while keeping the other errors exceptional.

```
15719:2021-11-10 18:52:06.342 [error] <0.1349.0>@blockchain_txn_rewards_v2:poc_witness_reward:1205 failed to calculate poc_witnesses_rewards, error throw:{error,{unknown_region,631729024070503935}}:[{blockchain_txn_poc_receipts_v1,get_channels_,3,[{file,"/opt/blockchain-etl/_build/default/lib/blockchain/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl"},{line,1623}]},
```

```
15718:2021-11-10 18:52:06.342 [error] <0.1349.0>@blockchain_txn_rewards_v2:legit_witnesses:1456 failed to calculate poc_challengees_rewards, error throw:{error,{unknown_region,631729024070503935}}:[{blockchain_txn_poc_receipts_v1,get_channels_,3,[{file,"/opt/blockchain-etl/_build/default/lib/blockchain/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl"},{line,1623}]},{
```