### PR TITLE
bump helium_proto dep for grpc ecc changes

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -66,7 +66,7 @@
   0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"45a0edda39eefc9b36e98c3a1019819e05321efc"}},
+       {ref,"6dc60a9933628c3baf9d2f5386481f20a5d79bb8"}},
   0},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},2},
  {<<"inert">>,{pkg,<<"inert">>,<<"1.0.3">>},2},


### PR DESCRIPTION
Bump the version of `helium_proto` dependency to include the addition of the new `ecdh` function for local grpc execution by gateway-rs to allow transitioning off the erlang ecc_worker