### PR TITLE
Dance moves disputed? Get off the Dance Floor!

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -341,7 +341,10 @@
 %% The "new" behavior (i.e., `true') is to count state channels
 %% that are only in the open state and ignore closed channels.
 -define(sc_only_count_open_active, sc_only_count_open_active).
-
+%% How to handle rewards when a state channel close is disputed.
+%%  - 0 :: reconcile as much as possible
+%%  - 1 :: accept first dispute, drop all DC from opener, no rewards
+-define(sc_dispute_strategy_version, sc_dispute_strategy_version).
 
 %% ------------------------------------------------------------------
 %% snapshot vars

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1095,6 +1095,8 @@ validate_var(?sc_only_count_open_active, Value) ->
         false -> ok;
         Other -> throw({error, {invalid_sc_only_count_open_active_value, Other}})
     end;
+validate_var(?sc_dispute_strategy_version, Value) ->
+    validate_int(Value, "sc_dispute_strategy_version", 0, 1, false);
 
 %% txn snapshot vars
 validate_var(?snapshot_version, Value) ->

--- a/test/blockchain_state_channel_SUITE.erl
+++ b/test/blockchain_state_channel_SUITE.erl
@@ -9,6 +9,7 @@
     all/0,
     test_cases/0,
     init_per_group/2, end_per_group/2,
+    init_per_suite/1, end_per_suite/1,
     init_per_testcase/2, end_per_testcase/2
 ]).
 
@@ -26,6 +27,7 @@
     open_without_oui_test/1,
     max_scs_open_test/1,
     max_scs_open_v2_test/1,
+    sc_dispute_prevention_test/1,
     oui_not_found_test/1,
     unknown_owner_test/1,
     crash_single_sc_test/1,
@@ -70,6 +72,7 @@ test_cases() ->
         open_without_oui_test,
         max_scs_open_test,
         max_scs_open_v2_test,
+        sc_dispute_prevention_test,
         oui_not_found_test,
         unknown_owner_test,
         crash_single_sc_test,
@@ -83,12 +86,27 @@ test_cases() ->
 %% TEST CASE SETUP
 %%--------------------------------------------------------------------
 
+init_per_suite(Config) ->
+    [{sc_client_transport_handler, blockchain_state_channel_handler} | Config].
+
 %% NOTE: If you're running individual tests 'sc_client_transport_handler` will be unset.
 %% Run with --group=(sc_libp2p | sc_grpc)
 init_per_group(sc_libp2p, Config) ->
     [{sc_client_transport_handler, blockchain_state_channel_handler} | Config];
 init_per_group(sc_grpc, Config) ->
     [{sc_client_transport_handler, blockchain_grpc_sc_client_test_handler} | Config].
+
+debug_modules_for_node(_, _, []) ->
+    ok;
+debug_modules_for_node(Node, Filename, [Module | Rest]) ->
+    {ok, _} = ct_rpc:call(
+                Node,
+                lager,
+                trace_file,
+                [Filename, [{module, Module}], debug]
+               ),
+    debug_modules_for_node(Node, Filename, Rest).
+
 
 init_per_testcase(Test, Config) ->
     application:ensure_all_started(throttle),
@@ -103,49 +121,23 @@ init_per_testcase(Test, Config) ->
 
     [RouterNode, GatewayNode1|_] = Nodes,
     Dir = os:getenv("SC_DIR", ""),
-    {ok, _} = ct_rpc:call(
-        RouterNode,
-        lager,
-        trace_file,
-        [Dir ++ "sc_server.log", [{module, blockchain_state_channels_server}], debug]
-    ),
-    {ok, _} = ct_rpc:call(
-        RouterNode,
-        lager,
-        trace_file,
-        [Dir ++ "sc_server.log", [{module, blockchain_state_channel_handler}], debug]
-    ),
-    {ok, _} = ct_rpc:call(
-        RouterNode,
-        lager,
-        trace_file,
-        [Dir ++ "sc_server.log", [{module, blockchain_state_channel_v1}], debug]
-    ),
-    {ok, _} = ct_rpc:call(
-        RouterNode,
-        lager,
-        trace_file,
-        [Dir ++ "sc_server.log", [{module, blockchain_state_channels_worker}], debug]
-    ),
-    {ok, _} = ct_rpc:call(
-        RouterNode,
-        lager,
-        trace_file,
-        [Dir ++ "sc_server.log", [{module, blockchain_state_channels_cache}], debug]
-    ),
-
-    {ok, _} = ct_rpc:call(
-        GatewayNode1,
-        lager,
-        trace_file,
-        [Dir ++ "sc_client.log", [{module, blockchain_state_channels_client}], debug]
-    ),
-    {ok, _} = ct_rpc:call(
-        GatewayNode1,
-        lager,
-        trace_file,
-        [Dir ++ "sc_client.log", [{module, blockchain_state_channel_handler}], debug]
-    ),
+    debug_modules_for_node(
+      RouterNode,
+      Dir ++ "sc_server.log",
+      [blockchain_state_channel_v1,
+       blockchain_state_channels_cache,
+       blockchain_state_channels_handler,
+       blockchain_state_channels_server,
+       blockchain_state_channels_worker,
+       blockchain_txn_state_channel_close_v1]
+     ),
+    debug_modules_for_node(
+      GatewayNode1,
+      Dir ++ "sc_client_1.log",
+      [blockchain_state_channel_v1,
+       blockchain_state_channels_client,
+       blockchain_state_channels_handler]
+     ),
 
     %% accumulate the address of each node
     Addrs = lists:foldl(fun(Node, Acc) ->
@@ -183,6 +175,10 @@ init_per_testcase(Test, Config) ->
                        end, [{RouterNode, GatewayNodeAddr}, {GatewayNode, RouterNodeAddr}])
              end, 200, 150),
 
