### PR TITLE
Add support for sc_merge_version

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -341,6 +341,8 @@
 %% The "new" behavior (i.e., `true') is to count state channels
 %% that are only in the open state and ignore closed channels.
 -define(sc_only_count_open_active, sc_only_count_open_active).
+%% State Channel merge strategy, set to 1 for new style merge, undefined = old style merge
+-define(sc_merge_version, sc_merge_version).
 
 
 %% ------------------------------------------------------------------

--- a/src/ledger/v1/blockchain_ledger_state_channel_v2.erl
+++ b/src/ledger/v1/blockchain_ledger_state_channel_v2.erl
@@ -312,9 +312,12 @@ maybe_dispute_test() ->
     SC1 = blockchain_state_channel_v1:new(<<"id2">>, <<"key2">>, 200),
     Nonce4 = blockchain_state_channel_v1:nonce(4, SC0),
     Nonce8 = blockchain_state_channel_v1:nonce(8, SC1),
-    ?assertEqual({closed, SC0}, maybe_dispute(SC0, SC0, false, 2000)),
-    ?assertEqual({closed, Nonce4}, maybe_dispute(Nonce4, Nonce8, false, 2000)),
-    ?assertEqual({dispute, Nonce8}, maybe_dispute(Nonce8, Nonce4, false, 2000)).
+    ?assertEqual({closed, SC0}, maybe_dispute(SC0, SC0, false, 2000, undefined)),
+    ?assertEqual({closed, Nonce4}, maybe_dispute(Nonce4, Nonce8, false, 2000, undefined)),
+    ?assertEqual({dispute, Nonce8}, maybe_dispute(Nonce8, Nonce4, false, 2000, undefined)),
+    ?assertEqual({closed, SC0}, maybe_dispute(SC0, SC0, false, 2000, 1)),
+    ?assertEqual({closed, Nonce4}, maybe_dispute(Nonce4, Nonce8, false, 2000, 1)),
+    ?assertEqual({dispute, Nonce8}, maybe_dispute(Nonce8, Nonce4, false, 2000, 1)).
 
 maybe_dispute_with_effect_of_test() ->
     SC0 = blockchain_state_channel_v1:new(<<"id1">>, <<"key1">>, 100),
@@ -325,16 +328,23 @@ maybe_dispute_with_effect_of_test() ->
     Summary1 = blockchain_state_channel_summary_v1:num_packets(2, blockchain_state_channel_summary_v1:num_dcs(2, blockchain_state_channel_summary_v1:new(<<"key1">>))),
     Nonce4WithSummary = blockchain_state_channel_v1:summaries([Summary1], Nonce4),
 
-    ?assertEqual({closed, SC0}, maybe_dispute(SC0, SC0, true, 2000)),
-    ?assertEqual({closed, Nonce8}, maybe_dispute(Nonce4, Nonce8, true, 2000)),
-    ?assertEqual({closed, Nonce8}, maybe_dispute(Nonce8, Nonce4, true, 2000)),
+    ?assertEqual({closed, SC0}, maybe_dispute(SC0, SC0, true, 2000, undefined)),
+    ?assertEqual({closed, Nonce8}, maybe_dispute(Nonce4, Nonce8, true, 2000, undefined)),
+    ?assertEqual({closed, Nonce8}, maybe_dispute(Nonce8, Nonce4, true, 2000, undefined)),
+    ?assertEqual({closed, SC0}, maybe_dispute(SC0, SC0, true, 2000, 1)),
+    ?assertEqual({closed, Nonce8}, maybe_dispute(Nonce4, Nonce8, true, 2000, 1)),
+    ?assertEqual({closed, Nonce8}, maybe_dispute(Nonce8, Nonce4, true, 2000, 1)),
 
     %% Same nonce but no summary, conflict, return merged
     ?assertEqual({dispute, blockchain_state_channel_v1:merge(Nonce4, Nonce4WithSummary, 2000)},
-                 maybe_dispute(Nonce4, Nonce4WithSummary, true, 2000)),
+                 maybe_dispute(Nonce4, Nonce4WithSummary, true, 2000, undefined)),
+    ?assertEqual({dispute, blockchain_state_channel_v1:merge(Nonce4, Nonce4WithSummary, 2000)},
+                 maybe_dispute(Nonce4, Nonce4WithSummary, true, 2000, 1)),
     %% Older nonce with summary, but higher nonce with no summary, conflict, return merged
     ?assertEqual({dispute, blockchain_state_channel_v1:merge(Nonce4WithSummary, Nonce8, 2000)},
-                 maybe_dispute(Nonce4WithSummary, Nonce8, true, 2000)).
+                 maybe_dispute(Nonce4WithSummary, Nonce8, true, 2000, undefined)),
+    ?assertEqual({dispute, blockchain_state_channel_v1:merge(Nonce4WithSummary, Nonce8, 2000)},
+                 maybe_dispute(Nonce4WithSummary, Nonce8, true, 2000, 1)).
 
 is_sc_participant_test() ->
     Ids = [<<"key1">>, <<"key2">>, <<"key3">>],

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -3324,7 +3324,8 @@ close_state_channel(Owner, Closer, SC, SCID, HadConflict, Ledger) ->
                                                false
                                        end,
                     MaxActorsAllowed = blockchain_state_channel_v1:max_actors_allowed(Ledger),
-                    NewSCE = blockchain_ledger_state_channel_v2:close_proposal(Closer, SC, HadConflict, PrevSCE, ConsiderEffectOf, MaxActorsAllowed),
+                    SCMergeVer = blockchain_state_channel_v1:sc_merge_version(Ledger),
+                    NewSCE = blockchain_ledger_state_channel_v2:close_proposal(Closer, SC, HadConflict, PrevSCE, ConsiderEffectOf, MaxActorsAllowed, SCMergeVer),
                     Bin = blockchain_ledger_state_channel_v2:serialize(NewSCE),
                     cache_put(Ledger, SCsCF, Key, Bin);
                 false ->

--- a/src/state_channel/v1/blockchain_state_channel_v1.erl
+++ b/src/state_channel/v1/blockchain_state_channel_v1.erl
@@ -38,7 +38,9 @@
     is_causally_newer/2,
     merge/3, new_merge/3,
     can_fit/3,
-    max_actors_allowed/1
+    max_actors_allowed/1,
+    sc_merge_version/1,
+    versioned_merge/4
 ]).
 
 -include_lib("helium_proto/include/blockchain_state_channel_v1_pb.hrl").
@@ -587,6 +589,23 @@ max_actors_allowed(Ledger) ->
         {ok, I} -> I;
         _ -> ?SC_MAX_ACTORS
     end.
+
+-spec sc_merge_version(Ledger :: blockchain_ledger_v1:ledger()) -> pos_integer() | undefined.
+sc_merge_version(Ledger) ->
+    case blockchain_ledger_v1:config(?sc_merge_version, Ledger) of
+        {ok, I} -> I;
+        _ -> undefined
+    end.
+
+-spec versioned_merge(
+        SCMergeVer :: undefined | pos_integer(),
+        SCA :: blockchain_state_channel_v1:state_channel(),
+        SCB :: blockchain_state_channel_v1:state_channel(),
+        MaxActorsAllowed :: non_neg_integer()) -> blockchain_state_channel_v1:state_channel().
+versioned_merge(undefined, SCA, SCB, MaxActorsAllowed) ->
+    merge(SCA, SCB, MaxActorsAllowed);
+versioned_merge(1, SCA, SCB, MaxActorsAllowed) ->
+    new_merge(SCA, SCB, MaxActorsAllowed).
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1095,6 +1095,11 @@ validate_var(?sc_only_count_open_active, Value) ->
         false -> ok;
         Other -> throw({error, {invalid_sc_only_count_open_active_value, Other}})
     end;
+validate_var(?sc_merge_version, Value) ->
+    case Value of
+        N when is_integer(N), N == 1 -> ok;
+        Other -> throw({error, {invalid_sc_merge_version, Other}})
+    end;
 
 %% txn snapshot vars
 validate_var(?snapshot_version, Value) ->


### PR DESCRIPTION
Problem
----
Existing way of merging state channels is slow and we haven't been able to faithfully reproduce sync crash when using the new style of state channel merge.

Solution
----
Move to new style state channel merge guarded behind a new chain variable `sc_merge_version`; the only allowed value for this var would be `1` (and would have to be manually incremented and validated in the future if we have to update it).