### PR TITLE
add a tuning knob for h3dex gc res

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -282,6 +282,9 @@
 %% Hierarchical targeting variables
 %% Create hexes at this resolution for all the hotspots on the network.
 -define(poc_target_hex_parent_res, poc_target_hex_parent_res).
+%% Defines the resolution at which the garbage collection is run, allowing us 
+%% to tune the per-block workload
+-define(poc_target_hex_collection_res, poc_target_hex_collection_res).
 
 %% RSSI Bucketing variables
 %% Weight associated with biasing for RSSI centrality measures

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -4514,8 +4514,9 @@ maybe_gc_h3dex(Ledger) ->
     end.
 
 gc_h3dex_hex(Location, Height, InactivityThreshold, Ledger) ->
-    HexMap = lookup_gateways_from_hex(Location, Ledger),
     {ok, Res} = blockchain:config(?poc_target_hex_parent_res, Ledger),
+    {ok, GCRes} = blockchain:config(?poc_target_hex_collection_res, Ledger),
+    HexMap = lookup_gateways_from_hex(h3:parent(Location, GCRes), Ledger),
     %% no maps:foreach in otp 22
     maps:fold(fun(H3, Gateways, _Acc) ->
                       lists:foreach(fun(GW) ->

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1003,6 +1003,8 @@ validate_var(?poc_typo_fixes, Value) ->
     end;
 validate_var(?poc_target_hex_parent_res, Value) ->
     validate_int(Value, "poc_target_hex_parent_res", 3, 7, false);
+validate_var(?poc_target_hex_collection_res, Value) ->
+    validate_int(Value, "poc_target_hex_collection_res", 7, 12, false);
 validate_var(?poc_good_bucket_low, Value) ->
     validate_int(Value, "poc_good_bucket_low", -150, -90, false);
 validate_var(?poc_good_bucket_high, Value) ->


### PR DESCRIPTION
This allows the gc area to be increased so we then have two tuning knobs:  the number of requests we'd like to consider, and the area we'd like each of them to cover.