### PR TITLE
avoid rehashing blocks

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -20,7 +20,7 @@
     put_block_height/3,
     put_block_info/3, get_block_info/2,
     mk_block_info/2,
-    save_block/2,
+    save_block/2, save_bin_block/3,
     has_block/2,
     find_first_block_after/2,
 
@@ -84,14 +84,30 @@
 -include("blockchain.hrl").
 -include("blockchain_vars.hrl").
 
+%% don't like adding this here, but
+-include_lib("helium_proto/include/blockchain_block_v1_pb.hrl").
+
 -ifdef(TEST).
+
 -export([bootstrap_hexes/1, can_add_block/2, get_plausible_blocks/1, clean/1]).
 %% export a macro so we can interpose block saving to test failure
 -define(save_block(Block, Chain), ?MODULE:save_block(Block, Chain)).
+-define(save_bin_block(BinBlock, Chain), ?MODULE:save_bin_block(Block, BinBlock, Chain)).
 -include_lib("eunit/include/eunit.hrl").
+
 -else.
+
 -define(save_block(Block, Chain), save_block(Block, Chain)).
+-define(save_bin_block(Block, BinBlock, Chain), save_bin_block(Block, BinBlock, Chain)).
+
 -endif.
+
+-record(block_data,
+        {
+         block :: undefined | blockchain_block:block(),
+         bin :: undefined | binary(),
+         hash :: undefined | blockchain_block:hash()
+        }).
 
 -record(blockchain, {
     dir :: file:filename_all(),
@@ -896,7 +912,7 @@ find_first_block_after(MinHeight, Blockchain) ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec add_blocks([blockchain_block:block()], blockchain()) -> ok | exists | plausible | {error, any()}.
+-spec add_blocks([binary()], blockchain()) -> ok | exists | plausible | {error, any()}.
 add_blocks(Blocks, Chain) ->
     add_blocks(Blocks, <<>>, Chain).
 
@@ -915,23 +931,63 @@ add_blocks(Blocks, GossipedHash, Chain) ->
 
 add_blocks_([], _, _Chain) ->  ok;
 add_blocks_([Block | Blocks], GossipedHash, Chain) ->
-    case ?MODULE:add_block(Block, Chain, GossipedHash /= blockchain_block:hash_block(Block)) of
+    case ?MODULE:add_block(Block, Chain, {unknown, GossipedHash}) of
         Res when Res == ok; Res == plausible; Res == exists ->
             add_blocks_(Blocks, GossipedHash, Chain);
         Error ->
             Error
     end.
 
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
--spec add_block(blockchain_block:block(), blockchain()) -> ok | exists | plausible | {error, any()}.
+-spec add_block(binary() | blockchain_block:block(), blockchain()) -> ok | exists | plausible | {error, any()}.
 add_block(Block, Blockchain) ->
     add_block(Block, Blockchain, false).
 
--spec add_block(blockchain_block:block(), blockchain(), boolean()) -> ok | exists | plausible | {error, any()}.
-add_block(Block, #blockchain{db=DB, blocks=BlocksCF, heights=HeightsCF, default=DefaultCF} = Blockchain, Syncing) ->
+-spec add_block(binary() | blockchain_block:block() | #block_data{},
+                blockchain(), boolean()) ->
+          ok | exists | plausible | {error, any()}.
+add_block(Block, Blockchain, Syncing0) when is_record(Block, blockchain_block_v1_pb) ->
+    put(suppress_stack, true),
+    BinBlock = blockchain_block:serialize(Block),
+    Type = blockchain_block:type(Block),
+    Hash = blockchain_block:hash_serialized(Type, BinBlock),
+    erase(suppress_stack),
+    BlockData =
+        #block_data{
+           block = Block,
+           bin = BinBlock,
+           hash = Hash
+          },
+    Syncing =
+        case Syncing0 of
+            {unknown, GossipedHash} ->
+                GossipedHash /= Hash;
+            _ ->
+                Syncing0
+        end,
+    add_block(BlockData, Blockchain, Syncing);
+add_block(BinBlock, Blockchain, Syncing0) when is_binary(BinBlock) ->
+    put(suppress_stack, true),
+    Block = blockchain_block:deserialize(BinBlock),
+    Type = blockchain_block:type(Block),
+    Hash = blockchain_block:hash_serialized(Type, BinBlock),
+    erase(suppress_stack),
+    BlockData =
+        #block_data{
+           block = Block,
+           bin = BinBlock,
+           hash = Hash
+          },
+    Syncing =
+        case Syncing0 of
+            {unknown, GossipedHash} ->
+                GossipedHash /= Hash;
+            _ ->
+                Syncing0
+        end,
+    add_block(BlockData, Blockchain, Syncing);
+add_block(#block_data{block = Block, hash = Hash, bin = BinBlock} = BlockData,
+          #blockchain{db=DB, blocks=BlocksCF, heights=HeightsCF, default=DefaultCF} = Blockchain, Syncing)
+  when is_record(BlockData, block_data) ->
     blockchain_lock:acquire(),
     try
         PrevHash = blockchain_block:prev_hash(Block),
@@ -939,7 +995,6 @@ add_block(Block, #blockchain{db=DB, blocks=BlocksCF, heights=HeightsCF, default=
             {ok, PrevHash} ->
                 %% this is the block we've been missing
                 Height = blockchain_block:height(Block),
-                Hash = blockchain_block:hash_block(Block),
                 %% check if it fits between the 2 known good blocks
                 case get_block(Height + 1, Blockchain) of
                     {ok, NextBlock} ->
@@ -947,7 +1002,7 @@ add_block(Block, #blockchain{db=DB, blocks=BlocksCF, heights=HeightsCF, default=
                             Hash ->
                                 {ok, Batch} = rocksdb:batch(),
                                 %% everything lines up
-                                ok = rocksdb:batch_put(Batch, BlocksCF, Hash, blockchain_block:serialize(Block)),
+                                ok = rocksdb:batch_put(Batch, BlocksCF, Hash, BinBlock),
                                 %% lexiographic ordering works better with big endian
                                 ok = rocksdb:batch_put(Batch, HeightsCF, <<Height:64/integer-unsigned-big>>, Hash),
                                 ok = rocksdb:batch_delete(Batch, DefaultCF, ?MISSING_BLOCK),
@@ -961,7 +1016,7 @@ add_block(Block, #blockchain{db=DB, blocks=BlocksCF, heights=HeightsCF, default=
             _ ->
                 case persistent_term:get(?ASSUMED_VALID, undefined) of
                     undefined ->
-                        case add_block_(Block, Blockchain, Syncing) of
+                        case add_block_(BlockData, Blockchain, Syncing) of
                             ok ->
                                 check_plausible_blocks(Blockchain),
                                 ok;
@@ -978,8 +1033,21 @@ add_block(Block, #blockchain{db=DB, blocks=BlocksCF, heights=HeightsCF, default=
         blockchain_lock:release()
     end.
 
-can_add_block(Block, Blockchain) ->
-    Hash = blockchain_block:hash_block(Block),
+%% this top clause is test-only
+can_add_block(Block, Blockchain)  when is_record(Block, blockchain_block_v1_pb) ->
+    put(suppress_stack, true),
+    BinBlock = blockchain_block:serialize(Block),
+    Type = blockchain_block:type(Block),
+    Hash = blockchain_block:hash_serialized(Type, BinBlock),
+    erase(suppress_stack),
+    BlockData =
+        #block_data{
+           block = Block,
+           bin = BinBlock,
+           hash = Hash
+          },
+    can_add_block(BlockData, Blockchain);
+can_add_block(#block_data{hash = Hash, block = Block}, Blockchain) ->
     {ok, GenesisHash} = blockchain:genesis_hash(Blockchain),
     case blockchain_block:is_genesis(Block) of
         true when Hash =:= GenesisHash ->
@@ -1096,7 +1164,8 @@ get_key_or_keys(Ledger) ->
             blockchain_ledger_v1:master_key(Ledger)
     end.
 
-add_block_(Block, Blockchain, Syncing) ->
+add_block_(#block_data{hash = Hash, block = Block, bin = BinBlock},
+           Blockchain, Syncing) ->
     %% TODO: we know that swarm calls can block, it would be nice if we had all the pubkey bin and
     %% tid calls threaded through from the top
     Ledger = blockchain:ledger(Blockchain),
@@ -1108,13 +1177,12 @@ add_block_(Block, Blockchain, Syncing) ->
             case can_add_block(Block, Blockchain) of
                 {true, IsRescue} ->
                     Height = blockchain_block:height(Block),
-                    Hash = blockchain_block:hash_block(Block),
                     Sigs = blockchain_block:signatures(Block),
                     MyAddress = try blockchain_swarm:pubkey_bin() catch _:_ -> nomatch end,
-                    BeforeCommit = fun(FChain, FHash) ->
+                    BeforeCommit = fun(FChain) ->
                                            lager:debug("adding block ~p", [Height]),
-                                           ok = ?save_block(Block, Blockchain),
-                                           ok = run_gc_hooks(FChain, FHash)
+                                           ok = ?save_bin_block(BinBlock, Blockchain),
+                                           ok = run_gc_hooks(FChain, Hash)
                                    end,
                     {Signers, _Signatures} = lists:unzip(Sigs),
                     Fun = case lists:member(MyAddress, Signers) orelse FollowMode of
@@ -2778,29 +2846,30 @@ check_plausible_blocks(Chain) ->
 check_plausible_blocks(#blockchain{db=DB}=Chain, GossipedHash) ->
     blockchain_lock:acquire(), %% need the lock and we can get called without holding it
     Blocks = get_plausible_blocks(Chain),
-    SortedBlocks = lists:sort(fun(A, B) -> blockchain_block:height(A) =< blockchain_block:height(B) end, Blocks),
+    SortedBlocks = lists:sort(fun(#block_data{block = A},
+                                  #block_data{block = B}) ->
+                                      blockchain_block:height(A) =< blockchain_block:height(B)
+                              end, Blocks),
     {ok, Batch} = rocksdb:batch(),
-    lists:foreach(fun(Block) ->
-                          Hash = blockchain_block:hash_block(Block),
-                          try can_add_block(Block, Chain) of
+    lists:foreach(fun(#block_data{hash = Hash, height = Height, block = Block} = BlockData) ->
+                          try can_add_block(BlockData, Chain) of
                               {true, _IsRescue} ->
-                                  %% TODO try to retain the binary block through here and pass it into add_block to
-                                  %% save on another serialize() call
-                                  add_block_(Block, Chain, GossipedHash /= Hash),
-                                  remove_plausible_block(Chain, Batch, Hash, blockchain_block:height(Block));
+                                  %% set the sync flag to true as we've already gossiped these blocks on
+                                  add_block_(BlockData, Chain, GossipedHash /= Hash),
+                                  remove_plausible_block(Chain, Batch, Hash, Height);
                               exists ->
                                   case is_block_plausible(Block, Chain) of
                                       true ->
                                           %% still plausible, leave it alone
                                           ok;
                                       false ->
-                                          remove_plausible_block(Chain, Batch, Hash, blockchain_block:height(Block))
+                                          remove_plausible_block(Chain, Batch, Hash, Height)
                                   end;
                               _Error ->
-                                  remove_plausible_block(Chain, Batch, Hash, blockchain_block:height(Block))
+                                  remove_plausible_block(Chain, Batch, Hash, Height)
                           catch
                               _:_ ->
-                                  remove_plausible_block(Chain, Batch, Hash, blockchain_block:height(Block))
+                                  remove_plausible_block(Chain, Batch, Hash, Height)
                           end
                   end, SortedBlocks),
     rocksdb:write_batch(DB, Batch, [{sync, true}]),
@@ -2809,8 +2878,10 @@ check_plausible_blocks(#blockchain{db=DB}=Chain, GossipedHash) ->
 -spec get_plausible_blocks(blockchain()) -> [blockchain_block:block()].
 get_plausible_blocks(#blockchain{db=DB, plausible_blocks=CF}) ->
     {ok, Itr} = rocksdb:iterator(DB, CF, []),
+    put(suppress_stack, true),
     Res = get_plausible_blocks(Itr, rocksdb:iterator_move(Itr, first), []),
     catch rocksdb:iterator_close(Itr),
+    erase(suppress_stack),
     Res.
 
 get_plausible_blocks(_Itr, {error, _}, Acc) ->
@@ -2820,7 +2891,11 @@ get_plausible_blocks(Itr, {ok, <<_Height:64/integer-unsigned-big>>, _BinBlock}, 
 get_plausible_blocks(Itr, {ok, _Key, BinBlock}, Acc) ->
     NewAcc = try blockchain_block:deserialize(BinBlock) of
                  Block ->
-                     [Block|Acc]
+                     Hash = blockchain_block:hash_serialized(blockchain_block:type(Block),
+                                                             BinBlock),
+                     [#block_data{block = Block,
+                                  bin = BinBlock,
+                                  hash = Hash} | Acc]
              catch
                  What:Why ->
                      lager:warning("error when deserializing plausible block at key ~p: ~p ~p", [_Key, What, Why]),

--- a/src/blockchain_block_v1.erl
+++ b/src/blockchain_block_v1.erl
@@ -23,7 +23,7 @@
     set_signatures/2, set_signatures/3,
     new_genesis_block/1,
     is_genesis/1,
-    hash_block/1,
+    hash_block/1, hash_serialized/1,
     rescue_signature/1,
     rescue_signatures/1,
     seen_votes/1,
@@ -234,8 +234,22 @@ is_genesis(Block) ->
 %%--------------------------------------------------------------------
 -spec hash_block(block()) -> blockchain_block:hash().
 hash_block(Block) ->
+    lager:info("hashing block ~p", [stack()]),
     EncodedBlock = blockchain_block:serialize(?MODULE:set_signatures(Block, [], <<>>)),
     crypto:hash(sha256, EncodedBlock).
+
+-spec hash_serialized(binary()) -> blockchain_block:hash().
+hash_serialized(EncodedBlock) ->
+    lager:info("hashing serialized block"),
+    crypto:hash(sha256, EncodedBlock).
+
+stack() ->
+    case get(suppress_stack) of
+        true ->
+            ok;
+        _ ->
+            element(2, erlang:process_info(self(), current_stacktrace))
+    end.
 
 %%--------------------------------------------------------------------
 %% @doc The two arities for `verify_signatures` are meant to allow for
@@ -257,7 +271,6 @@ verify_signatures(Block, ConsensusMembers, Signatures, Threshold) ->
             {true, Sigs};
         Else -> Else
     end.
-
 
 -spec verify_signatures(Block::binary() | block(),
                         ConsensusMembers::[libp2p_crypto:pubkey_bin()],

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -440,8 +440,7 @@ absorb_and_commit(Block, Chain0, BeforeCommit, Rescue) ->
             case ?MODULE:absorb_block(Block, Rescue, Chain1) of
                 {ok, Chain2} ->
                     Ledger2 = blockchain:ledger(Chain2),
-                    Hash = blockchain_block:hash_block(Block),
-                    case BeforeCommit(Chain2, Hash) of
+                    case BeforeCommit(Chain2) of
                         ok ->
                             ok = blockchain_ledger_v1:commit_context(Ledger2),
                             End2 = erlang:monotonic_time(millisecond),


### PR DESCRIPTION
this is a draft PR for being more thrifty about doing work on whole blocks.  it's only one approach, and it's possible that it isn't the right one.

another approach would be to immediately denormalize every block accepted into various individually fetchable fields (bonus points for separate, iterable transactions with types outside of the serialization) and then simply mark them as valid and present separately, doing away with the whole distinction between valid and plausible blocks.