### PR TITLE
Dont get ledger twice

### DIFF
--- a/src/transactions/v1/blockchain_txn_state_channel_close_v1.erl
+++ b/src/transactions/v1/blockchain_txn_state_channel_close_v1.erl
@@ -338,7 +338,6 @@ absorb(Txn, Chain) ->
         {error, _Reason}=Error ->
             Error;
         ok ->
-            Ledger = blockchain:ledger(Chain),
             MaxActorsAllowed = blockchain_state_channel_v1:max_actors_allowed(Ledger),
             {MergedSC, HadConflict} = case ?MODULE:conflicts_with(Txn) of
                                           undefined -> {SC, false};


### PR DESCRIPTION
There seems to be a typo in sc close v1 transaction absorb where we are getting the ledger twice from the incoming Chain handle.