### PR TITLE
Implement balance-clearing txn payments

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -358,6 +358,9 @@
 %% Set this var to false to disable zero amount txns (payment_v1, payment_v2, htlc_create)
 -define(allow_zero_amount, allow_zero_amount).
 
+%% Set this var to `true' to enable balance clearing txns
+-define(enable_balance_clearing, enable_balance_clearing). % boolean
+
 %% General txn vars
 
 %% Enable more robust validation on some legacy transactions with incorrect on-chain txns

--- a/rebar.config
+++ b/rebar.config
@@ -40,7 +40,7 @@
     {erlang_stats, ".*", {git, "https://github.com/helium/erlang-stats.git", {branch, "master"}}},
     {e2qc, ".*", {git, "https://github.com/helium/e2qc", {branch, "master"}}},
     {vincenty, ".*", {git, "https://github.com/helium/vincenty", {branch, "master"}}},
-    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "master"}}},
+    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "jg/clean_close_payment"}}},
     {merkerl, ".*", {git, "https://github.com/helium/merkerl.git", {branch, "master"}}},
     {xxhash, {git, "https://github.com/pierreis/erlang-xxhash", {branch, "master"}}},
     {exor_filter, ".*", {git, "https://github.com/mpope9/exor_filter", {branch, "master"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -40,7 +40,7 @@
     {erlang_stats, ".*", {git, "https://github.com/helium/erlang-stats.git", {branch, "master"}}},
     {e2qc, ".*", {git, "https://github.com/helium/e2qc", {branch, "master"}}},
     {vincenty, ".*", {git, "https://github.com/helium/vincenty", {branch, "master"}}},
-    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "jg/clean_close_payment"}}},
+    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "master"}}},
     {merkerl, ".*", {git, "https://github.com/helium/merkerl.git", {branch, "master"}}},
     {xxhash, {git, "https://github.com/pierreis/erlang-xxhash", {branch, "master"}}},
     {exor_filter, ".*", {git, "https://github.com/mpope9/exor_filter", {branch, "master"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -77,7 +77,7 @@
  {<<"hackney">>,{pkg,<<"hackney">>,<<"1.18.0">>},0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"73ed90cc875451ddcdff968a368c586e55eb730a"}},
+       {ref,"c3826f6bc385a59bd59464dee2a4a0caeb544972"}},
   0},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},2},
  {<<"idna">>,{pkg,<<"idna">>,<<"6.1.1">>},1},

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1087,8 +1087,11 @@ validate_var(?poc_v4_randomness_wt, Value) ->
     validate_float(Value, "poc_v4_randomness_wt", 0.0, 1.0);
 validate_var(?poc_v5_target_prob_randomness_wt, Value) ->
     validate_float(Value, "poc_v5_target_prob_randomness_wt", 0.0, 1.0);
-validate_var(?poc_typo_fixes, Value) when is_boolean(Value) -> ok;
-validate_var(?poc_typo_fixes, Value) -> throw({error, {invalidate_poc_typo_fixes, Value}});
+validate_var(?poc_typo_fixes, Value) ->
+    case Value of
+        Val when is_boolean(Val) -> ok;
+        _ -> throw({error, {invalid_poc_typo_fixes, Value}})
+    end;
 validate_var(?poc_target_hex_parent_res, Value) ->
     validate_int(Value, "poc_target_hex_parent_res", 3, 7, false);
 validate_var(?poc_target_hex_collection_res, Value) ->
@@ -1109,8 +1112,11 @@ validate_var(?fspl_loss, Value) ->
     validate_float(Value, "fspl_loss", 0.0, 5.0);
 validate_var(?poc_distance_limit, Value) ->
     validate_int(Value, "poc_distance_limit", 0, 1000, false);
-validate_var(?check_snr, Value) when is_boolean(Value)-> ok;
-validate_var(?check_snr, Value) -> throw({error, {invalid_check_snr, Value}});
+validate_var(?check_snr, Value) ->
+    case Value of
+        Val when is_boolean(Val) -> ok;
+        _ -> throw({error, {invalid_check_snr, Value}})
+    end;
 validate_var(?polyfill_resolution, Value) ->
     validate_int(Value, "polyfill_resolution", 0, 15, false);
 validate_var(?h3dex_gc_width, Value) ->
@@ -1193,17 +1199,29 @@ validate_var(?max_bundle_size, Value) ->
 validate_var(?max_payments, Value) ->
     validate_int(Value, "max_payments", 5, 50, false);
 
-validate_var(?deprecate_payment_v1, Value) when is_boolean(Value) -> ok;
-validate_var(?deprecate_payment_v1, Value) -> throw({error, {invalidate_deprecate_payment_v1, Value}});
+validate_var(?deprecate_payment_v1, Value) ->
+    case Value of
+        Val when is_boolean(Val) -> ok;
+        _ -> throw({error, {invalidate_deprecate_payment_v1, Value}})
+    end;
 
-validate_var(?allow_payment_v2_memos, Value) when is_boolean(Value) -> ok;
-validate_var(?allow_payment_v2_memos, Value) -> throw({error, {invalid_allow_payment_v2_memos, Value}});
+validate_var(?allow_payment_v2_memos, Value) ->
+    case Value of
+        Val when is_boolean(Val) -> ok;
+        _ -> throw({error, {invalid_allow_payment_v2_memos, Value}})
+    end;
 
-validate_var(?allow_zero_amount, Value) when is_boolean(Value) -> ok;
-validate_var(?allow_zero_amount, Value) -> throw({error, {invalid_allow_zero_amount, Value}});
+validate_var(?allow_zero_amount, Value) ->
+    case Value of
+        Val when is_boolean(Val) -> ok;
+        _ -> throw({error, {invalid_allow_zero_amount, Value}})
+    end;
 
-validate_var(?enable_balance_clearing, Value) when is_boolean(Value) -> ok;
-validate_var(?enable_balance_clearing, Value) -> throw({error, {invalid_enable_balance_clearing, Value}});
+validate_var(?enable_balance_clearing, Value) ->
+    case Value of
+        Val when is_boolean(Val) -> ok;
+        _ -> throw({error, {invalid_enable_balance_clearing, Value}})
+    end;
 
 %% general txn vars
 
@@ -1244,8 +1262,11 @@ validate_var(?sc_gc_interval, Value) ->
     validate_int(Value, "sc_gc_interval", 10, 100, false);
 validate_var(?sc_max_actors, Value) ->
     validate_int(Value, "sc_max_actors", 500, 10000, false);
-validate_var(?sc_only_count_open_active, Value) when is_boolean(Value) -> ok;
-validate_var(?sc_only_count_open_active, Value) -> throw({error, {invalid_sc_only_count_open_active_value, Value}});
+validate_var(?sc_only_count_open_active, Value) ->
+    case Value of
+        Val when is_boolean(Val) -> ok;
+        _ -> throw({error, {invalid_sc_only_count_open_active_value, Value}})
+    end;
 validate_var(?sc_dispute_strategy_version, Value) ->
     validate_int(Value, "sc_dispute_strategy_version", 0, 1, false);
 
@@ -1296,8 +1317,11 @@ validate_var(?price_oracle_height_delta, Value) ->
     validate_int(Value, "price_oracle_height_delta", 0, 500, false);
 
 %% txn fee related vars
-validate_var(?txn_fees, Value) when is_boolean(Value) -> ok;
-validate_var(?txn_fees, Value) -> throw({error, {invalid_txn_fees, Value}});
+validate_var(?txn_fees, Value) ->
+    case Value of
+        Val when is_boolean(Val) -> ok;
+        _ -> throw({error, {invalid_txn_fees, Value}})
+    end;
 
 validate_var(?staking_keys, Value) ->
     validate_staking_keys_format(Value);
@@ -1347,8 +1371,11 @@ validate_var(?txn_fee_multiplier, Value) ->
 validate_var(?data_aggregation_version, Value) ->
     validate_int(Value, "data_aggregation_version", 1, 3, false);
 
-validate_var(?use_multi_keys, Value) when is_boolean(Value) -> ok;
-validate_var(?use_multi_keys, Value) -> throw({error, {invalid_multi_keys, Value}});
+validate_var(?use_multi_keys, Value) ->
+    case Value of
+        Val when is_boolean(Val) -> ok;
+        _ -> throw({error, {invalid_multi_keys, Value}})
+    end;
 
 validate_var(?transfer_hotspot_stale_poc_blocks, Value) ->
     validate_int(Value, "transfer_hotspot_stale_poc_blocks", 1, 50000, false);
@@ -1438,8 +1465,11 @@ validate_var(?validator_liveness_grace_period, Value) ->
     validate_int(Value, "validator_liveness_grace_period", 1, 200, false);
 validate_var(?validator_hb_reactivation_limit, Value) ->
     validate_int(Value, "validator_hb_reactivation_limit", 5, 100, false);
-validate_var(?validator_key_check, Value) when is_boolean(Value) -> ok;
-validate_var(?validator_key_check, Value) -> throw({error, {invalidate_validator_key_check, Value}});
+validate_var(?validator_key_check, Value) ->
+    case Value of
+        Val when is_boolean(Val) -> ok;
+        _ -> throw({error, {invalidate_validator_key_check, Value}})
+    end;
 %% TODO fix this var
 validate_var(?stake_withdrawal_cooldown, Value) ->
     %% maybe set this in the test
@@ -1458,8 +1488,11 @@ validate_var(?penalty_history_limit, Value) ->
     %% also low end cannot be 0
     validate_int(Value, "penalty_history_limit", 10, 100000, false);
 
-validate_var(?net_emissions_enabled, Value) when is_boolean(Value) -> ok;
-validate_var(?net_emissions_enabled, Value) -> throw({error, {invalid_net_emissions_boolean, Value}});
+validate_var(?net_emissions_enabled, Value) ->
+    case Value of
+        Val when is_boolean(Val) -> ok;
+        _ -> throw({error, {invalid_net_emissions_boolean, Value}})
+    end;
 validate_var(?net_emissions_max_rate, Value) ->
     validate_int(Value, "net_emissions_max_rate", 0, ?bones(200), false);
 
@@ -1477,8 +1510,11 @@ validate_var(?regulatory_regions, Value) when is_binary(Value) ->
     end;
 validate_var(?regulatory_regions, Value) ->
     throw({error, {invalid_regulatory_regions_not_binary, Value}});
-validate_var(?discard_zero_freq_witness, Value) when is_boolean(Value) -> ok;
-validate_var(?discard_zero_freq_witness, Value) -> throw({error, {invalid_discard_zero_freq_witness, Value}});
+validate_var(?discard_zero_freq_witness, Value) ->
+    case Value of
+        Val when is_boolean(Val) -> ok;
+        _ -> throw({error, {invalid_discard_zero_freq_witness, Value}})
+    end;
 validate_var(?block_size_limit, Value) ->
     validate_int(Value, "block_size_limit", 1*1024*1024, 512*1024*1024, false);
 

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1087,12 +1087,8 @@ validate_var(?poc_v4_randomness_wt, Value) ->
     validate_float(Value, "poc_v4_randomness_wt", 0.0, 1.0);
 validate_var(?poc_v5_target_prob_randomness_wt, Value) ->
     validate_float(Value, "poc_v5_target_prob_randomness_wt", 0.0, 1.0);
-validate_var(?poc_typo_fixes, Value) ->
-    case Value of
-        true -> ok;
-        false -> ok;
-        _ -> throw({error, {invalid_poc_typo_fixes, Value}})
-    end;
+validate_var(?poc_typo_fixes, Value) when is_boolean(Value) -> ok;
+validate_var(?poc_typo_fixes, Value) -> throw({error, {invalidate_poc_typo_fixes, Value}});
 validate_var(?poc_target_hex_parent_res, Value) ->
     validate_int(Value, "poc_target_hex_parent_res", 3, 7, false);
 validate_var(?poc_target_hex_collection_res, Value) ->
@@ -1113,12 +1109,8 @@ validate_var(?fspl_loss, Value) ->
     validate_float(Value, "fspl_loss", 0.0, 5.0);
 validate_var(?poc_distance_limit, Value) ->
     validate_int(Value, "poc_distance_limit", 0, 1000, false);
-validate_var(?check_snr, Value) ->
-    case Value of
-        true -> ok;
-        false -> ok;
-        _ -> throw({error, {invalid_check_snr, Value}})
-    end;
+validate_var(?check_snr, Value) when is_boolean(Value)-> ok;
+validate_var(?check_snr, Value) -> throw({error, {invalid_check_snr, Value}});
 validate_var(?polyfill_resolution, Value) ->
     validate_int(Value, "polyfill_resolution", 0, 15, false);
 validate_var(?h3dex_gc_width, Value) ->
@@ -1201,26 +1193,17 @@ validate_var(?max_bundle_size, Value) ->
 validate_var(?max_payments, Value) ->
     validate_int(Value, "max_payments", 5, 50, false);
 
-validate_var(?deprecate_payment_v1, Value) ->
-    case Value of
-        true -> ok;
-        false -> ok;
-        _ -> throw({error, {invalid_deprecate_payment_v1, Value}})
-    end;
+validate_var(?deprecate_payment_v1, Value) when is_boolean(Value) -> ok;
+validate_var(?deprecate_payment_v1, Value) -> throw({error, {invalidate_deprecate_payment_v1, Value}});
 
-validate_var(?allow_payment_v2_memos, Value) ->
-    case Value of
-        true -> ok;
-        false -> ok;
-        _ -> throw({error, {invalid_allow_payment_v2_memos, Value}})
-    end;
+validate_var(?allow_payment_v2_memos, Value) when is_boolean(Value) -> ok;
+validate_var(?allow_payment_v2_memos, Value) -> throw({error, {invalid_allow_payment_v2_memos, Value}});
 
-validate_var(?allow_zero_amount, Value) ->
-    case Value of
-        true -> ok;
-        false -> ok;
-        _ -> throw({error, {invalid_allow_zero_amount, Value}})
-    end;
+validate_var(?allow_zero_amount, Value) when is_boolean(Value) -> ok;
+validate_var(?allow_zero_amount, Value) -> throw({error, {invalid_allow_zero_amount, Value}});
+
+validate_var(?enable_balance_clearing, Value) when is_boolean(Value) -> ok;
+validate_var(?enable_balance_clearing, Value) -> throw({error, {invalid_enable_balance_clearing, Value}});
 
 %% general txn vars
 
@@ -1261,12 +1244,8 @@ validate_var(?sc_gc_interval, Value) ->
     validate_int(Value, "sc_gc_interval", 10, 100, false);
 validate_var(?sc_max_actors, Value) ->
     validate_int(Value, "sc_max_actors", 500, 10000, false);
-validate_var(?sc_only_count_open_active, Value) ->
-    case Value of
-        true -> ok;
-        false -> ok;
-        Other -> throw({error, {invalid_sc_only_count_open_active_value, Other}})
-    end;
+validate_var(?sc_only_count_open_active, Value) when is_boolean(Value) -> ok;
+validate_var(?sc_only_count_open_active, Value) -> throw({error, {invalid_sc_only_count_open_active_value, Value}});
 validate_var(?sc_dispute_strategy_version, Value) ->
     validate_int(Value, "sc_dispute_strategy_version", 0, 1, false);
 
@@ -1317,12 +1296,8 @@ validate_var(?price_oracle_height_delta, Value) ->
     validate_int(Value, "price_oracle_height_delta", 0, 500, false);
 
 %% txn fee related vars
-validate_var(?txn_fees, Value) ->
-    case Value of
-        true -> ok;
-        false -> ok;
-        _ -> throw({error, {invalid_txn_fees, Value}})
-    end;
+validate_var(?txn_fees, Value) when is_boolean(Value) -> ok;
+validate_var(?txn_fees, Value) -> throw({error, {invalid_txn_fees, Value}});
 
 validate_var(?staking_keys, Value) ->
     validate_staking_keys_format(Value);
@@ -1372,12 +1347,8 @@ validate_var(?txn_fee_multiplier, Value) ->
 validate_var(?data_aggregation_version, Value) ->
     validate_int(Value, "data_aggregation_version", 1, 3, false);
 
-validate_var(?use_multi_keys, Value) ->
-    case Value of
-        true -> ok;
-        false -> ok;
-        _ -> throw({error, {invalid_multi_keys, Value}})
-    end;
+validate_var(?use_multi_keys, Value) when is_boolean(Value) -> ok;
+validate_var(?use_multi_keys, Value) -> throw({error, {invalid_multi_keys, Value}});
 
 validate_var(?transfer_hotspot_stale_poc_blocks, Value) ->
     validate_int(Value, "transfer_hotspot_stale_poc_blocks", 1, 50000, false);
@@ -1467,12 +1438,8 @@ validate_var(?validator_liveness_grace_period, Value) ->
     validate_int(Value, "validator_liveness_grace_period", 1, 200, false);
 validate_var(?validator_hb_reactivation_limit, Value) ->
     validate_int(Value, "validator_hb_reactivation_limit", 5, 100, false);
-validate_var(?validator_key_check, Value) ->
-    case Value of
-        true -> ok;
-        false -> ok;
-        _ -> throw({error, {invalid_validator_key_check, Value}})
-    end;
+validate_var(?validator_key_check, Value) when is_boolean(Value) -> ok;
+validate_var(?validator_key_check, Value) -> throw({error, {invalidate_validator_key_check, Value}});
 %% TODO fix this var
 validate_var(?stake_withdrawal_cooldown, Value) ->
     %% maybe set this in the test
@@ -1491,12 +1458,8 @@ validate_var(?penalty_history_limit, Value) ->
     %% also low end cannot be 0
     validate_int(Value, "penalty_history_limit", 10, 100000, false);
 
-validate_var(?net_emissions_enabled, Value) ->
-    case Value of
-        true -> ok;
-        false -> ok;
-        _ -> throw({error, {invalid_net_emissions_boolean, Value}})
-    end;
+validate_var(?net_emissions_enabled, Value) when is_boolean(Value) -> ok;
+validate_var(?net_emissions_enabled, Value) -> throw({error, {invalid_net_emissions_boolean, Value}});
 validate_var(?net_emissions_max_rate, Value) ->
     validate_int(Value, "net_emissions_max_rate", 0, ?bones(200), false);
 
@@ -1514,12 +1477,8 @@ validate_var(?regulatory_regions, Value) when is_binary(Value) ->
     end;
 validate_var(?regulatory_regions, Value) ->
     throw({error, {invalid_regulatory_regions_not_binary, Value}});
-validate_var(?discard_zero_freq_witness, Value) ->
-    case Value of
-        true -> ok;
-        false -> ok;
-        _ -> throw({error, {invalid_discard_zero_freq_witness, Value}})
-    end;
+validate_var(?discard_zero_freq_witness, Value) when is_boolean(Value) -> ok;
+validate_var(?discard_zero_freq_witness, Value) -> throw({error, {invalid_discard_zero_freq_witness, Value}});
 validate_var(?block_size_limit, Value) ->
     validate_int(Value, "block_size_limit", 1*1024*1024, 512*1024*1024, false);
 

--- a/src/transactions/v2/blockchain_payment_v2.erl
+++ b/src/transactions/v2/blockchain_payment_v2.erl
@@ -15,7 +15,9 @@
          payee/1,
          amount/1,
          memo/1, memo/2,
+         max/1,
          is_valid_memo/1,
+         is_valid_max/1,
          print/1,
          json_type/0,
          to_json/2
@@ -31,23 +33,40 @@
 -export_type([payment/0, payments/0]).
 
 -spec new(Payee :: libp2p_crypto:pubkey_bin(),
-          Amount :: non_neg_integer()) -> payment().
-new(Payee, Amount) ->
+          Amount :: non_neg_integer() | max) -> payment().
+new(Payee, Amount) when is_integer(Amount) ->
     #payment_pb{
        payee=Payee,
        amount=Amount,
-       memo=0
+       memo=0,
+       max=false
+      };
+new(Payee, max) ->
+    #payment_pb{
+       payee=Payee,
+       amount=0,
+       memo=0,
+       max=true
       }.
 
 -spec new(Payee :: libp2p_crypto:pubkey_bin(),
-          Amount :: non_neg_integer(),
+          Amount :: non_neg_integer() | max ,
           Memo :: non_neg_integer()) -> payment().
-new(Payee, Amount, Memo) ->
+new(Payee, Amount, Memo) when is_integer(Amount) ->
     #payment_pb{
        payee=Payee,
        amount=Amount,
-       memo=Memo
+       memo=Memo,
+       max=false
+      };
+new(Payee, max, Memo) ->
+    #payment_pb{
+       payee=Payee,
+       amount=0,
+       memo=Memo,
+       max=true
       }.
+
 
 -spec payee(Payment :: payment()) -> libp2p_crypto:pubkey_bin().
 payee(Payment) ->
@@ -65,6 +84,10 @@ memo(Payment) ->
 memo(Payment, Memo) ->
     Payment#payment_pb{memo=Memo}.
 
+-spec max(Payment :: payment()) -> boolean().
+max(Payment) ->
+    Payment#payment_pb.max.
+
 -spec is_valid_memo(Payment :: payment()) -> boolean().
 is_valid_memo(#payment_pb{memo = Memo}) ->
     try
@@ -75,10 +98,15 @@ is_valid_memo(#payment_pb{memo = Memo}) ->
             false
     end.
 
+-spec is_valid_max(Payment :: payment()) -> boolean().
+is_valid_max(#payment_pb{amount=Amount, max=false}) when Amount > 0 -> true;
+is_valid_max(#payment_pb{amount=0, max=true}) -> true;
+is_valid_max(_) -> false.
+
 print(undefined) ->
     <<"type=payment undefined">>;
-print(#payment_pb{payee=Payee, amount=Amount, memo=Memo}) ->
-    io_lib:format("type=payment payee: ~p amount: ~p, memo: ~p", [?TO_B58(Payee), Amount, Memo]).
+print(#payment_pb{payee=Payee, amount=Amount, memo=Memo, max=Max}) ->
+    io_lib:format("type=payment payee: ~p amount: ~p, memo: ~p, max: ~p", [?TO_B58(Payee), Amount, Memo, Max]).
 
 json_type() ->
     undefined.
@@ -88,7 +116,8 @@ to_json(Payment, _Opts) ->
     #{
       payee => ?BIN_TO_B58(payee(Payment)),
       amount => amount(Payment),
-      memo => ?MAYBE_FN(fun (V) -> base64:encode(<<(V):64/unsigned-little-integer>>) end, memo(Payment))
+      memo => ?MAYBE_FN(fun (V) -> base64:encode(<<(V):64/unsigned-little-integer>>) end, memo(Payment)),
+      max => ?MODULE:max(Payment)
      }.
 
 %% ------------------------------------------------------------------
@@ -108,10 +137,22 @@ amount_test() ->
     Payment = new(<<"payee">>, 100),
     ?assertEqual(100, ?MODULE:amount(Payment)).
 
+max_test() ->
+    Payment1 = new(<<"payee">>, 100),
+    ?assertEqual(false, ?MODULE:max(Payment1)),
+    Payment2 = new(<<"payee">>, max),
+    ?assertEqual(true, ?MODULE:max(Payment2)).
+
+is_valid_max_test() ->
+    Payment1 = new(<<"payee1">>, max),
+    ?assertEqual(true, ?MODULE:is_valid_max(Payment1)),
+    Payment2 = #payment_pb{payee= <<"payee2">>, amount= 100, max= true},
+    ?assertEqual(false, ?MODULE:is_valid_max(Payment2)).
+
 to_json_test() ->
     Payment = new(<<"payee">>, 100),
     Json = to_json(Payment, []),
     ?assert(lists:all(fun(K) -> maps:is_key(K, Json) end,
-                      [payee, amount])).
+                      [payee, amount, memo, max])).
 
 -endif.

--- a/src/transactions/v2/blockchain_txn_payment_v2.erl
+++ b/src/transactions/v2/blockchain_txn_payment_v2.erl
@@ -18,25 +18,25 @@
 -include_lib("helium_proto/include/blockchain_txn_payment_v2_pb.hrl").
 
 -export([
-         new/3,
-         hash/1,
-         payer/1,
-         payments/1,
-         payees/1,
-         amounts/1,
-         total_amount/1,
-         fee/1, fee/2,
-         fee_payer/2,
-         calculate_fee/2, calculate_fee/5,
-         nonce/1,
-         signature/1,
-         sign/2,
-         is_valid/2,
-         absorb/2,
-         print/1,
-         json_type/0,
-         to_json/2
-        ]).
+    new/3,
+    hash/1,
+    payer/1,
+    payments/1,
+    payees/1,
+    amounts/2,
+    total_amount/2,
+    fee/1, fee/2,
+    fee_payer/2,
+    calculate_fee/2, calculate_fee/5,
+    nonce/1,
+    signature/1,
+    sign/2,
+    is_valid/2,
+    absorb/2,
+    print/1,
+    json_type/0,
+    to_json/2
+]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -46,17 +46,19 @@
 
 -export_type([txn_payment_v2/0]).
 
--spec new(Payer :: libp2p_crypto:pubkey_bin(),
-          Payments :: blockchain_payment_v2:payments(),
-          Nonce :: non_neg_integer()) -> txn_payment_v2().
+-spec new(
+    Payer :: libp2p_crypto:pubkey_bin(),
+    Payments :: blockchain_payment_v2:payments(),
+    Nonce :: non_neg_integer()
+) -> txn_payment_v2().
 new(Payer, Payments, Nonce) ->
     #blockchain_txn_payment_v2_pb{
-       payer=Payer,
-       payments=Payments,
-       nonce=Nonce,
-       fee=?LEGACY_TXN_FEE,
-       signature = <<>>
-      }.
+        payer = Payer,
+        payments = Payments,
+        nonce = Nonce,
+        fee = ?LEGACY_TXN_FEE,
+        signature = <<>>
+    }.
 
 -spec hash(txn_payment_v2()) -> blockchain_txn:hash().
 hash(Txn) ->
@@ -76,13 +78,16 @@ payments(Txn) ->
 payees(Txn) ->
     [blockchain_payment_v2:payee(Payment) || Payment <- ?MODULE:payments(Txn)].
 
--spec amounts(txn_payment_v2()) -> [pos_integer()].
-amounts(Txn) ->
-    [blockchain_payment_v2:amount(Payment) || Payment <- ?MODULE:payments(Txn)].
+-spec amounts(txn_payment_v2(), blockchain_ledger_v1:ledger()) -> [pos_integer()].
+amounts(Txn, Ledger) ->
+    case split_payment_amounts(Txn, Ledger) of
+        {undefined, Payments} -> Payments;
+        {MaxPayment, Payments} -> [MaxPayment | Payments]
+    end.
 
--spec total_amount(txn_payment_v2()) -> pos_integer().
-total_amount(Txn) ->
-    lists:sum(?MODULE:amounts(Txn)).
+-spec total_amount(txn_payment_v2(), blockchain_ledger_v1:ledger()) -> pos_integer().
+total_amount(Txn, Ledger) ->
+    lists:sum(?MODULE:amounts(Txn, Ledger)).
 
 -spec fee(txn_payment_v2()) -> non_neg_integer().
 fee(Txn) ->
@@ -90,9 +95,10 @@ fee(Txn) ->
 
 -spec fee(txn_payment_v2(), non_neg_integer()) -> txn_payment_v2().
 fee(Txn, Fee) ->
-    Txn#blockchain_txn_payment_v2_pb{fee=Fee}.
+    Txn#blockchain_txn_payment_v2_pb{fee = Fee}.
 
--spec fee_payer(txn_payment_v2(), blockchain_ledger_v1:ledger()) -> libp2p_crypto:pubkey_bin() | undefined.
+-spec fee_payer(txn_payment_v2(), blockchain_ledger_v1:ledger()) ->
+    libp2p_crypto:pubkey_bin() | undefined.
 fee_payer(Txn, _Ledger) ->
     payer(Txn).
 
@@ -107,7 +113,7 @@ signature(Txn) ->
 -spec sign(txn_payment_v2(), libp2p_crypto:sig_fun()) -> txn_payment_v2().
 sign(Txn, SigFun) ->
     EncodedTxn = blockchain_txn_payment_v2_pb:encode_msg(Txn),
-    Txn#blockchain_txn_payment_v2_pb{signature=SigFun(EncodedTxn)}.
+    Txn#blockchain_txn_payment_v2_pb{signature = SigFun(EncodedTxn)}.
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -119,18 +125,30 @@ sign(Txn, SigFun) ->
 calculate_fee(Txn, Chain) ->
     ?calculate_fee_prep(Txn, Chain).
 
--spec calculate_fee(txn_payment_v2(), blockchain_ledger_v1:ledger(), pos_integer(), pos_integer(), boolean()) -> non_neg_integer().
+-spec calculate_fee(
+    txn_payment_v2(), blockchain_ledger_v1:ledger(), pos_integer(), pos_integer(), boolean()
+) -> non_neg_integer().
 calculate_fee(_Txn, _Ledger, _DCPayloadSize, _TxnFeeMultiplier, false) ->
     ?LEGACY_TXN_FEE;
 calculate_fee(Txn, Ledger, DCPayloadSize, TxnFeeMultiplier, true) ->
-    ?calculate_fee(Txn#blockchain_txn_payment_v2_pb{fee=0, signature = <<0:512>>}, Ledger, DCPayloadSize, TxnFeeMultiplier).
+    ?calculate_fee(
+        Txn#blockchain_txn_payment_v2_pb{fee = 0, signature = <<0:512>>},
+        Ledger,
+        DCPayloadSize,
+        TxnFeeMultiplier
+    ).
 
 -spec is_valid(txn_payment_v2(), blockchain:blockchain()) -> ok | {error, any()}.
 is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     case blockchain:config(?max_payments, Ledger) of
         {ok, M} when is_integer(M) ->
-            case blockchain_txn:validate_fields([{{payee, P}, {address, libp2p}} || P <- ?MODULE:payees(Txn)]) of
+            case
+                blockchain_txn:validate_fields([
+                    {{payee, P}, {address, libp2p}}
+                 || P <- ?MODULE:payees(Txn)
+                ])
+            of
                 ok ->
                     do_is_valid_checks(Txn, Chain, M);
                 Error ->
@@ -140,48 +158,80 @@ is_valid(Txn, Chain) ->
             {error, {invalid, max_payments_not_set}}
     end.
 
-
 -spec absorb(txn_payment_v2(), blockchain:blockchain()) -> ok | {error, any()}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
-    TotAmount = ?MODULE:total_amount(Txn),
+    SpecifiedAmount = lists:sum([blockchain_payment_v2:amount(Payment) || Payment <- ?MODULE:payments(Txn)]),
+    TotAmount = ?MODULE:total_amount(Txn, Ledger),
+    MaxPayment = TotAmount - SpecifiedAmount,
     Fee = ?MODULE:fee(Txn),
     Hash = ?MODULE:hash(Txn),
     Payer = ?MODULE:payer(Txn),
     Nonce = ?MODULE:nonce(Txn),
     AreFeesEnabled = blockchain_ledger_v1:txn_fees_active(Ledger),
     case blockchain_ledger_v1:debit_fee(Payer, Fee, Ledger, AreFeesEnabled, Hash, Chain) of
-        {error, _Reason}=Error ->
+        {error, _Reason} = Error ->
             Error;
         ok ->
             case blockchain_ledger_v1:debit_account(Payer, TotAmount, Nonce, Ledger) of
-                {error, _Reason}=Error ->
+                {error, _Reason} = Error ->
                     Error;
                 ok ->
                     Payments = ?MODULE:payments(Txn),
-                    ok = lists:foreach(fun(Payment) ->
-                                               PayeePubkeyBin = blockchain_payment_v2:payee(Payment),
-                                               PayeeAmount = blockchain_payment_v2:amount(Payment),
-                                               blockchain_ledger_v1:credit_account(PayeePubkeyBin, PayeeAmount, Ledger)
-                                       end, Payments)
+                    ok = lists:foreach(
+                        fun(Payment) ->
+                            PayeePubkeyBin = blockchain_payment_v2:payee(Payment),
+                            PayeeAmount = case blockchain_payment_v2:amount(Payment) of
+                                              0 -> MaxPayment;
+                                              Amount when Amount > 0 -> Amount
+                                          end,
+                            blockchain_ledger_v1:credit_account(PayeePubkeyBin, PayeeAmount, Ledger)
+                        end,
+                        Payments
+                    )
             end
     end.
 
 -spec print(txn_payment_v2()) -> iodata().
-print(undefined) -> <<"type=payment_v2, undefined">>;
-print(#blockchain_txn_payment_v2_pb{payer=Payer,
-                                    fee=Fee,
-                                    payments=Payments,
-                                    nonce=Nonce,
-                                    signature = S}=Txn) ->
-    io_lib:format("type=payment_v2, payer=~p, total_amount: ~p, fee=~p, nonce=~p, signature=~s~n payments: ~s",
-                  [?TO_B58(Payer), ?MODULE:total_amount(Txn), Fee, Nonce, ?TO_B58(S), print_payments(Payments)]).
+print(undefined) ->
+    <<"type=payment_v2, undefined">>;
+print(
+    #blockchain_txn_payment_v2_pb{
+        payer = Payer,
+        fee = Fee,
+        payments = Payments,
+        nonce = Nonce,
+        signature = S
+    }
+) ->
+    {MaxPayment, SpecifiedPayments} = split_max_payment(Payments),
+    SpecifiedTotal = lists:sum([blockchain_payment_v2:amount(Payment) || Payment <- SpecifiedPayments]),
+    TotalAmount = case length(MaxPayment) > 1 of
+                      true -> erlang:integer_to_list(SpecifiedTotal) ++ " + a balance clearing payment";
+                      false -> SpecifiedTotal
+                  end,
+    io_lib:format(
+        "type=payment_v2, payer=~p, total_amount: ~p, fee=~p, nonce=~p, signature=~s~n payments: ~s",
+        [
+            ?TO_B58(Payer),
+            TotalAmount,
+            Fee,
+            Nonce,
+            ?TO_B58(S),
+            print_payments(Payments)
+        ]
+    ).
 
 print_payments(Payments) ->
-    string:join(lists:map(fun(Payment) ->
-                                  blockchain_payment_v2:print(Payment)
-                          end,
-                          Payments), "\n\t").
+    string:join(
+        lists:map(
+            fun(Payment) ->
+                blockchain_payment_v2:print(Payment)
+            end,
+            Payments
+        ),
+        "\n\t"
+    ).
 
 json_type() ->
     <<"payment_v2">>.
@@ -189,20 +239,22 @@ json_type() ->
 -spec to_json(txn_payment_v2(), blockchain_json:opts()) -> blockchain_json:json_object().
 to_json(Txn, _Opts) ->
     #{
-      type => ?MODULE:json_type(),
-      hash => ?BIN_TO_B64(hash(Txn)),
-      payer => ?BIN_TO_B58(payer(Txn)),
-      payments => [blockchain_payment_v2:to_json(Payment, []) || Payment <- payments(Txn)],
-      fee => fee(Txn),
-      nonce => nonce(Txn)
-     }.
+        type => ?MODULE:json_type(),
+        hash => ?BIN_TO_B64(hash(Txn)),
+        payer => ?BIN_TO_B58(payer(Txn)),
+        payments => [blockchain_payment_v2:to_json(Payment, []) || Payment <- payments(Txn)],
+        fee => fee(Txn),
+        nonce => nonce(Txn)
+    }.
 
 %% ------------------------------------------------------------------
 %% Internal Functions
 %% ------------------------------------------------------------------
--spec do_is_valid_checks(Txn :: txn_payment_v2(),
-                         Chain :: blockchain:blockchain(),
-                         MaxPayments :: pos_integer()) -> ok | {error, any()}.
+-spec do_is_valid_checks(
+    Txn :: txn_payment_v2(),
+    Chain :: blockchain:blockchain(),
+    MaxPayments :: pos_integer()
+) -> ok | {error, any()}.
 do_is_valid_checks(Txn, Chain, MaxPayments) ->
     Ledger = blockchain:ledger(Chain),
     Payer = ?MODULE:payer(Txn),
@@ -223,7 +275,7 @@ do_is_valid_checks(Txn, Chain, MaxPayments) ->
                     {error, zero_payees};
                 false ->
                     case blockchain_ledger_v1:find_entry(Payer, Ledger) of
-                        {error, _}=Error0 ->
+                        {error, _} = Error0 ->
                             Error0;
                         {ok, Entry} ->
                             TxnNonce = ?MODULE:nonce(Txn),
@@ -250,7 +302,7 @@ do_is_valid_checks(Txn, Chain, MaxPayments) ->
                                                             case {AmountCheck, MemoCheck} of
                                                                 {false, _} ->
                                                                     {error, invalid_transaction};
-                                                                {_, {error, _}=E} ->
+                                                                {_, {error, _} = E} ->
                                                                     E;
                                                                 {true, ok} ->
                                                                     fee_check(Txn, Chain, Ledger)
@@ -269,7 +321,11 @@ do_is_valid_checks(Txn, Chain, MaxPayments) ->
 %% Internal functions
 %% ------------------------------------------------------------------
 
--spec fee_check(Txn :: txn_payment_v2(), Chain :: blockchain:blockchain(), Ledger :: blockchain_ledger_v1:ledger()) -> ok | {error, any()}.
+-spec fee_check(
+    Txn :: txn_payment_v2(),
+    Chain :: blockchain:blockchain(),
+    Ledger :: blockchain_ledger_v1:ledger()
+) -> ok | {error, any()}.
 fee_check(Txn, Chain, Ledger) ->
     AreFeesEnabled = blockchain_ledger_v1:txn_fees_active(Ledger),
     ExpectedTxnFee = ?MODULE:calculate_fee(Txn, Chain),
@@ -282,7 +338,8 @@ fee_check(Txn, Chain, Ledger) ->
             blockchain_ledger_v1:check_dc_or_hnt_balance(Payer, TxnFee, Ledger, AreFeesEnabled)
     end.
 
--spec memo_check(Txn :: txn_payment_v2(), Ledger :: blockchain_ledger_v1:ledger()) -> ok | {error, any()}.
+-spec memo_check(Txn :: txn_payment_v2(), Ledger :: blockchain_ledger_v1:ledger()) ->
+    ok | {error, any()}.
 memo_check(Txn, Ledger) ->
     Payments = ?MODULE:payments(Txn),
     case blockchain:config(?allow_payment_v2_memos, Ledger) of
@@ -302,15 +359,43 @@ memo_check(Txn, Ledger) ->
 
 -spec amount_check(Txn :: txn_payment_v2(), Ledger :: blockchain_ledger_v1:ledger()) -> boolean().
 amount_check(Txn, Ledger) ->
-    TotAmount = ?MODULE:total_amount(Txn),
     Payments = ?MODULE:payments(Txn),
-    case blockchain:config(?allow_zero_amount, Ledger) of
-        {ok, false} ->
-            %% check that none of the payments have a zero amount
-            has_non_zero_amounts(Payments);
+    case blockchain:config(?enable_balance_clearing, Ledger) of
+        {ok, true} ->
+            %% balance clearing txns should be mutually exclusive with allowing zero amount txns
+            %% or else we can't tell whether or not a payment with a 0 amount is one or the other;
+            %% no more than one payment has a 0 amount and only if `max' is `true'
+            case has_single_max_payment(Payments) of
+                true ->
+                    case split_payment_amounts(Txn, Ledger) of
+                        {MaxPmt, _OtherPmts} when MaxPmt > 0 -> true;
+                        _ -> false
+                    end;
+                false -> false
+            end;
         _ ->
