### PR TITLE
Handle `undefined` `poc_witness_consideration_limit`

### DIFF
--- a/src/poc/blockchain_poc_target_v3.erl
+++ b/src/poc/blockchain_poc_target_v3.erl
@@ -140,7 +140,13 @@ choose_zone(RandState, HexList) ->
             {ok, {Hex, HexRandState}}
     end.
 
-limit_addrs(#{?poc_witness_consideration_limit := Limit}, RandState, Witnesses) ->
-    blockchain_utils:deterministic_subset(Limit, RandState, Witnesses);
-limit_addrs(_Vars, RandState, Witnesses) ->
-    {RandState, Witnesses}.
+-spec limit_addrs(map(), RandState, [Witness]) -> {RandState, [Witness]}.
+limit_addrs(Vars, RandState, Witnesses) when is_map(Vars) ->
+    %% XXX Value could literally be 'undefined' or just missing,
+    %%     so defaulting to 'undefined' handles both cases:
+    case maps:get(?poc_witness_consideration_limit, Vars, undefined) of
+        undefined ->
+            {RandState, Witnesses};
+        Limit when is_integer(Limit) ->
+            blockchain_utils:deterministic_subset(Limit, RandState, Witnesses)
+    end.


### PR DESCRIPTION
Looks like it is set to `undefined` by `blockchain_utils:get_vars` during `blockchain_txn_poc_receipts_v1:check_is_valid_poc`, but `blockchain_poc_target_v3:limit_addrs` assumes that a present value in the map is an integer, which later causes a crash in `lists:sublist` within `blockchain_utils:deterministic_subset`, which tries to use `undefined` as a sublist length.