### PR TITLE
reject v2 receipts txn if no reports

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -160,6 +160,10 @@
 %% NOTE the minimum value here should be greater than that of validator_liveness_interval
 -define(poc_validator_ephemeral_key_timeout, poc_validator_ephemeral_key_timeout).
 
+%% determines whether or not to reject a v2 receipts txn which has no receipt : boolean
+-define(poc_reject_empty_receipts, poc_reject_empty_receipts).
+
+
 %% Determines whether or not to filter out inactive gateways
 %% from POC targets :: boolean()
 -define(poc_activity_filter_enabled, poc_activity_filter_enabled).

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -281,6 +281,7 @@
 
 -ifdef(TEST).
 -export([median/1, checkpoint_base/1, checkpoint_dir/2, clean_checkpoints/1]).
+-export([promote_to_public_poc/2]).
 -endif.
 
 -type entries() :: #{libp2p_crypto:pubkey_bin() => blockchain_ledger_entry_v1:entry()}.

--- a/src/transactions/v1/blockchain_poc_receipt_v1.erl
+++ b/src/transactions/v1/blockchain_poc_receipt_v1.erl
@@ -161,7 +161,9 @@ sign(Receipt, SigFun) ->
     EncodedReceipt = blockchain_txn_poc_receipts_v1_pb:encode_msg(BaseReceipt),
     Receipt#blockchain_poc_receipt_v1_pb{signature=SigFun(EncodedReceipt)}.
 
--spec is_valid(Receipt :: poc_receipt(), blockchain_ledger_v1:ledger()) -> boolean().
+-spec is_valid(Receipt :: undefined | poc_receipt(), blockchain_ledger_v1:ledger()) -> boolean().
+is_valid(undefined, _Ledger) ->
+    false;
 is_valid(Receipt=#blockchain_poc_receipt_v1_pb{gateway=Gateway, signature=Signature, addr_hash=AH}, Ledger) ->
     ValidHash = case blockchain_ledger_v1:config(?poc_addr_hash_byte_count, Ledger) of
                     {ok, Bytes} when is_integer(Bytes), Bytes > 0 ->

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1018,6 +1018,12 @@ validate_var(?poc_activity_filter_enabled, Value) ->
         false -> ok;
         _ -> throw({error, {poc_activity_filter_enabled, Value}})
     end;
+validate_var(?poc_reject_empty_receipts, Value) ->
+    case Value of
+        true -> ok;
+        false -> ok;
+        _ -> throw({error, {poc_reject_empty_receipts, Value}})
+    end;
 validate_var(?poc_challenge_sync_interval, Value) ->
     validate_int(Value, "poc_challenge_sync_interval", 10, 1440, false);
 validate_var(?poc_path_limit, undefined) ->

--- a/src/transactions/v2/blockchain_txn_poc_receipts_v2.erl
+++ b/src/transactions/v2/blockchain_txn_poc_receipts_v2.erl
@@ -38,7 +38,7 @@
     good_quality_witnesses/2,
     valid_witnesses/3, valid_witnesses/4,
     tagged_witnesses/3,
-    get_channels/2, get_channels/4, get_channels_/5,
+    get_channels/2, get_channels/4, get_channels/5,
     get_path/9
 ]).
 
@@ -232,7 +232,7 @@ check_is_valid_poc(POCVersion, Txn, Chain) ->
                             %% no witness will exist with the first layer hash
                             [_|LayerHashes] = [crypto:hash(sha256, L) || L <- Layers],
                             StartV = maybe_log_duration(packet_construction, StartP),
-                            Channels = ?MODULE:get_channels_(POCVersion, OldLedger, Path, LayerData, no_prefetch),
+                            Channels = ?MODULE:get_channels(POCVersion, OldLedger, Path, LayerData, no_prefetch),
                             %% %% run validations
                             Ret = validate(POCVersion, Txn, Path, LayerData, LayerHashes, OldLedger),
                             maybe_log_duration(receipt_validation, StartV),
