### PR TITLE
pass seednode_connections to blockchain swarm

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -86,7 +86,7 @@
  {<<"lager">>,{pkg,<<"lager">>,<<"3.9.2">>},0},
  {<<"libp2p">>,
   {git,"https://github.com/helium/erlang-libp2p.git",
-       {ref,"059ab21518633b1a99dbf17d6d5ca510d8e50f6f"}},
+       {ref,"95fd37f967e6d83b9fd7796ef7d060abff47a018"}},
   0},
  {<<"libp2p_crypto">>,
   {git,"https://github.com/helium/libp2p-crypto.git",

--- a/src/blockchain_sup.erl
+++ b/src/blockchain_sup.erl
@@ -104,6 +104,7 @@ init(Args) ->
            %% connections will hog all the gossip
            {peerbook_connections, application:get_env(blockchain, outbound_gossip_connections, 2)},
            {inbound_connections, application:get_env(blockchain, max_inbound_connections, 6)},
+           {seednode_connections, application:get_env(blockchain, seednode_connections, undefined)},
            {peer_cache_timeout, application:get_env(blockchain, peer_cache_timeout, 10 * 1000)}
           ]}
         ] ++ GroupMgrArgs,


### PR DESCRIPTION
libp2p_group_gossip_server looks for seednode_connections in the blockchain swarm options, which was not previously passed