### PR TITLE
Catch unknown_region for tagged path elements

### DIFF
--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -742,8 +742,13 @@ tagged_path_elements_fold(Fun, Acc0, Txn, Ledger, Chain) ->
             lists:foldl(fun({_ElementPos, Element}, Acc) ->
                                 Witnesses = lists:reverse(blockchain_poc_path_element_v1:witnesses(Element)),
                                 Fun(Element, {[{false, list_to_binary(io_lib:format("missing_region_parameters_for_~p", [Region])), Witness} || Witness <- Witnesses], undefined}, Acc)
+                        end, Acc0, lists:zip(lists:seq(1, length(Path)), Path));
+        throw:{error,{unknown_region, UnknownH3}} ->
+            Path = ?MODULE:path(Txn),
+            lists:foldl(fun({_ElementPos, Element}, Acc) ->
+                                Witnesses = lists:reverse(blockchain_poc_path_element_v1:witnesses(Element)),
+                                Fun(Element, {lists:map(fun(Witness) -> {false, list_to_binary(io_lib:format("challengee_region_unknown_~p", [UnknownH3])), Witness} end, Witnesses) , undefined}, Acc)
                         end, Acc0, lists:zip(lists:seq(1, length(Path)), Path))
-
     end.
 
 %% again this is broken because of the current witness situation


### PR DESCRIPTION
Fix for error:

```
** Reason for termination ==
** {bad_return_value,{error,{unknown_region,632810598964399103}}}
** Client <0.1546.0> stacktrace
** [{gen,do_call,4,[{file,"gen.erl"},{line,208}]},{gen_server,call,3,[{file,"gen_server.erl"},{line,242}]},{poolboy,transaction,3,[{file,"/opt/blockchain-etl/_build/default/lib/poolboy/src/poolboy.erl"},{line,84}]},{be_db_follower,load_block,5,[{file,"/opt/blockchain-etl/src/be_db_follower.erl"},{line,105}]},{blockchain_follower,handle_info,2,[{file,"/opt/blockchain-etl/_build/default/lib/blockchain/src/blockchain_follower.erl"},{line,122}]},{blockchain_follower,handle_info,2,[{file,"/opt/blockchain-etl/_build/default/lib/blockchain/src/blockchain_follower.erl"},{line,74}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,689}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,765}]}
```