### PR TITLE
Fix badly formed 'endif'

### DIFF
--- a/src/transactions/v2/blockchain_txn_assert_location_v2.erl
+++ b/src/transactions/v2/blockchain_txn_assert_location_v2.erl
@@ -4,13 +4,10 @@
 %% @end
 %%%-------------------------------------------------------------------
 -module(blockchain_txn_assert_location_v2).
--ifdef(TEST).
--include_lib("common_test/include/ct.hrl").
--endif
 
 -behavior(blockchain_txn).
-
 -behavior(blockchain_json).
+
 -include("blockchain_json.hrl").
 -include("blockchain_txn_fees.hrl").
 -include_lib("helium_proto/include/blockchain_txn_assert_location_v2_pb.hrl").


### PR DESCRIPTION
Fix for
```
===> Compiling _build/default/lib/blockchain/src/transactions/v2/blockchain_txn_assert_location_v2.erl failed
_build/default/lib/blockchain/src/transactions/v2/blockchain_txn_assert_location_v2.erl:11:1: badly formed 'endif'
_build/default/lib/blockchain/src/transactions/v2/blockchain_txn_assert_location_v2.erl:705:1: unterminated '-ifdef'
```
when running `./rebar3 as test compile`