@@ -1071,16 +1071,16 @@ get_channels(Txn, POCVersion, RegionVars, Chain) ->
             Entropy1 = <<OnionKeyHash/binary, BlockHash/binary>>,
             [_ | LayerData] = blockchain_txn_poc_receipts_v2:create_secret_hash(Entropy1, PathLength+1),
             Path = [blockchain_poc_path_element_v1:challengee(Element) || Element <- Path0],
-            Channels = get_channels_(POCVersion, Ledger, Path, LayerData, RegionVars),
+            Channels = get_channels(POCVersion, Ledger, Path, LayerData, RegionVars),
             {ok, Channels}
     end.
 
--spec get_channels_(POCVersion :: pos_integer(),
+-spec get_channels(POCVersion :: pos_integer(),
                     Ledger :: blockchain_ledger_v1:ledger(),
                     Path :: [libp2p_crypto:pubkey_bin()],
                     LayerData :: [binary()],
                     RegionVars :: no_prefetch | [{atom(), binary() | {error, any()}}] | {ok, [{atom(), binary() | {error, any()}}]} | {error, any()}) -> [non_neg_integer()].
-get_channels_(_POCVersion, Ledger, Path, LayerData, RegionVars0) ->
+get_channels(_POCVersion, Ledger, Path, LayerData, RegionVars0) ->
     Challengee = hd(Path),
     RegionVars =
         case RegionVars0 of

--- a/src/transactions/v2/blockchain_txn_poc_receipts_v2.erl
+++ b/src/transactions/v2/blockchain_txn_poc_receipts_v2.erl
@@ -38,7 +38,8 @@
     good_quality_witnesses/2,
     valid_witnesses/3, valid_witnesses/4,
     tagged_witnesses/3,
-    get_channels/2, get_channels/4
+    get_channels/2, get_channels/4, get_channels_/5,
+    get_path/9
 ]).
 
 -ifdef(TEST).
@@ -218,7 +219,7 @@ check_is_valid_poc(POCVersion, Txn, Chain) ->
                             StartFT = maybe_log_duration(ledger_at, StartLA),
                             Vars = vars(OldLedger),
                             Entropy = <<POCOnionKeyHash/binary, PrePoCBlockHash/binary>>,
-                            {Path, StartP} = get_path(POCVersion, Challenger, BlockTime, Entropy, Keys, Vars, OldLedger, Ledger, StartFT),
+                            {Path, StartP} = ?MODULE:get_path(POCVersion, Challenger, BlockTime, Entropy, Keys, Vars, OldLedger, Ledger, StartFT),
                             N = erlang:length(Path),
                             [<<IV:16/integer-unsigned-little, _/binary>> | LayerData] = blockchain_txn_poc_receipts_v2:create_secret_hash(Entropy, N+1),
                             OnionList = lists:zip([libp2p_crypto:bin_to_pubkey(P) || P <- Path], LayerData),
@@ -231,7 +232,7 @@ check_is_valid_poc(POCVersion, Txn, Chain) ->
                             %% no witness will exist with the first layer hash
                             [_|LayerHashes] = [crypto:hash(sha256, L) || L <- Layers],
                             StartV = maybe_log_duration(packet_construction, StartP),
-                            Channels = get_channels_(POCVersion, OldLedger, Path, LayerData, no_prefetch),
+                            Channels = ?MODULE:get_channels_(POCVersion, OldLedger, Path, LayerData, no_prefetch),
                             %% %% run validations
                             Ret = validate(POCVersion, Txn, Path, LayerData, LayerHashes, OldLedger),
                             maybe_log_duration(receipt_validation, StartV),
@@ -602,18 +603,20 @@ validate(_POCVersion, Txn, Path, LayerData, LayerHashes, OldLedger) ->
                                            true ->
                                                IsFirst = Elem == hd(?MODULE:path(Txn)),
                                                Receipt = blockchain_poc_path_element_v1:receipt(Elem),
+                                               Witnesses = blockchain_poc_path_element_v1:witnesses(Elem),
                                                ExpectedOrigin = case IsFirst of
                                                                     true -> p2p;
                                                                     false -> radio
                                                                 end,
                                                %% check the receipt
                                                RejectTxnEmptyReceipt =
