### PR TITLE
exclude infos, like blocks, from the internal hash

### DIFF
--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -380,10 +380,18 @@ serialize_v6(#{version := v6}=Snapshot0, BlocksOrNoBlocks) ->
             noblocks ->
                 EmptyListBin
         end,
+    Infos =
+        case BlocksOrNoBlocks of
+            blocks ->
+                maps:get(infos, Snapshot0, EmptyListBin);
+            noblocks ->
+                EmptyListBin
+        end,
 
     Snapshot1 = maps:put(blocks, Blocks, Snapshot0),
+    Snapshot2 = maps:put(infos, Infos, Snapshot1),
 
-    Pairs = lists:keysort(1, maps:to_list(Snapshot1)),
+    Pairs = lists:keysort(1, maps:to_list(Snapshot2)),
     frame(6, serialize_pairs(Pairs)).
 
 -spec serialize_v5(snapshot_v5(), noblocks) -> binary().
@@ -854,7 +862,7 @@ hash(Snap) ->
                               hash_bytes(TmpCtx, FD, Len)
                       end, Ctx1, lists:keysort(1, maps:to_list(Snap))),
             crypto:hash_final(FinalCtx);
-        _ -> 
+        _ ->
             crypto:hash(sha256, serialize(Snap, noblocks))
     end.
 

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -835,10 +835,14 @@ hash(Snap) ->
         v6 ->
             %% attempt to incrementally hash the snapshot without building up a big binary
             Ctx0 = crypto:hash_init(sha256),
-            Size = snapshot_size(Snap#{blocks => <<>>}),
+            Size = snapshot_size(Snap#{blocks => <<>>, infos => <<>>}),
             Ctx1 = crypto:hash_update(Ctx0, <<6, Size:32/integer-unsigned-little>>),
             FinalCtx = lists:foldl(fun({blocks, _}, Acc) ->
                               Key = term_to_binary(blocks),
+                              KeyLen = byte_size(Key),
+                              crypto:hash_update(Acc, <<KeyLen:32/integer-unsigned-little, Key/binary, 0:32/integer-unsigned-little>>);
+                          ({infos, _}, Acc) ->
+                              Key = term_to_binary(infos),
                               KeyLen = byte_size(Key),
                               crypto:hash_update(Acc, <<KeyLen:32/integer-unsigned-little, Key/binary, 0:32/integer-unsigned-little>>);
                           ({version, Version}, Acc) ->

--- a/test/blockchain_snapshot_SUITE.erl
+++ b/test/blockchain_snapshot_SUITE.erl
@@ -80,6 +80,22 @@ basic_test(DeserializeFrom, Cfg0) ->
         "Hashes A and B are equal after removal of VolatileFields."
     ),
 
+    ?assertEqual(
+        snap_hash_with_field(SnapshotA, blocks, [<<"fake-block">>]),
+        snap_hash_with_field(SnapshotA, blocks, []),
+        "'blocks' field is ignored in hashing."
+    ),
+    ?assertEqual(
+        snap_hash_with_field(SnapshotA, infos, [<<"fake-info">>]),
+        snap_hash_with_field(SnapshotA, infos, []),
+        "'infos' field is ignored in hashing."
+    ),
+    ?assertNotEqual(
+        snap_hash_with_field(SnapshotA, multi_keys, [<<"fake-key">>]),
+        snap_hash_with_field(SnapshotA, multi_keys, []),
+        "'multi_keys' is NOT ignored in hashing." % TODO Test other fields too.
+    ),
+
     Ledger0 = blockchain:ledger(Chain),
     {ok, Height0} = blockchain_ledger_v1:current_height(Ledger0),
     ct:pal("ledger height BEFORE snap load: ~p", [Height0]),
@@ -193,6 +209,10 @@ mem_limit_test(Cfg) ->
 -spec snap_hash_without_fields([atom()], map()) -> map().
 snap_hash_without_fields(Fields, Snap) ->
     blockchain_ledger_snapshot_v1:hash(snap_without_fields(Fields, Snap)).
+
+-spec snap_hash_with_field(map(), atom(), term()) -> map().
+snap_hash_with_field(Snap, Key, Val) ->
+    blockchain_ledger_snapshot_v1:hash(maps:put(Key, term_to_binary(Val), Snap)).
 
 -spec snap_without_fields([atom()], map()) -> map().
 snap_without_fields(Fields, Snap) ->


### PR DESCRIPTION
they contain maps, so the ordering is going to be different, and they are not properly part of the ledger.