### PR TITLE
Test fix for no genesis boot crash

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -165,6 +165,9 @@ new(Dir, undefined, QuickSyncMode, QuickSyncData) ->
             lager:error("DB corrupted cleaning up ~p", [_Corrupted]),
             ok = clean(Blockchain),
             new(Dir, undefined, QuickSyncMode, QuickSyncData);
+        {Blockchain, {error, not_found}} ->
+            lager:info("no genesis block found, returning bare chain"),
+            {no_genesis, Blockchain};
         {Blockchain, {error, _Reason}} ->
             lager:info("no genesis block found: ~p", [_Reason]),
             {no_genesis, init_quick_sync(QuickSyncMode, Blockchain, QuickSyncData)};

--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -165,12 +165,9 @@ new(Dir, undefined, QuickSyncMode, QuickSyncData) ->
             lager:error("DB corrupted cleaning up ~p", [_Corrupted]),
             ok = clean(Blockchain),
             new(Dir, undefined, QuickSyncMode, QuickSyncData);
-        {Blockchain, {error, not_found}} ->
-            lager:info("no genesis block found, returning bare chain"),
-            {no_genesis, Blockchain};
         {Blockchain, {error, _Reason}} ->
             lager:info("no genesis block found: ~p", [_Reason]),
-            {no_genesis, init_quick_sync(QuickSyncMode, Blockchain, QuickSyncData)};
+            {no_genesis, Blockchain};
         {Blockchain, {ok, _GenBlock}} ->
             lager:info("stuff is ok"),
             {ok, init_quick_sync(QuickSyncMode, Blockchain, QuickSyncData)}


### PR DESCRIPTION
Problem
----
When testing locally and supplying `{honor_quick_sync, false}`, miner would not boot at all and crash catastrophically.

Solution
----
If there is no genesis block, just return the bare chain without trying to quick sync.