-                                                    case blockchain_ledger_v1:config(?poc_reject_empty_receipts, Ledger) of
+                                                    case blockchain_ledger_v1:config(?poc_reject_empty_receipts, OldLedger) of
                                                         {ok, V} -> V;
                                                         _ -> false
                                                     end,
                                                case
                                                    (Receipt == undefined andalso RejectTxnEmptyReceipt == false) orelse
+                                                   (Receipt == undefined andalso RejectTxnEmptyReceipt == true andalso Witnesses /= []) orelse
                                                    (blockchain_poc_receipt_v1:is_valid(Receipt, OldLedger) andalso
                                                     blockchain_poc_receipt_v1:gateway(Receipt) == Gateway andalso
                                                     blockchain_poc_receipt_v1:data(Receipt) == LayerDatum andalso
@@ -640,7 +643,7 @@ validate(_POCVersion, Txn, Path, LayerData, LayerHashes, OldLedger) ->
                                                            true ->
                                                                lager:warning([{poc_id, POCID}],
                                                                              "Receipt undefined, ExpectedOrigin: ~p, LayerDatum: ~p, Gateway: ~p",
-                                                                             [Receipt, ExpectedOrigin, LayerDatum, Gateway]);
+                                                                             [ExpectedOrigin, LayerDatum, Gateway]);
                                                            false ->
                                                                lager:warning([{poc_id, POCID}],
                                                                              "Origin: ~p, ExpectedOrigin: ~p, Data: ~p, LayerDatum: ~p, ReceiptGateway: ~p, Gateway: ~p",
@@ -740,7 +743,8 @@ check_witness_layerhash(Witnesses, Gateway, LayerHash, OldLedger) ->
          )
     of
         true -> ok;
-        false -> {error, invalid_witness}
+        false ->
+            {error, invalid_witness}
     end.
 
 -spec poc_id(txn_poc_receipts()) -> binary().

--- a/src/transactions/v2/blockchain_txn_poc_receipts_v2.erl
+++ b/src/transactions/v2/blockchain_txn_poc_receipts_v2.erl
@@ -607,8 +607,13 @@ validate(_POCVersion, Txn, Path, LayerData, LayerHashes, OldLedger) ->
                                                                     false -> radio
                                                                 end,
                                                %% check the receipt
+                                               RejectTxnEmptyReceipt =
+                                                    case blockchain_ledger_v1:config(?poc_reject_empty_receipts, Ledger) of
+                                                        {ok, V} -> V;
+                                                        _ -> false
+                                                    end,
                                                case
