### PR TITLE
continuous block gc

### DIFF
--- a/src/blockchain_gc.erl
+++ b/src/blockchain_gc.erl
@@ -43,7 +43,7 @@ handle_call(_Other, _From, State) ->
 
 
 maybe_gc(State=#state{bytes=Bytes}) ->
-    case application:get_env(blockchain, gc_byte_interval, 10 * 1024 * 1024) < Bytes of
+    case application:get_env(blockchain, gc_byte_interval, 100 * 1024 * 1024) < Bytes of
         true ->
             %% run a GC, this blocks the process
             blockchain:rocksdb_gc(Bytes, blockchain_worker:blockchain()),

--- a/src/blockchain_gc.erl
+++ b/src/blockchain_gc.erl
@@ -1,0 +1,53 @@
+-module(blockchain_gc).
+
+-behaviour(gen_server).
+
+-export([start_link/0]).
+
+-export([init/1, handle_info/2, handle_cast/2, handle_call/3]).
+
+-record(state, {
+         bytes = 0
+        }).
+
+start_link() ->
+    gen_server:start_link(?MODULE, [], []).
+
+init([]) ->
+    %% if we were started with the GC env var, try to keep
+    %% the blockchain.db reasonably sized
+    case os:getenv("BLOCKCHAIN_ROCKSDB_GC_BYTES") of
+        false -> ignore;
+        ValString ->
+            try list_to_integer(ValString, 10) of
+                _BytesToGC ->
+                    blockchain_event:add_handler(self()),
+                    {ok, #state{}}
+            catch _:_ ->
+                      ignore
+            end
+    end.
+
+handle_info({blockchain_event, {add_block, Hash, _Sync, Ledger}}, State) ->
+    %% use add block event to track how much we're writing to rocks, roughly
+    {ok, Bin} = blockchain_ledger_v1:get_raw_block(Hash, Ledger),
+    {noreply, maybe_gc(State#state{bytes=byte_size(Bin) + State#state.bytes})};
+handle_info(_Other, State) ->
+    {noreply, State}.
+
+handle_cast(_Other, State) ->
+    {noreply, State}.
+
+handle_call(_Other, _From, State) ->
+    {reply, ok, State}.
+
+
+maybe_gc(State=#state{bytes=Bytes}) ->
+    case application:get_env(blockchain, gc_byte_interval, 10 * 1024 * 1024) < Bytes of
+        true ->
+            %% run a GC, this blocks the process
+            blockchain:rocksdb_gc(Bytes, blockchain_worker:blockchain()),
+            State#state{bytes=0};
+        false ->
+            State
+    end.

--- a/src/blockchain_sup.erl
+++ b/src/blockchain_sup.erl
@@ -128,6 +128,7 @@ init(Args) ->
         ++
         [?WORKER(blockchain_score_cache, []),
          ?WORKER(blockchain_worker, [BWorkerOpts]),
+         ?WORKER(blockchain_gc, []),
          ?WORKER(blockchain_txn_mgr, [BTxnManagerOpts]),
          ?SUP(blockchain_txn_mgr_sup, [BTxnMgrSupOpts]),
          ?SUP(blockchain_state_channel_sup, [StateChannelSupOpts])

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -3582,7 +3582,8 @@ context_cache(Cache, GwCache, Ledger) ->
           {ok, blockchain_block:block()} | {error, any()}.
 get_block(Height, #ledger_v1{blocks_db = DB,
                              heights_cf = HeightsCF} = Ledger) when is_integer(Height) ->
-    case {ok, Height} > current_height(Ledger) of
+    {ok, LedgerHeight} = current_height(Ledger),
+    case Height > LedgerHeight of
         true -> {error, too_new};
         _ ->
             case rocksdb:get(DB, HeightsCF, <<Height:64/integer-unsigned-big>>, []) of


### PR DESCRIPTION
Problem to solve: Even if we GC bytes on startup, we may run so long we still fill up the disk. This change attempts to keep the blockchain size roughly constant if the user has asked for GC by monitoring new blocks being added and every 10 mb, by default, GCing 10mb more data.