### PR TITLE
add fixedwidth bitvector encoding and var to control its use in miner

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -50,6 +50,9 @@
 %% a round
 -define(election_seen_penalty, election_seen_penalty).
 
+%% flag for bitvector width fix
+-define(election_bitvector_fix, election_bitvector_fix).
+
 %%%
 %%% ledger vars
 %%%

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -834,6 +834,12 @@ validate_var(?election_bba_penalty, Value) ->
     validate_float(Value, "election_bba_penalty", 0.001, 0.5);
 validate_var(?election_seen_penalty, Value) ->
     validate_float(Value, "election_seen_penalty", 0.001, 0.5);
+validate_var(?election_bitvector_fix, Value) ->
+    case Value of
+        true -> ok;
+        false -> ok;
+        _ -> throw({error, {invalid_bitvector_fix_boolean, Value}})
+    end;
 
 %% ledger vars
 validate_var(?var_gw_inactivity_threshold, Value) ->


### PR DESCRIPTION
this code initially assumed that all votes would be present, but we failed to enforce that, so we need to provide a new version that can only be used safely.   while we don't use this function in core, a var is required because otherwise we will produce halting blocks during the upgrade process.