+    SCDisputeStrat = case Test == sc_dispute_prevention_test of
+                         false -> 0;
+                         true -> 1
+                     end,
     DefaultVars = #{num_consensus_members => NumConsensusMembers},
     ExtraVars = #{
         max_open_sc => 2,
@@ -195,7 +191,8 @@ init_per_testcase(Test, Config) ->
         sc_grace_blocks => 5,
         dc_payload_size => 24,
         sc_max_actors => 100,
-        sc_version => 2 %% we are focring 2 for all test as 1 is just rly old now
+        sc_version => 2, %% we are focring 2 for all test as 1 is just rly old now
+        sc_dispute_strategy_version => SCDisputeStrat
     },
 
     {InitialVars, {master_key, MasterKey}} = blockchain_ct_utils:create_vars(maps:merge(DefaultVars, ExtraVars)),
@@ -250,6 +247,9 @@ end_per_testcase(Test, Config) ->
     blockchain_ct_utils:end_per_testcase(Test, Config).
 
 end_per_group(_, _Config) ->
+    ok.
+
+end_per_suite(_) ->
     ok.
 
 %%--------------------------------------------------------------------
@@ -1623,6 +1623,197 @@ max_scs_open_v2_test(Config) ->
     {ok, _Block31} = ct_rpc:call(RouterNode, test_utils, create_block, [ConsensusMembers, [SignedSCOpenTxn3]]),
     ok.
 
