### PR TITLE
conditionally include the common_test lib

### DIFF
--- a/src/transactions/v2/blockchain_txn_assert_location_v2.erl
+++ b/src/transactions/v2/blockchain_txn_assert_location_v2.erl
@@ -4,7 +4,9 @@
 %% @end
 %%%-------------------------------------------------------------------
 -module(blockchain_txn_assert_location_v2).
+-ifdef(TEST).
 -include_lib("common_test/include/ct.hrl").
+-endif
 
 -behavior(blockchain_txn).
 


### PR DESCRIPTION
I was trying a source build and apparently the erlang release I have doesn't have the test libs. But we should be able to remove this when not doing a test build?