### PR TITLE
Disable reward tests that don't provide useful assessments

### DIFF
--- a/test/blockchain_reward_perf_SUITE.erl
+++ b/test/blockchain_reward_perf_SUITE.erl
@@ -134,7 +134,9 @@ end_per_testcase(_TestCase, Config) ->
     ok.
 
 all() ->
-    [reward_perf_test].
+    [
+    %reward_perf_test - run test manually
+    ].
 
 reward_perf_test(Config) ->
     Chain = ?config(chain, Config),

--- a/test/blockchain_reward_v2_SUITE.erl
+++ b/test/blockchain_reward_v2_SUITE.erl
@@ -65,7 +65,7 @@ end_per_suite(Config) ->
 
 all() ->
     [
-     calc_v1_and_v2_test%,
+     %calc_v1_and_v2_test, - test is out of date
      %calc_v2_and_compare_to_chain - do not run this for now, need a better snapshot
     ].
 


### PR DESCRIPTION
Disable `reward_perf_test` and `calc_v1_and_v2_test`. `reword_perf_test` needs to be run manually. `calc_v1_and_v2_test` is out of date.