-            %% if undefined or true, use the old check
-            (TotAmount >= 0)
+            case blockchain:config(?allow_zero_amount, Ledger) of
+                {ok, false} ->
+                    %% check that none of the payments have a zero amount
+                    has_non_zero_amounts(Payments);
+                _ ->
+                    %% if undefined or true, use the old check
+                    ?MODULE:total_amount(Txn, Ledger) >= 0
+            end
+    end.
+
+-spec split_payment_amounts(Txn :: txn_payment_v2(), Ledger :: blockchain_ledger_v1:ledger()) -> {pos_integer() | undefined, [pos_integer()]}.
+split_payment_amounts(#blockchain_txn_payment_v2_pb{payer=Payer, fee=Fee}=Txn, Ledger) ->
+    {MaxPayment, SpecifiedPayments} = split_max_payment(?MODULE:payments(Txn)),
+    SpecifiedAmounts = [blockchain_payment_v2:amount(Payment) || Payment <- SpecifiedPayments],
+    case length(MaxPayment) == 1 of
+        true ->
+            {ok, PayerEntry} = blockchain_ledger_v1:find_entry(Payer, Ledger),
+            Balance = blockchain_ledger_entry_v1:balance(PayerEntry),
+            MaxPaymentAmount = Balance - lists:sum(SpecifiedAmounts) - Fee,
+            {MaxPaymentAmount, SpecifiedAmounts};
+        false ->
+            {undefined, SpecifiedAmounts}
     end.
 
 -spec has_unique_payees(Payments :: blockchain_payment_v2:payments()) -> boolean().
@@ -323,22 +408,47 @@ has_non_zero_amounts(Payments) ->
     Amounts = [blockchain_payment_v2:amount(P) || P <- Payments],
     lists:all(fun(A) -> A > 0 end, Amounts).
 
+-spec has_single_max_payment(Payments :: blockchain_payment_v2:payments()) -> boolean().
+has_single_max_payment(Payments) ->
+    {MaxTrue, MaxFalse} = split_max_payment(Payments),
+    length(MaxTrue) =< 1 andalso
+        lists:all(fun(Payment) -> blockchain_payment_v2:amount(Payment) > 0 end, MaxFalse).
+
 -spec has_valid_memos(Payments :: blockchain_payment_v2:payments()) -> boolean().
 has_valid_memos(Payments) ->
     lists:all(
         fun(Payment) ->
-                %% check that the memo field is valid
-                FieldCheck = blockchain_txn:validate_fields([ {{memo, blockchain_payment_v2:memo(Payment)}, {is_integer, 0}} ]),
-                case FieldCheck of
-                    ok ->
-                        %% check that the memo field is within limits
-                        blockchain_payment_v2:is_valid_memo(Payment);
-                    _ ->
-                        false
-                end
+            %% check that the memo field is valid
+            FieldCheck = blockchain_txn:validate_fields([
+                {{memo, blockchain_payment_v2:memo(Payment)}, {is_integer, 0}}
+            ]),
+            case FieldCheck of
+                ok ->
+                    %% check that the memo field is within limits
+                    blockchain_payment_v2:is_valid_memo(Payment);
+                _ ->
+                    false
+            end
         end,
         Payments
     ).
+
+-spec split_max_payment(Payments) -> {Payments, Payments} when
+    Payments :: blockchain_payment_v2:payments().
+split_max_payment(Payments) ->
+    {MaxPayment, _OtherPayments} = SplitPayments = lists:partition(
+            fun(Payment) ->
+                blockchain_payment_v2:max(Payment) andalso
+                    blockchain_payment_v2:is_valid_max(Payment)
+            end,
+            Payments
+        ),
+    case length(MaxPayment) > 1 of
+        true ->
+            throw({error, invalid_payment_txn});
+        false ->
+            SplitPayments
+    end.
 
 -spec has_default_memos(Payments :: blockchain_payment_v2:payments()) -> boolean().
 has_default_memos(Payments) ->
@@ -356,102 +466,161 @@ has_default_memos(Payments) ->
 -ifdef(TEST).
 
 new_test() ->
-    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
-                blockchain_payment_v2:new(<<"y">>, 20),
-                blockchain_payment_v2:new(<<"z">>, 30)],
+    Payments = [
+        blockchain_payment_v2:new(<<"x">>, 10),
+        blockchain_payment_v2:new(<<"y">>, 20),
+        blockchain_payment_v2:new(<<"z">>, 30)
+    ],
 
     Tx = #blockchain_txn_payment_v2_pb{