+sc_dispute_prevention_test(Config) ->
+    [RouterNode, GatewayNode1, GatewayNode2 |_] = ?config(nodes, Config),
+    ConsensusMembers = ?config(consensus_members, Config),
+
+    %% NOTE: sc_dispute_strategy_version chain var is toggled for this test in init_per_test_case/2
+
+    Self = self(),
+    ok = setup_meck_txn_forwarding(RouterNode, Self),
+    ok = setup_meck_txn_forwarding(GatewayNode1, Self),
+
+    %% Get router chain, swarm and pubkey_bin
+    RouterChain = ct_rpc:call(RouterNode, blockchain_worker, blockchain, []),
+    RouterLedger = blockchain:ledger(RouterChain),
+    RouterSwarm = ct_rpc:call(RouterNode, blockchain_swarm, swarm, []),
+
+    {ok, RouterPubkey, RouterSigFun, _} = ct_rpc:call(RouterNode, blockchain_swarm, keys, []),
+    RouterPubkeyBin = libp2p_crypto:pubkey_to_bin(RouterPubkey),
+
+    {ok, Gateway1Pubkey, Gateway1SigFun, _} = ct_rpc:call(GatewayNode1, blockchain_swarm, keys, []),
+    Gateway1PubkeyBin = libp2p_crypto:pubkey_to_bin(Gateway1Pubkey),
+
+    {ok, Gateway2Pubkey, Gateway2SigFun, _} = ct_rpc:call(GatewayNode2, blockchain_swarm, keys, []),
+    Gateway2PubkeyBin = libp2p_crypto:pubkey_to_bin(Gateway2Pubkey),
+
+    ct:pal("Pubkeys: ~n~p",
+           [[
+             {routernode, RouterPubkeyBin},
+             {gateway_1, Gateway1PubkeyBin},
+             {gateway_2, Gateway2PubkeyBin}
+            ]]),
+
+    %% Create OUI txn
+    SignedOUITxn = create_oui_txn(1, RouterNode, [], 8),
+    ct:pal("SignedOUITxn: ~p", [SignedOUITxn]),
+
+    %% ===================================================================
+    %% - open state channel
+
+    ID1 = crypto:strong_rand_bytes(24),
+    Nonce1 = 1,
+    SignedSCOpenTxn1 = create_sc_open_txn(RouterNode, ID1, 12, 1, Nonce1, 99),
+
+    %% Adding block with state channels
+    {ok, B2} = add_block(RouterNode, RouterChain, ConsensusMembers, [SignedOUITxn, SignedSCOpenTxn1]),
+    ok = ct_rpc:call(RouterNode, blockchain_gossip_handler, add_block, [B2, RouterChain, Self, RouterSwarm]),
+
+    ok = blockchain_ct_utils:wait_until_height(RouterNode, 2),
+
+    %% sanity check
+    OpenSCCountForOwner0 = ct_rpc:call(RouterNode, blockchain_ledger_v1, count_open_scs_for_owner, [[ID1], RouterPubkeyBin, RouterLedger]),
+    ?assertEqual(1, OpenSCCountForOwner0),
+
+
+    %% Helpers
+    AddFakeBlocksFn =
+        fun(NumBlocks, ExpectedBlock, Nodes) ->
+                ok = add_and_gossip_fake_blocks(NumBlocks, ConsensusMembers, RouterNode, RouterSwarm, RouterChain, Self),
+                lists:foreach(fun(Node) ->
+                                      ok = blockchain_ct_utils:wait_until_height(Node, ExpectedBlock)
+                              end, Nodes)
+                end,
+
+    SendPacketsFn = fun(NumPackets, Gateway) ->
+                         lists:foreach(
+                           fun(_) ->
+                                   DevNonce0 = crypto:strong_rand_bytes(2),
+                                   Packet0 = blockchain_ct_utils:join_packet(?APPKEY, DevNonce0, 0.0),
+                                   ok = ct_rpc:call(Gateway, blockchain_state_channels_client, packet, [Packet0, [], 'US915'])
+                           end,
+                           lists:seq(1, NumPackets)
+                          )
+                 end,
+
+    %% Wait until Gateways have gotten blocks with OUI txn to send packets
+    AddFakeBlocksFn(3, 5, [RouterNode, GatewayNode1]),
+
+    %% ===================================================================
+    %% Sending 10 packet from first gateway
+    SendPacketsFn(20, GatewayNode1),
+    AddFakeBlocksFn(1, 6, [RouterNode, GatewayNode1]),
+
+    %% Send packets from another gateway
+    %% Gateway2 needs to be involved state channel to dispute
+    SendPacketsFn(20, GatewayNode2),
+    AddFakeBlocksFn(1, 7, [RouterNode, GatewayNode1, GatewayNode2]),
+
+    %% ===================================================================
+    %% Wait until we can get a state channel with both summaries
+    %% Failures to dial during this test can cause failures here
+    ok = test_utils:wait_until(
+           fun() ->
+                   case get_active_state_channel(RouterNode, ID1) of
+                       worker_not_started -> {false, worker_not_started};
+                       SC ->
+                           case length(blockchain_state_channel_v1:summaries(SC)) of
+                               2 -> true;
+                               C -> {false, summary_count, C}
+                           end
+                   end
+           end, 100, 100),
+
+    SC0 = get_active_state_channel(RouterNode, ID1),
+    ct:pal("Routernode SC: ~p", [lager:pr(SC0, blockchain_state_channel_v1)]),
+
+    %% ===================================================================
+    %% Let the state channel expire and add to the chain
+    AddFakeBlocksFn(8, 15, [RouterNode]),
+
+    %% Adding the close txn to the chain
+    receive
+        {txn, Txn} ->
+            %% routernode closing the state channel
+            {ok, B18} = ct_rpc:call(RouterNode, test_utils, create_block, [ConsensusMembers, [Txn], #{}, false]),
+            ok = ct_rpc:call(RouterNode, blockchain_gossip_handler, add_block, [B18, RouterChain, Self, RouterSwarm])
+    after 10000 ->
+        ct:fail("close txn timeout")
+    end,
+
+    %% ===================================================================
+    %% We've added the state channel to the chain. Rewards should be able to be
+    %% determined, and there should be some for the gateways involved.
+
+    ok = blockchain_ct_utils:wait_until_height(RouterNode, 16),
+
+    %% REVIEW: How can I assert something here about the rewards?
+    %% Nothing has been disputed yet.
+    {ok, Rewards1} = ct_rpc:call(RouterNode, blockchain_txn_rewards_v2, calculate_rewards_metadata, [5, 16, RouterChain]),
+    ct:pal("PubkeyBins: ~n~p", [[{routernode, RouterPubkeyBin}, {gateway_1, Gateway1PubkeyBin}, {gateway_2, Gateway2PubkeyBin}]]),
+    ct:pal("potential Rewards: ~p", [lager:pr(Rewards1, blockchain_txn_rewards_v2)]),
+
+    %% ===================================================================
+    %% Make two disputes that are both valid before they are submitted
+
+    {SC1, true} = blockchain_state_channel_v1:update_summary_for(
+            Gateway2PubkeyBin,
+            blockchain_state_channel_summary_v1:new(Gateway2PubkeyBin, 11, 22),
+            SC0,
+            90),
+
+    SignedSC1 = blockchain_state_channel_v1:sign(SC1, RouterSigFun),
+    Dispute1 = blockchain_txn_state_channel_close_v1:new(SC0, SignedSC1, Gateway1PubkeyBin),
+    SignedTxn1 = blockchain_txn_state_channel_close_v1:sign(Dispute1, Gateway1SigFun),
+
+    %% ----
+    {SC2, true} = blockchain_state_channel_v1:update_summary_for(
+            Gateway2PubkeyBin,
+            blockchain_state_channel_summary_v1:new(Gateway2PubkeyBin, 22, 33),
+            SC0,
+            90),
+
+    SignedSC2 = blockchain_state_channel_v1:sign(SC2, RouterSigFun),
+    Dispute2 = blockchain_txn_state_channel_close_v1:new(SC0, SignedSC2, Gateway2PubkeyBin),
+    SignedTxn2 = blockchain_txn_state_channel_close_v1:sign(Dispute2, Gateway2SigFun),
+
+    Res1 = ct_rpc:call(RouterNode, blockchain_txn_state_channel_close_v1, is_valid, [SignedTxn1, RouterChain]),
+    ?assertEqual(ok, Res1, "Our first dispute close is valid"),
+
+    Res2 = ct_rpc:call(RouterNode, blockchain_txn_state_channel_close_v1, is_valid, [SignedTxn2, RouterChain]),
+    ?assertEqual(ok, Res2, "Our second dispute close is valid"),
+
+    %% Should not be able to create a block with more than 1 dispute
+    %% REVIEW: Even with sc_dispute_prevention `false' this line passes
+    {error, {invalid_txns, [_]}} = add_block(RouterNode, RouterChain, ConsensusMembers, [SignedTxn1, SignedTxn1]),
+
+    %% ===================================================================
+    %% Submit one fo the close txns to put SC0 in dispute
+    {ok, B3} = add_block(RouterNode, RouterChain, ConsensusMembers, [SignedTxn1]),
+    ok = ct_rpc:call(RouterNode, blockchain_gossip_handler, add_block, [B3, RouterChain, Self, RouterSwarm]),
+
+    %% wait until this block has made it everywhere
+    AddFakeBlocksFn(1, 18, [RouterNode, GatewayNode1, GatewayNode1]),
+
+    %% REVIEW: How can I assert something here about the rewards?
+    {ok, Rewards2} = ct_rpc:call(RouterNode, blockchain_txn_rewards_v2, calculate_rewards_metadata, [5, 18, RouterChain]),
+    ct:pal("PubkeyBins: ~n~p", [[{routernode, RouterPubkeyBin}, {gateway_1, Gateway1PubkeyBin}, {gateway_2, Gateway2PubkeyBin}]]),
+    ct:pal("disputed Rewards: ~p", [lager:pr(Rewards2, blockchain_txn_rewards_v2)]),
+
+    %% Check that the state that was first closed by routernode, is in dispute
+    {ok, LedgerSC} = ct_rpc:call(RouterNode, blockchain_ledger_v1, find_state_channel, [ID1, RouterPubkeyBin, RouterLedger]),
+    ct:pal("Ledger SC: ~p", [lager:pr(LedgerSC, ledger_state_channel_v2)]),
+    ?assertEqual(dispute, blockchain_ledger_state_channel_v2:close_state(LedgerSC)),
+
+    %% ===================================================================
+    %% The unsubmitted close dispute is no longer valid
+    Res3 = ct_rpc:call(RouterNode, blockchain_txn_state_channel_close_v1, is_valid, [SignedTxn2, RouterChain]),
+    ct:pal("Trying to create block with bad txn: ~p", [Res3]),
+    ?assertEqual({error, already_disputed}, Res3, "Our second dispute close is not valid"),
+
+    ok.
+
+
 oui_not_found_test(Config) ->
     [RouterNode |_] = ?config(nodes, Config),
     ConsensusMembers = ?config(consensus_members, Config),
@@ -2326,6 +2517,9 @@ get_consensus_members(Config, ConsensusAddrs) ->
                                          end
                                  end, [], Nodes)).
 
+
+create_oui_txn(OUI, RouterNode, [], SubnetSize) ->
+    create_oui_txn(OUI, RouterNode, [{16#deadbeef, 16#deadc0de}], SubnetSize);
 create_oui_txn(OUI, RouterNode, EUIs, SubnetSize) ->
     {ok, RouterPubkey, RouterSigFun, _} = ct_rpc:call(RouterNode, blockchain_swarm, keys, []),
     RouterPubkeyBin = libp2p_crypto:pubkey_to_bin(RouterPubkey),
@@ -2387,7 +2581,7 @@ add_and_gossip_fake_blocks(NumFakeBlocks, ConsensusMembers, Node, Swarm, Chain, 
 
 setup_meck_txn_forwarding(Node, From) ->
     ok = ct_rpc:call(Node, meck_test_util, forward_submit_txn, [From]),
-    ok = ct_rpc:call(Node, blockchain_txn_mgr, submit, [fake_txn, fun(_, _) -> ok end]),
+    ok = ct_rpc:call(Node, blockchain_txn_mgr, submit, [fake_txn, fun(_) -> ok end]),
     receive
         {txn, fake_txn} ->
             ct:pal("Got fake_txn test"),

--- a/test/meck_test_util.erl
+++ b/test/meck_test_util.erl
@@ -5,7 +5,7 @@
 forward_submit_txn(Pid) ->
     meck:expect(blockchain_txn_mgr, submit, fun(T, F) ->
         Pid ! {txn, T},
-        F(ok, T),
+        F(ok),
         ok
     end),
     ok.


### PR DESCRIPTION
- Accept a single state channel close dispute txn to move a SC to disputed, the rest will be thrown away
- Cut rewards for disputed state channels

The added state channel test `sc_dispute_prevention_test`, if there are dial failures, the test will fail. It will complain about not enough summaries. I do not know how to increase the reliability at this time.