### PR TITLE
Adt/gc h3dex andymck additions

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -177,6 +177,7 @@
 -define(h3dex_gc_width, h3dex_gc_width).
 
 %% the version number of poc targeting in use: integer
+%% if not set, code paths with default to 3 ( blockchain_poc_target_v3 )
 -define(poc_targeting_version, poc_targeting_version).
 
 %% the number of random hexes to utilize when targeting: integer

--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -167,9 +167,19 @@
 %% resolution for h3 polyfills, defaulted to 7 before we set it
 -define(polyfill_resolution, polyfill_resolution).
 
-%% max number of hexes to GC in the h3dex per block
+%% determines which hexing type to use for gateways: hex_h3dex | h3dex or not set
+%% hex_h3dex will result in both hexes and h3dex being updated
+%% h3dex will result in only h3dex being updated
+%% not set will result in hexes being updated
+-define(poc_hexing_type, poc_hexing_type).
+
+%% max number of hexes to GC in the h3dex per block: integer
 -define(h3dex_gc_width, h3dex_gc_width).
 
+%% the version number of poc targeting in use: integer
+-define(poc_targeting_version, poc_targeting_version).
+
+%% the number of random hexes to utilize when targeting: integer
 -define(poc_target_pool_size, poc_target_pool_size).
 %%%
 %%% score vars

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -4113,7 +4113,8 @@ add_to_hex(Hex, Gateway, Res, Ledger) ->
     {ok, h3dex} ->
       add_gw_to_h3dex(Hex, Gateway, Res, Ledger);
     _ ->
-      add_gw_to_hex(Hex, Gateway, Res, Ledger)
+      add_gw_to_hex(Hex, Gateway, Res, Ledger),
+      add_gw_to_h3dex(Hex, Gateway, Res, Ledger)
   end.
 
 add_gw_to_hex(Hex, Gateway, Res, Ledger) ->
@@ -4368,7 +4369,6 @@ key_to_h3(Key) ->
     <<H3:64/integer-unsigned-big>> = <<0:1, 1:4/integer-unsigned-big, 0:3, (15 - InverseResolution):4/integer-unsigned-big, BaseCell:7/integer-unsigned-big, Digits:45/integer-unsigned-big>>,
     H3.
 
