### PR TITLE
Jc/sync final flag

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -71,7 +71,7 @@
  {<<"hackney">>,{pkg,<<"hackney">>,<<"1.18.0">>},0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"30f17c5d1a7942297923f4e743c681c46f917fc3"}},
+       {ref,"4e1e0d97358d736ce861ef8d8d4a52eeb6ae9a4b"}},
   0},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},2},
  {<<"idna">>,{pkg,<<"idna">>,<<"6.1.1">>},1},

--- a/src/cli/blockchain_cli_snapshot.erl
+++ b/src/cli/blockchain_cli_snapshot.erl
@@ -139,7 +139,8 @@ snapshot_grab(["snapshot", "grab", HeightStr, HashStr, Filename], [], []) ->
         Hash = hex_to_binary(HashStr),
         {ok, Snapshot} = blockchain_worker:grab_snapshot(Height, Hash),
         %% NOTE: grab_snapshot returns a deserialized snapshot
-        file:write_file(Filename, blockchain_ledger_snapshot_v1:serialize(Snapshot))
+        ok = file:write_file(Filename, blockchain_ledger_snapshot_v1:serialize(Snapshot)),
+        [clique_status:text(io_lib:format("saved to ~p", [Filename]))]
     catch
         _Type:Error ->
             [clique_status:text(io_lib:format("failed: ~p", [Error]))]

--- a/src/cli/blockchain_cli_snapshot.erl
+++ b/src/cli/blockchain_cli_snapshot.erl
@@ -213,7 +213,7 @@ snapshot_list(["snapshot", "list"], [], []) ->
     Chain = blockchain_worker:blockchain(),
     Snapshots = blockchain:find_last_snapshots(Chain, 5),
     case Snapshots of
-        undefined -> ok;
+        undefined -> [clique_status:text("No snapshot found")];
         _ ->
             [ clique_status:text(io_lib:format("Height ~p\nHash ~p (~p)\nHave ~p\n",
                                                [Height, Hash, binary_to_hex(Hash),


### PR DESCRIPTION
Add a flag to indicate the final batch of blocks in a sync, client skips eager gossip for non-final batch.  Fixes #1273 Depends on helium/proto#125