### PR TITLE
only promote proposal if outside of gc window

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -165,6 +165,9 @@
 
 %% determines whether or not to use the fix for a buggy POC GC : boolean
 -define(poc_apply_gc_fix, poc_apply_gc_fix).
+%% determines whether or not to check if poc proposals are within a GC window
+%% before deciding whether to promote
+-define(poc_proposal_gc_window_check, poc_proposal_gc_window_check).
 
 %% Determines whether or not to filter out inactive gateways
 %% from POC targets :: boolean()

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -2132,10 +2132,11 @@ process_poc_proposals(BlockHeight, BlockHash, Ledger) ->
             %% Mark the selected POCs as active on ledger
             case blockchain:config(?poc_challenge_rate, Ledger) of
                 {ok, K} ->
+                    {ok, POCValKeyProposalTimeout} = blockchain:config(?poc_validator_ephemeral_key_timeout, Ledger),
                     RandState = blockchain_utils:rand_state(BlockHash),
                     {Name, DB, CF} = proposed_pocs_cf(Ledger),
                     {ok, Itr} = rocksdb:iterator(DB, CF, []),
-                    POCSubset = promote_proposals(K, BlockHash, BlockHeight, RandState, Ledger, Name, Itr, []),
+                    POCSubset = promote_proposals(K, BlockHash, BlockHeight, POCValKeyProposalTimeout, RandState, Ledger, Name, Itr, []),
                     catch rocksdb:iterator_close(Itr),
                     lager:debug("Selected POCs ~p", [POCSubset]),
                     lager:info("Selected ~p POCs for block height ~p", [length(POCSubset), BlockHeight]),
@@ -2153,10 +2154,11 @@ process_poc_proposals(BlockHeight, BlockHash, Ledger) ->
             ok
     end.
 
--spec promote_proposals(non_neg_integer(), binary(), pos_integer(), rand:state(), ledger(), atom(), rocksdb:iterator(), blockchain_ledger_poc_v3:pocs()) -> blockchain_ledger_poc_v3:pocs().
-promote_proposals(0, _Hash, _Height, _RandState, _Ledger, _Name, _Iter, Acc) ->
+-spec promote_proposals(non_neg_integer(), binary(), pos_integer(), pos_integer(), rand:state(),
+    ledger(), atom(), rocksdb:iterator(), blockchain_ledger_poc_v3:pocs()) -> blockchain_ledger_poc_v3:pocs().
+promote_proposals(0, _Hash, _Height, _POCValKeyProposalTimeout, _RandState, _Ledger, _Name, _Iter, Acc) ->
     Acc;
-promote_proposals(K, BlockHash, BlockHeight, RandState, Ledger, Name, Iter, Acc) ->
+promote_proposals(K, BlockHash, BlockHeight, POCValKeyProposalTimeout, RandState, Ledger, Name, Iter, Acc) ->
     try
         {RandVal, NewRandState} = rand:uniform_s(RandState),
         RandHash = crypto:hash(sha256, <<RandVal:64/float>>),
@@ -2170,12 +2172,19 @@ promote_proposals(K, BlockHash, BlockHeight, RandState, Ledger, Name, Iter, Acc)
                         Acc;
                     false ->
                         POC = blockchain_ledger_poc_v3:deserialize(Binary),
-                        ActivePOC0 = blockchain_ledger_poc_v3:status(active, POC),
-                        ActivePOC1 = blockchain_ledger_poc_v3:block_hash(BlockHash, ActivePOC0),
-                        ActivePOC2 = blockchain_ledger_poc_v3:start_height(BlockHeight, ActivePOC1),
-                        case promote_to_public_poc(ActivePOC2, Ledger) of
-                            ok -> [ActivePOC2 | Acc];
-                            _ -> Acc
+                        ProposalHeight = blockchain_ledger_poc_v3:start_height(POC),
+                        %% if the proposal is not within GC window, then promote it
+                        case (BlockHeight - ProposalHeight) < POCValKeyProposalTimeout of
+                            true ->
+                                ActivePOC0 = blockchain_ledger_poc_v3:status(active, POC),
+                                ActivePOC1 = blockchain_ledger_poc_v3:block_hash(BlockHash, ActivePOC0),
+                                ActivePOC2 = blockchain_ledger_poc_v3:start_height(BlockHeight, ActivePOC1),
+                                case promote_to_public_poc(ActivePOC2, Ledger) of
+                                    ok -> [ActivePOC2 | Acc];
+                                    _ -> Acc
+                                end;
+                            _ ->
+                                Acc
                         end
                 end;
             {error, _Reason} ->
@@ -2184,7 +2193,7 @@ promote_proposals(K, BlockHash, BlockHeight, RandState, Ledger, Name, Iter, Acc)
                 %% proposals to make the cut (or we can somehow retry some fixed number of times)
                 Acc
         end,
-        promote_proposals(K - 1, BlockHash, BlockHeight, NewRandState, Ledger, Name, Iter, NewAcc)
+        promote_proposals(K - 1, BlockHash, BlockHeight, POCValKeyProposalTimeout, NewRandState, Ledger, Name, Iter, NewAcc)
     catch _What:_Why ->
         lager:warning("promote_proposals failed, ~p ~p", [_What, _Why]),
         Acc

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -2132,11 +2132,17 @@ process_poc_proposals(BlockHeight, BlockHash, Ledger) ->
             %% Mark the selected POCs as active on ledger
             case blockchain:config(?poc_challenge_rate, Ledger) of
                 {ok, K} ->