-                                                   Receipt == undefined orelse
+                                                   (Receipt == undefined andalso RejectTxnEmptyReceipt == false) orelse
                                                    (blockchain_poc_receipt_v1:is_valid(Receipt, OldLedger) andalso
                                                     blockchain_poc_receipt_v1:gateway(Receipt) == Gateway andalso
                                                     blockchain_poc_receipt_v1:data(Receipt) == LayerDatum andalso

--- a/test/blockchain_simple_SUITE.erl
+++ b/test/blockchain_simple_SUITE.erl
@@ -3665,7 +3665,7 @@ receipts_txn_reject_empty_receipt_test(Config) ->
     %% hardcode the poc packet, save having to create a real poc
     meck:new(blockchain_txn_poc_receipts_v2, [passthrough]),
     meck:expect(blockchain_txn_poc_receipts_v2, get_path, fun(_,_,_,_,_,_,_,_,_) -> {[Gateway], erlang:monotonic_time(microsecond)} end),
-    meck:expect(blockchain_txn_poc_receipts_v2, get_channels_, fun(_,_,_,_,_) -> {ok, [1]} end),
+    meck:expect(blockchain_txn_poc_receipts_v2, get_channels, fun(_,_,_,_,_) -> {ok, [1]} end),
     meck:expect(blockchain_txn_poc_receipts_v2, create_secret_hash, fun(_,_) -> [IVBytes, Data] end),
     meck:new(blockchain_poc_packet_v2, [passthrough]),
     meck:expect(blockchain_poc_packet_v2, build, fun(_,_,_) -> {<<"ignored_onion">>, [<<"ignored_layer">>,Layer]} end),

--- a/test/blockchain_simple_SUITE.erl
+++ b/test/blockchain_simple_SUITE.erl
@@ -3706,7 +3706,7 @@ receipts_txn_dont_reject_empty_receipt_test(Config) ->
     %% hardcode the poc packet, save having to create a real poc
     meck:new(blockchain_txn_poc_receipts_v2, [passthrough]),
     meck:expect(blockchain_txn_poc_receipts_v2, get_path, fun(_,_,_,_,_,_,_,_,_) -> {[Gateway], erlang:monotonic_time(microsecond)} end),
-    meck:expect(blockchain_txn_poc_receipts_v2, get_channels_, fun(_,_,_,_,_) -> {ok, [1]} end),
+    meck:expect(blockchain_txn_poc_receipts_v2, get_channels, fun(_,_,_,_,_) -> {ok, [1]} end),
     meck:expect(blockchain_txn_poc_receipts_v2, create_secret_hash, fun(_,_) -> [IVBytes, Data] end),
     meck:new(blockchain_poc_packet_v2, [passthrough]),
     meck:expect(blockchain_poc_packet_v2, build, fun(_,_,_) -> {<<"ignored_onion">>, [<<"ignored_layer">>,Layer]} end),

--- a/test/blockchain_simple_SUITE.erl
+++ b/test/blockchain_simple_SUITE.erl
@@ -53,7 +53,9 @@
     replay_oui_test/1,
     failed_txn_error_handling/1,
     genesis_no_var_validation_stay_invalid_test/1,
-    genesis_no_var_validation_make_valid_test/1
+    genesis_no_var_validation_make_valid_test/1,
+    receipts_txn_reject_empty_receipt_test/1,
+    receipts_txn_dont_reject_empty_receipt_test/1
 ]).
 
 -import(blockchain_utils, [normalize_float/1]).
@@ -109,7 +111,9 @@ all() ->
          replay_oui_test,
          failed_txn_error_handling,
          genesis_no_var_validation_stay_invalid_test,
-         genesis_no_var_validation_make_valid_test
+         genesis_no_var_validation_make_valid_test,
+         receipts_txn_reject_empty_receipt_test,
+         receipts_txn_dont_reject_empty_receipt_test
     ].
 
 %%--------------------------------------------------------------------
@@ -121,6 +125,8 @@ init_per_testcase(TestCase, Config) ->
     Balance =
         case TestCase of
             poc_v2_unset_challenger_type_chain_var_test -> ?bones(15000);
+            receipts_txn_reject_empty_receipt_test -> ?bones(15000);
+            receipts_txn_dont_reject_empty_receipt_test -> ?bones(15000);
             _ -> 5000
         end,
     {ok, Sup, {PrivKey, PubKey}, Opts} = test_utils:init(?config(base_dir, Config0)),
@@ -183,6 +189,40 @@ init_per_testcase(TestCase, Config) ->
                           ?reward_version => 5,
                           ?monthly_reward => 10000,
                           ?net_emissions_max_rate => 40000};