-            payer= <<"payer">>,
-            payments=Payments,
-            fee=0,
-            nonce=1,
-            signature = <<>>
-           },
+        payer = <<"payer">>,
+        payments = Payments,
+        fee = 0,
+        nonce = 1,
+        signature = <<>>
+    },
     New = new(<<"payer">>, Payments, 1),
     ?assertEqual(Tx, New).
 
 payer_test() ->
-    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
-                blockchain_payment_v2:new(<<"y">>, 20),
-                blockchain_payment_v2:new(<<"z">>, 30)],
+    Payments = [
+        blockchain_payment_v2:new(<<"x">>, 10),
+        blockchain_payment_v2:new(<<"y">>, 20),
+        blockchain_payment_v2:new(<<"z">>, 30)
+    ],
     Tx = new(<<"payer">>, Payments, 1),
     ?assertEqual(<<"payer">>, payer(Tx)).
 
 payments_test() ->
-    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
-                blockchain_payment_v2:new(<<"y">>, 20),
-                blockchain_payment_v2:new(<<"z">>, 30)],
+    Payments = [
+        blockchain_payment_v2:new(<<"x">>, 10),
+        blockchain_payment_v2:new(<<"y">>, 20),
+        blockchain_payment_v2:new(<<"z">>, 30)
+    ],
     Tx = new(<<"payer">>, Payments, 1),
     ?assertEqual(Payments, ?MODULE:payments(Tx)).
 
 payees_test() ->
