### PR TITLE
Set relx RPC timeout to 900 seconds

### DIFF
--- a/scripts/extensions/ledger
+++ b/scripts/extensions/ledger
@@ -4,6 +4,8 @@ if [ -t 0 ] ; then
     export CLIQUE_COLUMNS
 fi
 
+export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+
 j=1
 l=$#
 buf="[[\"ledger\","

--- a/scripts/extensions/peer
+++ b/scripts/extensions/peer
@@ -4,6 +4,8 @@ if [ -t 0 ] ; then
     export CLIQUE_COLUMNS
 fi
 
+export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+
 j=1
 l=$#
 buf="[[\"peer\","

--- a/scripts/extensions/repair
+++ b/scripts/extensions/repair
@@ -4,6 +4,8 @@ if [ -t 0 ] ; then
     export CLIQUE_COLUMNS
 fi
 
+export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+
 j=1
 l=$#
 buf="[[\"repair\","

--- a/scripts/extensions/sc
+++ b/scripts/extensions/sc
@@ -4,6 +4,8 @@ if [ -t 0 ] ; then
     export CLIQUE_COLUMNS
 fi
 
+export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+
 j=1
 l=$#
 buf="[[\"sc\","

--- a/scripts/extensions/snapshot
+++ b/scripts/extensions/snapshot
@@ -4,6 +4,8 @@ if [ -t 0 ] ; then
     export CLIQUE_COLUMNS
 fi
 
+export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+
 j=1
 l=$#
 buf="[[\"snapshot\","

--- a/scripts/extensions/trace
+++ b/scripts/extensions/trace
@@ -4,6 +4,8 @@ if [ -t 0 ] ; then
     export CLIQUE_COLUMNS
 fi
 
+export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+
 j=1
 l=$#
 buf="[[\"trace\","

--- a/scripts/extensions/txn
+++ b/scripts/extensions/txn
@@ -4,6 +4,8 @@ if [ -t 0 ] ; then
     export CLIQUE_COLUMNS
 fi
 
+export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+
 j=1
 l=$#
 buf="[[\"txn\","


### PR DESCRIPTION
Problem to solve: We want to stop getting timeouts from the command line

Solution: Set the relx rpc timeout value to 900 seconds.

(see also https://github.com/helium/miner/pull/1464)