-
 -spec add_gw_to_h3dex(Hex :: non_neg_integer(),
                     GWAddr :: libp2p_crypto:pubkey_bin(),
                     Res :: h3:index(),
@@ -4429,7 +4429,11 @@ maybe_gc_h3dex(Ledger) ->
     %% pick a random h3dex index and remove any inactive hotspots from it
     case ?MODULE:config(?h3dex_gc_width, Ledger) of
         {ok, Width} ->
-            {ok, InactivityThreshold} = ?MODULE:config(?hip17_interactivity_blocks, Ledger),
+            InactivityThreshold =
+              case ?MODULE:config(?hip17_interactivity_blocks, Ledger) of
+                {ok, InActV} -> InActV;
+                _ -> 10
+              end,
             %% we need a fairly deterministic way to choose hexes to be GC'd
             %% that ideally is not tied to internal representations like rocksdb
             %% sort order, etc.

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -1539,6 +1539,7 @@ add_gateway(OwnerAddr,
                         {ok, Res} = blockchain:config(?poc_target_hex_parent_res, Ledger),
                         Hex = h3:parent(Location, Res),
                         add_to_hex(Hex, GatewayAddress, Ledger),
+                        add_gw_to_hex(Hex, GatewayAddress, Ledger),
                         NewGw0;
                     {ok, V} when V > 3 ->
                         Gateways = active_gateways(Ledger),
@@ -4359,7 +4360,7 @@ add_gw_to_hex(Hex, GWAddr, Ledger) ->
                     %% hexes
                     case blockchain:config(?poc_target_hex_parent_res, Ledger) of
                         {ok, Res} ->
-                            build_random_hex_targeting_lookup(Ledger, Res);
+                            build_random_hex_targeting_lookup(Res, Ledger);
                         _ ->
                             ok
                     end;
@@ -4393,7 +4394,7 @@ remove_gw_from_hex(Hex, GWAddr, Ledger) ->
                             %% hexes
                             case blockchain:config(?poc_target_hex_parent_res, Ledger) of
                                 {ok, Res} ->
-                                    build_random_hex_targeting_lookup(Ledger, Res);
+                                    build_random_hex_targeting_lookup(Res, Ledger);
                                 _ ->
                                     ok
                             end;

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -4143,7 +4143,8 @@ remove_from_hex(Hex, Gateway, Res, Ledger) ->
     h3dex ->
       remove_gw_from_hex(Hex, Gateway, Ledger);
     _ ->
-      remove_gw_from_hex(Hex, Gateway, Ledger)
+      remove_gw_from_hex(Hex, Gateway, Ledger),
+      remove_gw_from_h3dex(Hex, Gateway, Res, Ledger)
   end.
 
 remove_gw_from_hex(Hex, Gateway, Ledger) ->

--- a/src/poc/blockchain_poc_target_v4.erl
+++ b/src/poc/blockchain_poc_target_v4.erl
@@ -97,14 +97,14 @@ hex_list(Ledger, RandState) ->
 hex_list(_Ledger, RandState, 0, Acc) ->
     %% usort so if we selected duplicates they don't get overselected
     {lists:usort(Acc), RandState};
-hex_list(Ledger, RandState, Count, Acc) ->
+hex_list(Ledger, RandState, HexCount, Acc) ->
     {ok, Hex, NewRandState} = blockchain_ledger_v1:random_targeting_hex(RandState, Ledger),
     case blockchain_ledger_v1:count_gateways_in_hex(Hex, Ledger) of
         0 ->
             %% this should not happen, but handle it anyway
-            hex_list(Ledger, NewRandState, Count, Acc);
-        Count ->
-            hex_list(Ledger, NewRandState, Count - 1, [{Hex, Count}|Acc])
+            hex_list(Ledger, NewRandState, HexCount, Acc);
+        GWCount ->
+            hex_list(Ledger, NewRandState, HexCount - 1, [{Hex, GWCount}|Acc])
     end.
 
 

--- a/src/transactions/v1/blockchain_txn_assert_location_v1.erl
+++ b/src/transactions/v1/blockchain_txn_assert_location_v1.erl
@@ -393,10 +393,11 @@ absorb(Txn, Chain) ->
             Error;
         ok ->
             blockchain_ledger_v1:add_gateway_location(Gateway, Location, Nonce, Ledger),
-            %% hex index update code needs to be unconditional and hard-coded
-            %% until we have chain var update hook
-            %% {ok, Res} = blockchain:config(?poc_target_hex_parent_res, Ledger),
-            Res = 5,
+            Res =
+              case blockchain:config(?poc_target_hex_parent_res, Ledger) of
+                {ok, ResV} -> ResV;
+                _ -> 5
+              end,
             OldLoc = blockchain_ledger_gateway_v2:location(OldGw),
             OldHex =
                 case OldLoc of
@@ -408,36 +409,25 @@ absorb(Txn, Chain) ->
             Hex = h3:parent(Location, Res),
 
             case {OldLoc, Location, Hex} of
-                {undefined, New, H} ->
+                {undefined, New, _H} ->
                     %% no previous location
-
                     %% add new hex
-                    blockchain_ledger_v1:add_to_hex(H, Gateway, Ledger),
-                    %% add new location of this gateway to h3dex
-                    blockchain_ledger_v1:add_gw_to_hex(New, Gateway, Ledger);
+                    blockchain_ledger_v1:add_to_hex(New, Gateway, Res, Ledger);
                 {Old, Old, _H} ->
                     %% why even check this, same loc as old loc
                     ok;
                 {Old, New, H} when H == OldHex ->
                     %% moved within the same Hex
-
                     %% remove old location of this gateway from h3dex
-                    blockchain_ledger_v1:remove_gw_from_hex(Old, Gateway, Ledger),
-
-                    %% add new location of this gateway to h3dex
-                    blockchain_ledger_v1:add_gw_to_hex(New, Gateway, Ledger);
-                {Old, New, H} ->
+                  blockchain_ledger_v1:remove_from_hex(Old, Gateway, Res, Ledger),
+                  %% add new location of this gateway to h3dex
+                  blockchain_ledger_v1:add_to_hex(New, Gateway, Res, Ledger);
+                {Old, New, _H} ->
                     %% moved to a different hex
-
                     %% remove this hex
-                    blockchain_ledger_v1:remove_from_hex(OldHex, Gateway, Ledger),
-                    %% add new hex
-                    blockchain_ledger_v1:add_to_hex(H, Gateway, Ledger),
-
-                    %% remove old location of this gateway from h3dex
-                    blockchain_ledger_v1:remove_gw_from_hex(Old, Gateway, Ledger),
-                    %% add new location of this gateway to h3dex
-                    blockchain_ledger_v1:add_gw_to_hex(New, Gateway, Ledger)
+                  blockchain_ledger_v1:remove_from_hex(Old, Gateway, Res, Ledger),
+                  %% add new hex
+                  blockchain_ledger_v1:add_to_hex(New, Gateway, Res, Ledger)
             end,
 
             case blockchain:config(?poc_version, Ledger) of

--- a/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
+++ b/src/transactions/v1/blockchain_txn_poc_receipts_v1.erl
@@ -304,7 +304,8 @@ check_is_valid_poc(Txn, Chain) ->
                                                        {ok, V} when V >= 8 ->
                                                            %% Targeting phase
                                                            %% Find the original target
-                                                           {ok, {Target, TargetRandState}} = blockchain_poc_target_v3:target(Challenger, Entropy, OldLedger, Vars),
+                                                           TargetingMod = targeting_mod(Ledger),
+                                                           {ok, {Target, TargetRandState}} = TargetingMod:target(Challenger, Entropy, OldLedger, Vars),
                                                            StartB = maybe_log_duration(target, StartFT),
                                                            %% Path building phase
                                                            RetB = blockchain_poc_path_v4:build(Target, TargetRandState, OldLedger, BlockTime, Vars),
@@ -1755,6 +1756,12 @@ poc_version(Ledger) ->
         {ok, V} -> V
     end.
 
+-spec targeting_mod(blockchain_ledger_v1:ledger()) -> atom().
+targeting_mod(Ledger) ->
+  case blockchain:config(?poc_targeting_version, Ledger) of
+    {ok, 4} -> blockchain_poc_target_v4;
+    _ -> blockchain_poc_target_v3
+  end.
 %% ------------------------------------------------------------------
 %% EUNIT Tests
 %% ------------------------------------------------------------------

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -974,10 +974,15 @@ validate_var(?polyfill_resolution, Value) ->
     validate_int(Value, "polyfill_resolution", 0, 15, false);
 validate_var(?h3dex_gc_width, Value) ->
   validate_int(Value, "h3dex_gc_width", 1, 10000, false);
-validate_var(?poc_targeting_version, Value) ->
-  validate_int(Value, "poc_targeting_version", 1, 1000, false);
 validate_var(?poc_target_pool_size, Value) ->
   validate_int(Value, "poc_target_pool_size", 1, 1000000, false);
+validate_var(?poc_targeting_version, Value) ->
+    case Value of
+        3 -> ok;
+        4 -> ok;
+        _ ->
+            throw({error, {invalid_poc_targeting_version, Value}})
+    end;
 
 %% score vars
 validate_var(?alpha_decay, Value) ->

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -972,6 +972,12 @@ validate_var(?check_snr, Value) ->
     end;
 validate_var(?polyfill_resolution, Value) ->
     validate_int(Value, "polyfill_resolution", 0, 15, false);
+validate_var(?h3dex_gc_width, Value) ->
+  validate_int(Value, "h3dex_gc_width", 1, 10000, false);
+validate_var(?poc_targeting_version, Value) ->
+  validate_int(Value, "poc_targeting_version", 1, 1000, false);
+validate_var(?poc_target_pool_size, Value) ->
+  validate_int(Value, "poc_target_pool_size", 1, 1000000, false);
 
 %% score vars
 validate_var(?alpha_decay, Value) ->

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -983,6 +983,14 @@ validate_var(?poc_targeting_version, Value) ->
         _ ->
             throw({error, {invalid_poc_targeting_version, Value}})
     end;
+validate_var(?poc_hexing_type, Value) ->
+  case Value of
+    hex_h3dex -> ok;
+    h3dex -> ok;
+    hex -> ok;
+    _ ->
+      throw({error, {poc_hexing_type, Value}})
+  end;
 
 %% score vars
 validate_var(?alpha_decay, Value) ->


### PR DESCRIPTION
- Fixes issues in targeting v4.
- Gates targeting version in use behind a chain var, distinct from poc_version
- Provides a uniform API to add/remove a gateway to hexing rather than individual calls to hex and h3dex
- Adds chain var to determine which hexing type to use ( hexes, h3dex or both ), allows olds hexes support to be stopped when required

Linked miner PR: https://github.com/helium/miner/pull/1387