### PR TITLE
memoize witness validation

### DIFF
--- a/src/transactions/v2/blockchain_txn_rewards_v2.erl
+++ b/src/transactions/v2/blockchain_txn_rewards_v2.erl
@@ -1512,7 +1512,6 @@ legit_witnesses(Txn, Chain, Ledger, Elem, StaticPath, RegionVars, Version) ->
                             VW;
                         VW -> VW
                     end,
-                lager:info("challenge witness ~p", [erlang:phash2(ValidWitnesses)]),
                 ValidWitnesses
             catch
                 throw:{error, {unknown_region, Region}}:_ST ->


### PR DESCRIPTION
When we make rewards, we assess witness validity twice for each receipt transaction.  The results are the same each time, so we might as well memoize it locally to make it cheaper.  It would be more complex to thread the results through, so we instead use the pdict.