-    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
-                blockchain_payment_v2:new(<<"y">>, 20),
-                blockchain_payment_v2:new(<<"z">>, 30)],
+    Payments = [
+        blockchain_payment_v2:new(<<"x">>, 10),
+        blockchain_payment_v2:new(<<"y">>, 20),
+        blockchain_payment_v2:new(<<"z">>, 30)
+    ],
     Tx = new(<<"payer">>, Payments, 1),
     ?assertEqual([<<"x">>, <<"y">>, <<"z">>], ?MODULE:payees(Tx)).
 
 amounts_test() ->
-    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
-                blockchain_payment_v2:new(<<"y">>, 20),
-                blockchain_payment_v2:new(<<"z">>, 30)],
+    BaseDir = test_utils:tmp_dir("amounts_test"),
+    Ledger = blockchain_ledger_v1:new(BaseDir),
+    Payments = [
+        blockchain_payment_v2:new(<<"x">>, 10),
+        blockchain_payment_v2:new(<<"y">>, 20),
+        blockchain_payment_v2:new(<<"z">>, 30)
+    ],
     Tx = new(<<"payer">>, Payments, 1),
-    ?assertEqual([10, 20, 30], ?MODULE:amounts(Tx)).
+    ?assertEqual([10, 20, 30], ?MODULE:amounts(Tx, Ledger)).
 
 total_amount_test() ->
