### PR TITLE
If a snapshot listed in latest.json is interrupted when loading, fix it

### DIFF
--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -51,7 +51,7 @@
     reset_ledger_to_snap/2,
     async_reset/1,
 
-    grab_snapshot/2,
+    grab_snapshot/2, fetch_and_parse_latest_snapshot/1,
 
     add_commit_hook/3, add_commit_hook/4,
     remove_commit_hook/1
@@ -1016,7 +1016,7 @@ start_snapshot_sync(Hash, Height, Peer,
                                                       application:get_env(blockchain, blessed_snapshot_block_height),
                                                   {BlessedHeight, Hash};
                                               true ->
-                                                  fetch_and_parse_latest(BaseUrl)
+                                                  fetch_and_parse_latest_snapshot(BaseUrl)
                                           end,
                                       {ok, Filename} = attempt_fetch_snap_source_snapshot(BaseUrl,
                                                                                  ConfigHeight),
@@ -1067,7 +1067,7 @@ attempt_fetch_p2p_snapshot(Hash, Height, SwarmTID, Chain, Peer) ->
             ok
     end.
 
-fetch_and_parse_latest(URL) ->
+fetch_and_parse_latest_snapshot(URL) ->
     Headers = [
                {"user-agent", "blockchain-worker-2"}
               ],


### PR DESCRIPTION
Previous to this change if a latest.json snap was loading and it was
interrupted (OOM, unplug, power loss, etc) the node would get stuck
trying to sync with an incomplete chain because the code didn't check
the latest.json snap when initializing the chain, only once the chain
had started. This would lead to a blessed snapshot in the config file
being "older" than the chain, but the chain being incomplete as a result
of an interrupted snapshot load from a latest.json snapshot at a higher
height.