### PR TITLE
cache height in the poc so gc doesn't need to deserialize

### DIFF
--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -1048,6 +1048,7 @@ v2_to_v3(#blockchain_snapshot_v2{
             oracle_price = OraclePrice,
             oracle_price_list = OraclePriceList
            }) ->
+    Chain = blockchain_worker:blockchain(),
     #blockchain_snapshot_v3{
        current_height = CurrHeight,
        transaction_fee = 0,
@@ -1069,7 +1070,7 @@ v2_to_v3(#blockchain_snapshot_v2{
        pocs =
             lists:map(
                 fun({K, V}) ->
-                    List = lists:map(fun blockchain_ledger_poc_v2:serialize/1, V),
+                    List = lists:map(fun(P) -> blockchain_ledger_poc_v2:serialize(P, Chain) end, V),
                     Value = term_to_binary(List),
                     {K, Value}
                 end,

--- a/src/transactions/v1/blockchain_txn_poc_request_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_request_v1.erl
@@ -225,7 +225,7 @@ absorb(Txn, Chain) ->
     SecretHash = ?MODULE:secret_hash(Txn),
     OnionKeyHash = ?MODULE:onion_key_hash(Txn),
     BlockHash = ?MODULE:block_hash(Txn),
-    blockchain_ledger_v1:request_poc(OnionKeyHash, SecretHash, Challenger, BlockHash, Version, Ledger).
+    blockchain_ledger_v1:request_poc(OnionKeyHash, SecretHash, Challenger, BlockHash, Version, Chain, Ledger).
 
 %%--------------------------------------------------------------------
 %% @doc


### PR DESCRIPTION
try to make poc gc a lot more efficient by pre-caching the height somewhere it's cheap to decode.