-    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
-                blockchain_payment_v2:new(<<"y">>, 20),
-                blockchain_payment_v2:new(<<"z">>, 30)],
+    BaseDir = test_utils:tmp_dir("total_amount_test"),
+    Ledger = blockchain_ledger_v1:new(BaseDir),
+    Payments = [
+        blockchain_payment_v2:new(<<"x">>, 10),
+        blockchain_payment_v2:new(<<"y">>, 20),
+        blockchain_payment_v2:new(<<"z">>, 30)
+    ],
     Tx = new(<<"payer">>, Payments, 1),
-    ?assertEqual(60, total_amount(Tx)).
+    ?assertEqual(60, total_amount(Tx, Ledger)).
+
+total_amount_with_max_test() ->
+    BaseDir = test_utils:tmp_dir("total_amount_with_max_test"),
+    Ledger = blockchain_ledger_v1:new(BaseDir),
+    Ledger1 = blockchain_ledger_v1:new_context(Ledger),
+    ok = blockchain_ledger_v1:credit_account(<<"payer">>, 100, Ledger1),
+    ok = blockchain_ledger_v1:commit_context(Ledger1),
+    Payments = [
+        blockchain_payment_v2:new(<<"x">>, 20),
+        blockchain_payment_v2:new(<<"y">>, max),
+        blockchain_payment_v2:new(<<"z">>, 40)
+    ],
+    Tx = new(<<"payer">>, Payments, 1),
+    ?assertEqual(100, total_amount(Tx, Ledger)).
+
+reject_multi_max_test() ->
+    BaseDir = test_utils:tmp_dir("reject_multi_max_test"),
+    Ledger = blockchain_ledger_v1:new(BaseDir),
+    Ledger1 = blockchain_ledger_v1:new_context(Ledger),
+    ok = blockchain_ledger_v1:credit_account(<<"payer">>, 100, Ledger1),
+    ok = blockchain_ledger_v1:commit_context(Ledger1),
+    Payments = [
+        blockchain_payment_v2:new(<<"x">>, max),
+        blockchain_payment_v2:new(<<"y">>, 20),
+        blockchain_payment_v2:new(<<"z">>, max)
+    ],
+    Tx = new(<<"payer">>, Payments, 1),
+    ?assertThrow({error, invalid_payment_txn}, total_amount(Tx, Ledger)).
 
 fee_test() ->