+                    receipts_txn_reject_empty_receipt_test ->
+                        #{
+                            ?poc_challenger_type => validator,
+                            ?poc_reject_empty_receipts => true,
+                            ?election_version => 5,
+                            ?validator_version => 3,
+                            ?validator_minimum_stake => ?bones(10000),
+                            ?validator_liveness_grace_period => 10,
+                            ?validator_liveness_interval => 5,
+                            ?validator_key_check => true,
+                            ?stake_withdrawal_cooldown => 10,
+                            ?stake_withdrawal_max => 500,
+                            ?dkg_penalty => 1.0,
+                            ?penalty_history_limit => 100,
+                            ?election_bba_penalty => 0.01,
+                            ?election_seen_penalty => 0.03
+                        };
+                    receipts_txn_dont_reject_empty_receipt_test ->
+                        #{
+                            ?poc_challenger_type => validator,
+                            ?poc_reject_empty_receipts => false,
+                            ?election_version => 5,
+                            ?validator_version => 3,
+                            ?validator_minimum_stake => ?bones(10000),
+                            ?validator_liveness_grace_period => 10,
+                            ?validator_liveness_interval => 5,
+                            ?validator_key_check => true,
+                            ?stake_withdrawal_cooldown => 10,
+                            ?stake_withdrawal_max => 500,
+                            ?dkg_penalty => 1.0,
+                            ?penalty_history_limit => 100,
+                            ?election_bba_penalty => 0.01,
+                            ?election_seen_penalty => 0.03
+                        };
                     _ ->
                         #{allow_zero_amount => false,
                           max_open_sc => 2,
@@ -3606,6 +3646,84 @@ genesis_no_var_validation_make_valid_test(Config) ->
 
     ok.
 
+receipts_txn_reject_empty_receipt_test(Config) ->
+    %% test behaviour enabled via poc_reject_empty_receipts chain var
+    %% when set to true receipts v2 txns will be rejected if they
+    %% have an empty actor list, ie no receipts or witnesses
+    Chain = ?config(chain, Config),
+
+    %% hardcode much of the poc data
+    IVBytes = crypto:strong_rand_bytes(16),
+    Data = <<"data">>,
+    Layer = <<119,199,206,154,93,134,187,56,109>>,
+
+    {Gateway, SignedPoCReceiptsTxn1, SignedPoCReceiptsTxn2, SignedPoCReceiptsTxn3} =
+        setup_receipts_txn_empty_receipt(Config, Data, Layer),
+
+    %% meck out all the things
+    %% remove any checks we dont care about
+    %% hardcode the poc packet, save having to create a real poc
+    meck:new(blockchain_txn_poc_receipts_v2, [passthrough]),
+    meck:expect(blockchain_txn_poc_receipts_v2, get_path, fun(_,_,_,_,_,_,_,_,_) -> {[Gateway], erlang:monotonic_time(microsecond)} end),
+    meck:expect(blockchain_txn_poc_receipts_v2, get_channels_, fun(_,_,_,_,_) -> {ok, [1]} end),
+    meck:expect(blockchain_txn_poc_receipts_v2, create_secret_hash, fun(_,_) -> [IVBytes, Data] end),
+    meck:new(blockchain_poc_packet_v2, [passthrough]),
+    meck:expect(blockchain_poc_packet_v2, build, fun(_,_,_) -> {<<"ignored_onion">>, [<<"ignored_layer">>,Layer]} end),
+
+    %%
+    %% validate the 3 receipts v2 txns
+    %% receipts v2 txn1 will be declared invalid as it has no receipt and no witnesses
+    ?assertEqual({error,invalid_receipt}, blockchain_txn_poc_receipts_v2:is_valid(SignedPoCReceiptsTxn1, Chain)),
+    %% receipts v2 txn2 will be declared valid as it has a receipt
+    ?assertEqual(ok, blockchain_txn_poc_receipts_v2:is_valid(SignedPoCReceiptsTxn2, Chain)),
+    %% receipts v2 txn3 will be declared valid as while it has no receipt, it does have witnesses
+    ?assertEqual(ok, blockchain_txn_poc_receipts_v2:is_valid(SignedPoCReceiptsTxn3, Chain)),
+
+    meck:unload(blockchain_txn_poc_receipts_v2),
+    meck:unload(blockchain_poc_packet_v2),
+
+    ok.
+
+receipts_txn_dont_reject_empty_receipt_test(Config) ->
+    %% test behaviour when poc_reject_empty_receipts chain var is disabled
+    %% when set to false or unset receipts v2 txns will be accepted if they
+    %% have an empty actor list, ie no receipts or witnesses
+    %% this is the same test as 'receipts_txn_reject_empty_receipt_test' but
+    %% with the chain var poc_reject_empty_receipts set to false
+    %% could have done it via a group but for sake of one test...
+    Chain = ?config(chain, Config),
+
+    %% hardcode much of the poc data
+    IVBytes = crypto:strong_rand_bytes(16),
+    Data = <<"data">>,
+    Layer = <<119,199,206,154,93,134,187,56,109>>,
+
+    {Gateway, SignedPoCReceiptsTxn1, SignedPoCReceiptsTxn2, SignedPoCReceiptsTxn3} =
+        setup_receipts_txn_empty_receipt(Config, Data, Layer),
+
+    %% meck out all the things
+    %% remove any checks we dont care about
+    %% hardcode the poc packet, save having to create a real poc
+    meck:new(blockchain_txn_poc_receipts_v2, [passthrough]),
+    meck:expect(blockchain_txn_poc_receipts_v2, get_path, fun(_,_,_,_,_,_,_,_,_) -> {[Gateway], erlang:monotonic_time(microsecond)} end),
+    meck:expect(blockchain_txn_poc_receipts_v2, get_channels_, fun(_,_,_,_,_) -> {ok, [1]} end),
+    meck:expect(blockchain_txn_poc_receipts_v2, create_secret_hash, fun(_,_) -> [IVBytes, Data] end),
+    meck:new(blockchain_poc_packet_v2, [passthrough]),
+    meck:expect(blockchain_poc_packet_v2, build, fun(_,_,_) -> {<<"ignored_onion">>, [<<"ignored_layer">>,Layer]} end),
+
+    %%
+    %% validate the 3 receipts v2 txns
+    %% receipts v2 txn1 will be declared valid even tho it has no receipt and no witnesses
+    ?assertEqual(ok, blockchain_txn_poc_receipts_v2:is_valid(SignedPoCReceiptsTxn1, Chain)),
+    %% receipts v2 txn2 will be declared valid as it has a receipt
+    ?assertEqual(ok, blockchain_txn_poc_receipts_v2:is_valid(SignedPoCReceiptsTxn2, Chain)),
+    %% receipts v2 txn3 will be declared valid whilst it has a witness only ( no receipt )
+    ?assertEqual(ok, blockchain_txn_poc_receipts_v2:is_valid(SignedPoCReceiptsTxn3, Chain)),
+
+    meck:unload(blockchain_txn_poc_receipts_v2),
+    meck:unload(blockchain_poc_packet_v2),
+
+    ok.
 %%--------------------------------------------------------------------
 %% Helper functions
 %%--------------------------------------------------------------------
