### PR TITLE
try to write gw denorm stuff less often

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -261,7 +261,7 @@ upgrade_gateways_v2(Ledger) ->
                            Neighbors = blockchain_poc_path:neighbors(A, Gateways, Ledger),
                            blockchain_ledger_gateway_v2:neighbors(Neighbors, G)
                    end,
-              blockchain_ledger_v1:update_gateway(G1, A, Ledger)
+              blockchain_ledger_v1:update_gateway(G, G1, A, Ledger)
       end, Gateways),
     ok.
 
@@ -275,7 +275,7 @@ upgrade_gateways_lg(Ledger) ->
               case blockchain_ledger_gateway_v2:serialize(Gw) of
                   BinGw -> ok;
                   _ ->
-                      blockchain_ledger_v1:update_gateway(Gw, Addr, Ledger)
+                      blockchain_ledger_v1:update_gateway(new, Gw, Addr, Ledger)
               end
       end,
       whatever,
@@ -293,7 +293,7 @@ upgrade_gateways_score(Ledger) ->
                       case blockchain_ledger_gateway_v2:serialize(Gw1) of
                           BinGw -> ok;
                           _ ->
-                              blockchain_ledger_v1:update_gateway(Gw1, Addr, Ledger)
+                              blockchain_ledger_v1:update_gateway(Gw, Gw1, Addr, Ledger)
                       end
               end,
               whatever,
@@ -365,7 +365,7 @@ upgrade_gateways_oui(Ledger) ->
     %% find all neighbors for everyone
     maps:map(
       fun(A, G) ->
-              blockchain_ledger_v1:update_gateway(G, A, Ledger)
+              blockchain_ledger_v1:update_gateway(new, G, A, Ledger)
       end, Gateways),
     ok.
 
@@ -381,7 +381,7 @@ clear_witnesses(Ledger) ->
               case blockchain_ledger_gateway_v2:serialize(Gw2) of
                   BinGw -> ok;
                   _ ->
-                      blockchain_ledger_v1:update_gateway(Gw2, Addr, Ledger)
+                      blockchain_ledger_v1:update_gateway(Gw, Gw2, Addr, Ledger)
               end
       end,
       whatever,

--- a/src/ledger/v1/blockchain_ledger_gateway_v2.erl
+++ b/src/ledger/v1/blockchain_ledger_gateway_v2.erl
@@ -755,7 +755,7 @@ filter_stale_witnesses(GatewayBin, GatewayToPurge = #gateway_v2{witnesses = Witn
             GatewayToPurge, Witnesses),
     case PurgeGW of
         true ->
-            ok = blockchain_ledger_v1:update_gateway(PurgedGW, GatewayBin, Ledger);
+            ok = blockchain_ledger_v1:update_gateway(GatewayToPurge, PurgedGW, GatewayBin, Ledger);
         _ ->
             noop
     end,

--- a/src/transactions/v1/blockchain_txn_assert_location_v1.erl
+++ b/src/transactions/v1/blockchain_txn_assert_location_v1.erl
@@ -451,7 +451,7 @@ absorb(Txn, Chain) ->
                     {ok, Gw} = blockchain_ledger_v1:find_gateway_info(Gateway, Ledger),
                     ok = blockchain_ledger_v1:fixup_neighbors(Gateway, Gateways, Neighbors, Ledger),
                     Gw1 = blockchain_ledger_gateway_v2:neighbors(Neighbors, Gw),
-                    ok = blockchain_ledger_v1:update_gateway(Gw1, Gateway, Ledger)
+                    ok = blockchain_ledger_v1:update_gateway(Gw, Gw1, Gateway, Ledger)
 
             end
     end.

--- a/src/transactions/v1/blockchain_txn_transfer_hotspot_v1.erl
+++ b/src/transactions/v1/blockchain_txn_transfer_hotspot_v1.erl
@@ -215,7 +215,7 @@ absorb(Txn, Chain) ->
             ok = blockchain_ledger_v1:debit_account(Buyer, HNTToSeller, BuyerNonce, Ledger),
             ok = blockchain_ledger_v1:credit_account(Seller, HNTToSeller, Ledger),
             NewGWInfo = blockchain_ledger_gateway_v2:owner_address(Buyer, GWInfo),
-            ok = blockchain_ledger_v1:update_gateway(NewGWInfo, Gateway, Ledger)
+            ok = blockchain_ledger_v1:update_gateway(GWInfo, NewGWInfo, Gateway, Ledger)
     end.
 
 -spec print(txn_transfer_hotspot()) -> iodata().

--- a/src/transactions/v2/blockchain_txn_assert_location_v2.erl
+++ b/src/transactions/v2/blockchain_txn_assert_location_v2.erl
@@ -459,7 +459,7 @@ maybe_update_neighbors(Gateway, Ledger) ->
             {ok, Gw} = blockchain_ledger_v1:find_gateway_info(Gateway, Ledger),
             ok = blockchain_ledger_v1:fixup_neighbors(Gateway, Gateways, Neighbors, Ledger),
             Gw1 = blockchain_ledger_gateway_v2:neighbors(Neighbors, Gw),
-            ok = blockchain_ledger_v1:update_gateway(Gw1, Gateway, Ledger)
+            ok = blockchain_ledger_v1:update_gateway(Gw, Gw1, Gateway, Ledger)
     end.
 
 -spec maybe_alter_hex(OldGw :: blockchain_ledger_gateway_v2:gateway(),

--- a/src/transactions/v2/blockchain_txn_transfer_hotspot_v2.erl
+++ b/src/transactions/v2/blockchain_txn_transfer_hotspot_v2.erl
@@ -179,7 +179,7 @@ absorb(Txn, Chain) ->
         ok ->
             NewGWInfo0 = blockchain_ledger_gateway_v2:owner_address(NewOwner, GWInfo),
             NewGWInfo1 = blockchain_ledger_gateway_v2:nonce(Nonce, NewGWInfo0),
-            ok = blockchain_ledger_v1:update_gateway(NewGWInfo1, Gateway, Ledger)
+            ok = blockchain_ledger_v1:update_gateway(GWInfo, NewGWInfo1, Gateway, Ledger)
     end.
 
 -spec print(txn_transfer_hotspot_v2()) -> iodata().


### PR DESCRIPTION
this is an attempt to write less on updates.  the operating theory here is that since we're mostly getting the locations, we're blowing the cache on those locations by rewriting them all of the time, even when they rarely change.  Also, writing this stuff over and over increases write amplification of these values, which might be what's slowing stuff down on gateways.