-    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
-                blockchain_payment_v2:new(<<"y">>, 20),
-                blockchain_payment_v2:new(<<"z">>, 30)],
+    Payments = [
+        blockchain_payment_v2:new(<<"x">>, 10),
+        blockchain_payment_v2:new(<<"y">>, 20),
+        blockchain_payment_v2:new(<<"z">>, 30)
+    ],
     Tx = new(<<"payer">>, Payments, 1),
     ?assertEqual(0, fee(Tx)).
 
 nonce_test() ->
-    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
-                blockchain_payment_v2:new(<<"y">>, 20),
-                blockchain_payment_v2:new(<<"z">>, 30)],
+    Payments = [
+        blockchain_payment_v2:new(<<"x">>, 10),
+        blockchain_payment_v2:new(<<"y">>, 20),
+        blockchain_payment_v2:new(<<"z">>, 30)
+    ],
     Tx = new(<<"payer">>, Payments, 1),
     ?assertEqual(1, nonce(Tx)).
 
 signature_test() ->
-    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
-                blockchain_payment_v2:new(<<"y">>, 20),
-                blockchain_payment_v2:new(<<"z">>, 30)],
+    Payments = [
+        blockchain_payment_v2:new(<<"x">>, 10),
+        blockchain_payment_v2:new(<<"y">>, 20),
+        blockchain_payment_v2:new(<<"z">>, 30)
+    ],
     Tx = new(<<"payer">>, Payments, 1),
     ?assertEqual(<<>>, signature(Tx)).
 
 sign_test() ->