+                    ProposalGCWindowCheck =
+                        case blockchain:config(?poc_proposal_gc_window_check, Ledger) of
+                            {ok, V} -> V;
+                            _ -> false
+                    end,
                     {ok, POCValKeyProposalTimeout} = blockchain:config(?poc_validator_ephemeral_key_timeout, Ledger),
                     RandState = blockchain_utils:rand_state(BlockHash),
                     {Name, DB, CF} = proposed_pocs_cf(Ledger),
                     {ok, Itr} = rocksdb:iterator(DB, CF, []),
-                    POCSubset = promote_proposals(K, BlockHash, BlockHeight, POCValKeyProposalTimeout, RandState, Ledger, Name, Itr, []),
+                    POCSubset = promote_proposals(K, BlockHash, BlockHeight, POCValKeyProposalTimeout,
+                        ProposalGCWindowCheck, RandState, Ledger, Name, Itr, []),
                     catch rocksdb:iterator_close(Itr),
                     lager:debug("Selected POCs ~p", [POCSubset]),
                     lager:info("Selected ~p POCs for block height ~p", [length(POCSubset), BlockHeight]),
@@ -2154,11 +2160,13 @@ process_poc_proposals(BlockHeight, BlockHash, Ledger) ->
             ok
     end.
 
--spec promote_proposals(non_neg_integer(), binary(), pos_integer(), pos_integer(), rand:state(),
+-spec promote_proposals(non_neg_integer(), binary(), pos_integer(), pos_integer(), boolean(), rand:state(),
     ledger(), atom(), rocksdb:iterator(), blockchain_ledger_poc_v3:pocs()) -> blockchain_ledger_poc_v3:pocs().
-promote_proposals(0, _Hash, _Height, _POCValKeyProposalTimeout, _RandState, _Ledger, _Name, _Iter, Acc) ->
+promote_proposals(0, _Hash, _Height, _POCValKeyProposalTimeout, _ProposalGCWindowCheck,
+    _RandState, _Ledger, _Name, _Iter, Acc) ->
     Acc;
-promote_proposals(K, BlockHash, BlockHeight, POCValKeyProposalTimeout, RandState, Ledger, Name, Iter, Acc) ->
+promote_proposals(K, BlockHash, BlockHeight, POCValKeyProposalTimeout,
+    ProposalGCWindowCheck, RandState, Ledger, Name, Iter, Acc) ->
     try
         {RandVal, NewRandState} = rand:uniform_s(RandState),
         RandHash = crypto:hash(sha256, <<RandVal:64/float>>),
@@ -2174,7 +2182,9 @@ promote_proposals(K, BlockHash, BlockHeight, POCValKeyProposalTimeout, RandState
                         POC = blockchain_ledger_poc_v3:deserialize(Binary),
                         ProposalHeight = blockchain_ledger_poc_v3:start_height(POC),
                         %% if the proposal is not within GC window, then promote it
-                        case (BlockHeight - ProposalHeight) < POCValKeyProposalTimeout of
+                        case ((BlockHeight - ProposalHeight) < POCValKeyProposalTimeout andalso
+                             ProposalGCWindowCheck)
+                            orelse ProposalGCWindowCheck =:= false of
                             true ->
                                 ActivePOC0 = blockchain_ledger_poc_v3:status(active, POC),
                                 ActivePOC1 = blockchain_ledger_poc_v3:block_hash(BlockHash, ActivePOC0),
@@ -2193,7 +2203,8 @@ promote_proposals(K, BlockHash, BlockHeight, POCValKeyProposalTimeout, RandState
                 %% proposals to make the cut (or we can somehow retry some fixed number of times)
                 Acc
         end,
-        promote_proposals(K - 1, BlockHash, BlockHeight, POCValKeyProposalTimeout, NewRandState, Ledger, Name, Iter, NewAcc)
+        promote_proposals(K - 1, BlockHash, BlockHeight, POCValKeyProposalTimeout,
+            ProposalGCWindowCheck, NewRandState, Ledger, Name, Iter, NewAcc)
     catch _What:_Why ->
         lager:warning("promote_proposals failed, ~p ~p", [_What, _Why]),
         Acc

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1030,6 +1030,13 @@ validate_var(?poc_apply_gc_fix, Value) ->
         false -> ok;
         _ -> throw({error, {poc_apply_gc_fix, Value}})
     end;
+validate_var(?poc_proposal_gc_window_check, Value) ->
+    case Value of
+        true -> ok;
+        false -> ok;
+        _ -> throw({error, {poc_proposal_gc_window_check, Value}})
+    end;
+
 validate_var(?poc_challenge_sync_interval, Value) ->
     validate_int(Value, "poc_challenge_sync_interval", 10, 1440, false);
 validate_var(?poc_path_limit, undefined) ->


### PR DESCRIPTION
This adds a check to the promotion of proposals to consider if the proposal is within the GC window.  If it is then dont select it.  This is necessary as not doing so could lead to potential sync problems if the chain var `poc_validator_ephemeral_key_timeout` is modified.