### PR TITLE
filter bad netids from sync targets

### DIFF
--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -891,7 +891,9 @@ start_sync(#state{blockchain = Chain, swarm_tid = SwarmTID} = State) ->
 get_random_peer(SwarmTID) ->
     Peerbook = libp2p_swarm:peerbook(SwarmTID),
     %% limit peers to random connections with public addresses
+    NetID = libp2p_swarm:network_id(SwarmTID),
     F = fun(Peer) ->
+                NetID == libp2p_peer:network_id(Peer) andalso
                 case application:get_env(blockchain, testing, false) of
                     false ->
                         lists:any(fun libp2p_transport_tcp:is_public/1,


### PR DESCRIPTION
somehow, some bad peers are getting into the peerbook.  we need to fix that issue, but for now at least don't try to sync with them.