-    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
-                blockchain_payment_v2:new(<<"y">>, 20),
-                blockchain_payment_v2:new(<<"z">>, 30)],
+    Payments = [
+        blockchain_payment_v2:new(<<"x">>, 10),
+        blockchain_payment_v2:new(<<"y">>, 20),
+        blockchain_payment_v2:new(<<"z">>, 30)
+    ],
     #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
     Tx0 = new(<<"payer">>, Payments, 1),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     Tx1 = sign(Tx0, SigFun),
     Sig1 = signature(Tx1),
-    EncodedTx1 = blockchain_txn_payment_v2_pb:encode_msg(Tx1#blockchain_txn_payment_v2_pb{signature = <<>>}),
+    EncodedTx1 = blockchain_txn_payment_v2_pb:encode_msg(Tx1#blockchain_txn_payment_v2_pb{
+        signature = <<>>
+    }),
     ?assert(libp2p_crypto:verify(EncodedTx1, Sig1, PubKey)).
 
 to_json_test() ->
-    Payments = [blockchain_payment_v2:new(<<"x">>, 10),
-                blockchain_payment_v2:new(<<"y">>, 20),
-                blockchain_payment_v2:new(<<"z">>, 30)],
+    Payments = [
+        blockchain_payment_v2:new(<<"x">>, 10),
+        blockchain_payment_v2:new(<<"y">>, 20),
+        blockchain_payment_v2:new(<<"z">>, 30)
+    ],
     Tx = #blockchain_txn_payment_v2_pb{
-            payer= <<"payer">>,
-            payments=Payments,
-            fee=?LEGACY_TXN_FEE,
-            nonce=1,
-            signature = <<>>
-           },
+        payer = <<"payer">>,
+        payments = Payments,
+        fee = ?LEGACY_TXN_FEE,
+        nonce = 1,
+        signature = <<>>
+    },
     Json = to_json(Tx, []),
-    ?assert(lists:all(fun(K) -> maps:is_key(K, Json) end,
-                      [type, payer, payments, fee, nonce])).
-
+    ?assert(
+        lists:all(
+            fun(K) -> maps:is_key(K, Json) end,
+            [type, payer, payments, fee, nonce]
+        )
+    ).
 
 -endif.


### PR DESCRIPTION
Addresses https://github.com/helium/blockchain-core/issues/1060 to allow for adding a single "balance-clearing" txn payment within a txn_payment_v2 that will empty the balance of the payer's account and direct it to the selected payee for whom `max` has been specified as the amount for the payment instead of a defined integer.

Validates that only a single balance-clearing (max) txn is accepted at a given time and implicitly queries the user's balance from the ledger based on the presence of such a payment in a txn payment list to retrieve the available balance and deduct any fees or other specified payments before directing the remainder to the payee in question.