### PR TITLE
Fix OP_SIZE "constant" so that it works well in all contexts.

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -118,7 +118,7 @@
 -define(GENESIS, <<"genesis">>).
 -define(ASSUMED_VALID, blockchain_core_assumed_valid_block_hash_and_height).
 -define(LAST_BLOCK_ADD_TIME, <<"last_block_add_time">>).
--define(OP_SIZE, 1024*1024). % output garbage collection in megabytes
+-define(OP_SIZE, (1024*1024)). % output garbage collection in megabytes
 
 -define(BC_UPGRADE_FUNS, [fun upgrade_gateways_v2/1,
                           fun bootstrap_hexes/1,


### PR DESCRIPTION
Fix the `OP_SIZE` definition so that it can reliably be used to represent
"one megabyte" in all expressions, e.g.:

```erlang
  Megabytes = Bytes div ?OP_SIZE.
```

Without parentheses (brackets) this is expanded to:

```erlang
  Megabytes = Bytes div 1024 * 1024.
``

Which is interpreted as:

```erlang
  Megabytes = (Bytes div 1024) * 1024.
```

Which might as well be:

```erlang
  Megabytes = Bytes.
```

Which clearly isn't correct.