### PR TITLE
Make delayed_absorb async when loading blocks

### DIFF
--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -23,7 +23,7 @@
 
     check_key/2, mark_key/2, unmark_key/2,
 
-    new_context/1, new_direct_context/1, delete_context/1, remove_context/1, reset_context/1, commit_context/1,
+    new_context/1, give_context/2, new_direct_context/1, delete_context/1, remove_context/1, reset_context/1, commit_context/1,
     get_context/1, context_cache/1,
 
     get_block/2, get_raw_block/2, get_block_info/2,
@@ -467,6 +467,19 @@ new_context(Ledger) ->
     Cache = ets:new(txn_cache, [set, protected, {keypos, 1}]),
     GwCache = ets:new(gw_cache, [set, protected, {keypos, 1}]),
     context_cache(Cache, GwCache, Ledger).
+
+
+give_context(Ledger, Pid) ->
+    case ?MODULE:context_cache(Ledger) of
+        {undefined, undefined} ->
+            ok;
+        {direct, _GwCache} ->
+            ok;
+        {Cache, _GwCache} ->
+            ets:give_away(Cache, Pid, Ledger),
+            ok
+    end.
+
 
 -spec new_direct_context(ledger()) -> ledger().
 new_direct_context(Ledger) ->

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -489,6 +489,7 @@ unvalidated_absorb_and_commit(Block, Chain0, BeforeCommit, Rescue) ->
     case ?MODULE:validate(Transactions, Chain1, Rescue) of
         {_ValidTxns, []} ->
             End = erlang:monotonic_time(millisecond),
+            AbsordDelayedRef = absorb_delayed_async(Block, Chain0),
             case ?MODULE:absorb_block(Block, Rescue, Chain1) of
                 {ok, Chain2} ->
                     Ledger2 = blockchain:ledger(Chain2),
@@ -497,7 +498,7 @@ unvalidated_absorb_and_commit(Block, Chain0, BeforeCommit, Rescue) ->
                         ok ->
                             ok = blockchain_ledger_v1:commit_context(Ledger2),
                             End2 = erlang:monotonic_time(millisecond),
-                            absorb_delayed(Block, Chain0),
+                            ok = handle_absorb_delayed_result(AbsordDelayedRef),
                             absorb_aux(Block, Chain0),
                             End3 = erlang:monotonic_time(millisecond),
                             lager:info("validation took ~p absorb took ~p post took ~p ms height ~p",

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -799,6 +799,9 @@ absorb_delayed(Block0, Chain0) ->
 
 handle_absorb_delayed_result({Pid, Ref, MonitorRef}) ->
     receive
+        {'ETS-TRANSFER', _, _, _} ->
+            %% we don't need this message, just discard it
+            handle_absorb_delayed_result({Pid, Ref, MonitorRef});
         {Ref, ok} ->
             %% nothing to absorb
             erlang:demonitor(MonitorRef, [flush]),


### PR DESCRIPTION
This allows for block absorb to be roughly 2x faster on a dual core
machine.