### PR TITLE
Macpie/banner signing

### DIFF
--- a/src/state_channel/blockchain_state_channels_worker.erl
+++ b/src/state_channel/blockchain_state_channels_worker.erl
@@ -64,7 +64,8 @@ start(Args) ->
 
 -spec get(Pid :: pid(), Timeout :: non_neg_integer()) -> blockchain_state_channel_v1:state_channel().
 get(Pid, Timeout) ->
-    gen_server:call(Pid, get, Timeout).
+    {SC, OwnerSigFun} = gen_server:call(Pid, get, Timeout),
+    blockchain_state_channel_v1:sign(SC, OwnerSigFun).
 
 -spec handle_offer(
     Pid :: pid(),
@@ -137,8 +138,8 @@ init(Args) ->
     },
     {ok, State}.
 
-handle_call(get, _From, #state{state_channel=SC}=State) ->
-    {reply, SC, State};
+handle_call(get, _From, #state{state_channel=SC, owner={_Owner, OwnerSigFun}}=State) ->
+    {reply, {SC, OwnerSigFun}, State};
 handle_call(_Msg, _From, State) ->
     lager:warning("rcvd unknown call msg: ~p from: ~p", [_Msg, _From]),
     {reply, ok, State}.

--- a/test/blockchain_state_channel_SUITE.erl
+++ b/test/blockchain_state_channel_SUITE.erl
@@ -304,6 +304,9 @@ full_test(Config) ->
         erlang:is_pid(SCWorkerPid1) andalso ct_rpc:call(RouterNode, erlang, is_process_alive, [SCWorkerPid1])
     end, 30, timer:seconds(1)),
 
+    SignedSC = ct_rpc:call(RouterNode, blockchain_state_channels_worker, get, [SCWorkerPid1, 100]),
+    ?assertEqual(ok, blockchain_state_channel_v1:validate(SignedSC)),
+
     %% Open another SC that will NOT expire
     ID2 = crypto:strong_rand_bytes(32),
     SignedSCOpenTxn2 = create_sc_open_txn(RouterNode, ID2, 30, 1, 2),


### PR DESCRIPTION
When banner are sent we need the SC to be signed as the client will verify banner and close connection if banner is unsigned.

For simplicity and speed the worker will not sign on demand (`handle_call(get, ...`) but inside the public function so that every call to `blockchain_state_channels_server:get` will always return a signed SC but (the actual work is done by the caller to not slow down the SC worker).