@@ -3651,4 +3769,152 @@ fake_poc_request(Gateway, GatewaySigFun, BlockHash) ->
     blockchain_txn_poc_request_v1:sign(PoCReqTxn0, GatewaySigFun).
 
 fake_public_poc(OnionKeyHash, Challenger, BlockHash, BlockHeight, Ledger) ->
-    ok = blockchain_ledger_v1:save_poc_proposal(OnionKeyHash, Challenger, BlockHash, BlockHeight, Ledger).
+    ok = blockchain_ledger_v1:save_poc_proposal(OnionKeyHash, Challenger, BlockHash, BlockHeight, Ledger),
+    {ok, POC} = blockchain_ledger_v1:find_poc_proposal(OnionKeyHash, Ledger),
+    _ = blockchain_ledger_v1:promote_to_public_poc(POC, Ledger).
+
+setup_receipts_txn_empty_receipt(Config, Data, Layer) ->
+    %% perform setup, adds validator, 2 gateways & fakes a POC
+    %% returns 3 receipts v2 txns
+    %% 1 whereby the path has no receipt nor witness reports
+    %% 1 whereby the path has a receipt but no witness reports
+    %% 1 whereby the path has no receipt but does have a witness report
+    ConsensusMembers = ?config(consensus_members, Config),
+    Chain = ?config(chain, Config),
+    Ledger = blockchain:ledger(Chain),
+
+    Keys = libp2p_crypto:generate_keys(ecc_compact),
+    Secret = libp2p_crypto:keys_to_bin(Keys),
+    #{public := OnionCompactKey} = Keys,
+    OnionKeyHash = crypto:hash(sha256, libp2p_crypto:pubkey_to_bin(OnionCompactKey)),
+
+    %% Get an owner of our actors
+    [{OwnerPubkeyBin, {_OwnerPub, _OwnerPriv, OwnerSigFun}} | _] = ?config(genesis_members, Config),
+
+    %%
+    %% Create and add two Gateway
+    %%
+    #{public := GatewayPubKey, secret := GatewayPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
+    Gateway = libp2p_crypto:pubkey_to_bin(GatewayPubKey),
+    GatewaySigFun = libp2p_crypto:mk_sig_fun(GatewayPrivKey),
+
+    #{public := Gateway2PubKey, secret := Gateway2PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
+    Gateway2 = libp2p_crypto:pubkey_to_bin(Gateway2PubKey),
+    Gateway2SigFun = libp2p_crypto:mk_sig_fun(Gateway2PrivKey),
+
+    % Add & assert Gateway1
+    AddGatewayTx = blockchain_txn_add_gateway_v1:new(OwnerPubkeyBin, Gateway),
+    SignedOwnerAddGatewayTx = blockchain_txn_add_gateway_v1:sign(AddGatewayTx, OwnerSigFun),
+    SignedGatewayAddGatewayTx = blockchain_txn_add_gateway_v1:sign_request(SignedOwnerAddGatewayTx, GatewaySigFun),
+
+    AssertLocationRequestTx = blockchain_txn_assert_location_v1:new(Gateway, OwnerPubkeyBin, ?TEST_LOCATION, 1),
+    PartialAssertLocationTxn = blockchain_txn_assert_location_v1:sign_request(AssertLocationRequestTx, GatewaySigFun),
+    SignedAssertLocationTx = blockchain_txn_assert_location_v1:sign(PartialAssertLocationTxn, OwnerSigFun),
+
+    % Add & assert Gateway2
+    AddGateway2Tx = blockchain_txn_add_gateway_v1:new(OwnerPubkeyBin, Gateway2),
+    SignedOwnerAddGateway2Tx = blockchain_txn_add_gateway_v1:sign(AddGateway2Tx, OwnerSigFun),
+    SignedGatewayAddGateway2Tx = blockchain_txn_add_gateway_v1:sign_request(SignedOwnerAddGateway2Tx, Gateway2SigFun),
+
+    AssertLocationRequestTx2 = blockchain_txn_assert_location_v1:new(Gateway2, OwnerPubkeyBin, ?TEST_LOCATION, 1),
+    PartialAssertLocationTxn2 = blockchain_txn_assert_location_v1:sign_request(AssertLocationRequestTx2, Gateway2SigFun),
+    SignedAssertLocationTx2 = blockchain_txn_assert_location_v1:sign(PartialAssertLocationTxn2, OwnerSigFun),
+
+    {ok, Block1} = test_utils:create_block(ConsensusMembers, [SignedGatewayAddGatewayTx, SignedAssertLocationTx, SignedGatewayAddGateway2Tx, SignedAssertLocationTx2]),
+    _ = blockchain_gossip_handler:add_block(Block1, Chain, self(), blockchain_swarm:tid()),
+    {ok, _GWInfo} = blockchain_ledger_v1:find_gateway_info(Gateway, Ledger),
+
+    %%
+    %% stake a validator
+    %%
+
+    %% make a validator
+    [{ValPubkeyBin, {_ValPub, _ValPriv, ValSigFun}}] = test_utils:generate_keys(1),
+    ct:pal("StakePubkeyBin: ~p~nOwnerPubkeyBin: ~p", [ValPubkeyBin, OwnerPubkeyBin]),
+
+    ValTxn = blockchain_txn_stake_validator_v1:new(
+        ValPubkeyBin,
+        OwnerPubkeyBin,
+        ?bones(10000),
+        ?bones(5)
+    ),
+    SignedValTxn = blockchain_txn_stake_validator_v1:sign(ValTxn, OwnerSigFun),
+    ct:pal("SignedStakeTxn: ~p", [SignedValTxn]),
+
+    {ok, Block2} = test_utils:create_block(ConsensusMembers, [SignedValTxn]),
+    _ = blockchain_gossip_handler:add_block(Block2, Chain, self(), blockchain_swarm:tid()),
+
+    %% fake a validator poc by manually populating the ledger
+    {ok, Height2} = blockchain:height(Chain),
+    {ok, BlockHash} = blockchain:get_block_hash(Height2, Chain),
+    Ledger1 = blockchain_ledger_v1:new_context(Ledger),
+    fake_public_poc(OnionKeyHash, ValPubkeyBin, BlockHash, Height2, Ledger1),
+    blockchain_ledger_v1:commit_context(Ledger1),
+
+    %% confirm the poc data exists
+    [_ValidatorPOC1 | _] = blockchain_ledger_v1:pocs(active, Ledger),
+
+    %%
+    %% Create version of the receipts txn with and without a receipt in the path
+    %%
+    R1 = blockchain_poc_receipt_v1:new(
+        Gateway,
+        1000,
+        10,
+        Data,
+        p2p
+    ),
+    SignedR1 = blockchain_poc_receipt_v1:sign(R1, GatewaySigFun),
+
+    Witness = blockchain_poc_witness_v1:new(
+        Gateway2,
+        1001,
+        10,
+        crypto:hash(sha256, Layer),
+        9.8,
+        915.2,
+        10,
+        <<"data_rate">>
+    ),
+    SignedWitness = blockchain_poc_witness_v1:sign(Witness, Gateway2SigFun),
+
+    %% generate path with no receipt and no witnesses
+    P1 = blockchain_poc_path_element_v1:new(Gateway, undefined, []),
+    ct:pal("P1: ~p", [P1]),
+
+    %% generate path with a receipt but no witnesses
+    P2 = blockchain_poc_path_element_v1:new(Gateway, SignedR1, []),
+    ct:pal("P2: ~p", [P2]),
+
+    %% generate path with no receipt but with a witness
+    P3 = blockchain_poc_path_element_v1:new(Gateway, undefined, [SignedWitness]),
+    ct:pal("P3: ~p", [P3]),
+
+    %% include the path in receipts v2 txns
+    PoCReceiptsTxn1 = blockchain_txn_poc_receipts_v2:new(
+        ValPubkeyBin,
+        Secret,
+        OnionKeyHash,
+        [P1],
+        BlockHash
+    ),
+
+    PoCReceiptsTxn2 = blockchain_txn_poc_receipts_v2:new(
+        ValPubkeyBin,
+        Secret,
+        OnionKeyHash,
+        [P2],
+        BlockHash
+    ),
+    PoCReceiptsTxn3 = blockchain_txn_poc_receipts_v2:new(
+        ValPubkeyBin,
+        Secret,
+        OnionKeyHash,
+        [P3],
+        BlockHash
+    ),
+    SignedPoCReceiptsTxn1 = blockchain_txn_poc_receipts_v2:sign(PoCReceiptsTxn1, ValSigFun),
+    SignedPoCReceiptsTxn2 = blockchain_txn_poc_receipts_v2:sign(PoCReceiptsTxn2, ValSigFun),
+    SignedPoCReceiptsTxn3 = blockchain_txn_poc_receipts_v2:sign(PoCReceiptsTxn3, ValSigFun),
+
+    {Gateway, SignedPoCReceiptsTxn1, SignedPoCReceiptsTxn2, SignedPoCReceiptsTxn3}.


### PR DESCRIPTION
This adds new receipt v2 validations to reject txns where there are no reports, ie no receipt from the challengee nor any witness reports.  Currently such txns are accepted and result in the challenger benefiting from rewards for failed POCs.

Much of the null report POCs stem from a validator which is relayed or does not have its GRPC port open and thus no gateways can connect to it.  By rejecting empty receipts it incentivises  validator owners to ensure their setups are correct as they will loose earnings.

The new validations are gated behind a new chain var 'poc_reject_empty_receipts'.

The PR also addresses some test rot encountered whilst adding test scenarios for the new behaviour.