### PR TITLE
Fix 404 copypasta error; add explicit 416 error

### DIFF
--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -1321,8 +1321,10 @@ do_snap_source_download(Url, Filepath) ->
                                           Loop(Ref);
                                       {hackney_response, Ref, {status, 403, _}} ->
                                           throw({error, url_forbidden});
-                                      {hackney_response, Ref, {status, 403, _}} ->
+                                      {hackney_response, Ref, {status, 404, _}} ->
                                           throw({error, url_not_found});
+                                      {hackney_response, Ref, {status, 416, _}} ->
+                                          throw({error, range_out_of_bounds});
                                       {hackney_response, Ref, {status, Status, Response}} ->
                                           throw({error, {Status, Response}});
                                       {hackney_response, Ref, {headers, _Headers}} ->


### PR DESCRIPTION
Problem to solve: A few weeks ago while doing some testing, I noticed the 416 HTTP status (an invalid byte range request) was not explicitly handled. It should be.

Solution: Add a clause for a 416 status. Fix a copypasta error for 404 status results too.