### PR TITLE
Allow snapshots to be loaded off disk rather than read into ram first

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -2515,7 +2515,7 @@ init_blessed_snapshot(Blockchain, _HashAndHeight={Hash, Height0}) when is_binary
                               _ ->
                                   blockchain_ledger_v1:clean(OldLedger),
                                   %% TODO proper error checking and recovery/retry
-                                  NewLedger = blockchain_ledger_snapshot_v1:import(Blockchain, Hash, Snap),
+                                  NewLedger = blockchain_ledger_snapshot_v1:import(Blockchain, SnapHeight, Hash, Snap, BinSnapOrFile),
                                   blockchain:ledger(NewLedger, Blockchain)
                           end;
                         Other ->

--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -1229,8 +1229,14 @@ get_quick_sync_height_and_hash(Mode) ->
     end.
 
 load_chain(SwarmTID, BaseDir, GenDir) ->
-    QuickSyncMode = application:get_env(blockchain, quick_sync_mode, assumed_valid),
-    QuickSyncData = get_quick_sync_height_and_hash(QuickSyncMode),
+    {QuickSyncMode, QuickSyncData} = case application:get_env(blockchain, honor_quick_sync, false) of
+        true ->
+            Mode = application:get_env(blockchain, quick_sync_mode, assumed_valid),
+            {Mode,
+            get_quick_sync_height_and_hash(Mode)};
+        false ->
+            {undefined, undefined}
+    end,
     case blockchain:new(BaseDir, GenDir, QuickSyncMode, QuickSyncData) of
         {no_genesis, _Chain}=R ->
             %% mark all upgrades done

--- a/src/cli/blockchain_cli_snapshot.erl
+++ b/src/cli/blockchain_cli_snapshot.erl
@@ -115,11 +115,7 @@ snapshot_load(_, _, _) ->
     usage.
 
 snapshot_load(Filename) ->
-    {ok, Snapshot} = blockchain_ledger_snapshot_v1:deserialize({file, Filename}),
-    Hash = blockchain_ledger_snapshot_v1:hash(Snapshot),
-
-    ok = blockchain_worker:install_snapshot(Hash, Snapshot),
-    ok.
+    blockchain_worker:install_snapshot_from_file(Filename).
 
 snapshot_grab_usage() ->
     [["snapshot", "grab"],

--- a/src/cli/blockchain_cli_snapshot.erl
+++ b/src/cli/blockchain_cli_snapshot.erl
@@ -115,9 +115,7 @@ snapshot_load(_, _, _) ->
     usage.
 
 snapshot_load(Filename) ->
-    {ok, BinSnap} = file:read_file(Filename),
-
-    {ok, Snapshot} = blockchain_ledger_snapshot_v1:deserialize(BinSnap),
+    {ok, Snapshot} = blockchain_ledger_snapshot_v1:deserialize({file, Filename}),
     Hash = blockchain_ledger_snapshot_v1:hash(Snapshot),
 
     ok = blockchain_worker:install_snapshot(Hash, Snapshot),

--- a/src/handlers/blockchain_snapshot_handler.erl
+++ b/src/handlers/blockchain_snapshot_handler.erl
@@ -75,7 +75,7 @@ handle_data(client, Data, #state{chain = Chain, hash = Hash, owner = undefined} 
                 true ->
                     lager:info("retrieved and stored snapshot ~p, installing",
                                [Height]),
-                    blockchain_worker:install_snapshot(Hash, Snapshot);
+                    blockchain_worker:install_snapshot(Height, Hash, Snapshot, BinSnap);
                 false ->
                     lager:info("could not install retrieved snapshot ~p", [Height]),
                     ok

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -1479,7 +1479,7 @@ deserialize_pairs(<<Bin/binary>>) ->
     ).
 
 -spec deserialize_field(key(), binary()) -> term().
-deserialize_field(hexes, Bin) ->
+deserialize_field(hexes, Bin) when is_binary(Bin) ->
     %% hexes are encoded as a term_to_binary of a big
     %% key/value list of {h3() -> [binary()]},
     %% and a single 'list' key which points to a map of

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -14,7 +14,7 @@
 
          snapshot/3,
          snapshot/4,
-         import/3,
+         import/5,
          load_into_ledger/3,
          load_blocks/3,
 
@@ -461,9 +461,9 @@ deserialize(DigestOpt, <<Bin0/binary>>) ->
     end.
 
 %% sha will be stored externally
--spec import(blockchain:blockchain(), binary(), snapshot()) ->
+-spec import(blockchain:blockchain(), pos_integer(), binary(), snapshot(), binary() | {file, filename:filename_all()}) ->
     blockchain_ledger_v1:ledger().
-import(Chain, SHA, #{version := v6}=Snapshot) ->
+import(Chain, Height, SHA, #{version := v6}=Snapshot, BinSnap) ->
     print_memory(),
     CLedger = blockchain:ledger(Chain),
     Dir = blockchain:dir(Chain),
@@ -521,7 +521,7 @@ import(Chain, SHA, #{version := v6}=Snapshot) ->
         {ok, _Snap} ->
             ok;
         {error, _} ->
-            blockchain:add_snapshot(Snapshot, Chain)
+            blockchain:add_bin_snapshot(BinSnap, Height, SHA, Chain)
     end,
     %% re-open the ledger with the normal options
     blockchain_ledger_v1:close(Ledger0),

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -845,11 +845,19 @@ is_v6(#{version := v6}) -> true;
 is_v6(_) -> false.
 
 -spec get_h3dex(snapshot()) -> [{integer(), [binary()]}].
-get_h3dex(#{h3dex := H3DexBin}) ->
+get_h3dex(#{h3dex := {FD, Pos, Len}}) ->
+    {ok, Pos} = file:position(FD, {bof, Pos}),
+    {ok, H3DexBin} = file:read(FD, Len),
+    binary_to_term(H3DexBin);
+get_h3dex(#{h3dex := H3DexBin}) when is_binary(H3DexBin) ->
     binary_to_term(H3DexBin).
 
 -spec height(snapshot()) -> non_neg_integer().
-height(#{current_height := HeightBin}) ->
+height(#{current_height := {FD, Pos, Len}}) ->
+    {ok, Pos} = file:position(FD, {bof, Pos}),
+    {ok, HeightBin} = file:read(FD, Len),
+    binary_to_term(HeightBin);
+height(#{current_height := HeightBin}) when is_binary(HeightBin) ->
     binary_to_term(HeightBin).
 
 -spec hash(snapshot_of_any_version()) -> binary().

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -28,11 +28,11 @@
          diff/2
         ]).
 
-%-ifdef(TEST).
+-ifdef(TEST).
 -export([
          deserialize_field/2
         ]).
-%-endif.
+-endif.
 
 -export_type([
     snapshot/0,
@@ -1560,7 +1560,7 @@ mk_file_iterator(FD, Pos, End) when Pos < End ->
             {ok, <<SizK:32/integer-unsigned-little>>} = file:read(FD, 4),
             {ok, <<K:SizK/binary, SizV:32/integer-unsigned-little>>} = file:read(FD, SizK + 4),
             {ok, V} = file:read(FD, SizV),
-            io:format("read key of size ~p and value of size ~p", [SizK, SizV]),
+            lager:debug("read key of size ~p and value of size ~p", [SizK, SizV]),
             {K, V, mk_file_iterator(FD, Pos + 4 + SizK + 4 + SizV, End)}
     end.
 


### PR DESCRIPTION
This change should help devices with less memory load larger snapshots.