### PR TITLE
fix proposal and public GC.  Only include poc if correctly promoted

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -163,6 +163,8 @@
 %% determines whether or not to reject a v2 receipts txn which has no receipt : boolean
 -define(poc_reject_empty_receipts, poc_reject_empty_receipts).
 
+%% determines whether or not to use the fix for a buggy POC GC : boolean
+-define(poc_apply_gc_fix, poc_apply_gc_fix).
 
 %% Determines whether or not to filter out inactive gateways
 %% from POC targets :: boolean()

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -2173,8 +2173,10 @@ promote_proposals(K, BlockHash, BlockHeight, RandState, Ledger, Name, Iter, Acc)
                         ActivePOC0 = blockchain_ledger_poc_v3:status(active, POC),
                         ActivePOC1 = blockchain_ledger_poc_v3:block_hash(BlockHash, ActivePOC0),
                         ActivePOC2 = blockchain_ledger_poc_v3:start_height(BlockHeight, ActivePOC1),
-                        promote_to_public_poc(ActivePOC2, Ledger),
-                        [ActivePOC2 | Acc]
+                        case promote_to_public_poc(ActivePOC2, Ledger) of
+                            ok -> [ActivePOC2 | Acc];
+                            _ -> Acc
+                        end
                 end;
             {error, _Reason} ->
                 lager:warning("promote_proposals failed, iterator failed ~p", [_Reason]),
@@ -2355,7 +2357,7 @@ maybe_gc_pocs(_Chain, Ledger, validator) ->
             %% or the reverse
             %% anything other than V3s we will want to GC no matter what
             %% V3s we will GC if lifespan is up
-            GCFun = fun(CF) -> cache_fold(
+            GCFun = fun(CF, CFGCFun) -> cache_fold(
                                  Ledger,
                                  CF,
                                  fun
@@ -2378,7 +2380,7 @@ maybe_gc_pocs(_Chain, Ledger, validator) ->
                           ((POCStatus /= active) andalso (CurHeight - POCStartHeight) > POCValKeyProposalTimeout) of
                           true ->
                               %% the lifespan of the POC for this key has passed, we can GC
-                              ok = delete_public_poc(OnionKeyHash, Ledger);
+                              ok = CFGCFun(OnionKeyHash, Ledger);
                           _ ->
                               ok
                       end,
@@ -2392,8 +2394,9 @@ maybe_gc_pocs(_Chain, Ledger, validator) ->
                                  []
                                 )
                     end,
-            GCFun(PoCsCF),
-            GCFun(ProposedPoCsCF),
+
+            GCFun(PoCsCF, fun delete_public_poc/2),
+            GCFun(ProposedPoCsCF, fun delete_poc_proposal/2),
             ok;
         _ ->
           ok

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1024,6 +1024,12 @@ validate_var(?poc_reject_empty_receipts, Value) ->
         false -> ok;
         _ -> throw({error, {poc_reject_empty_receipts, Value}})
     end;
+validate_var(?poc_apply_gc_fix, Value) ->
+    case Value of
+        true -> ok;
+        false -> ok;
+        _ -> throw({error, {poc_apply_gc_fix, Value}})
+    end;
 validate_var(?poc_challenge_sync_interval, Value) ->
     validate_int(Value, "poc_challenge_sync_interval", 10, 1440, false);
 validate_var(?poc_path_limit, undefined) ->


### PR DESCRIPTION
Addresses two issues

1.  during GC of POCs, a fun is created and then used to purge the two POC related CFs ( proposals and public ).  However when deleting a POC it would only delete it from the public poc CF, even if the intended POC to GC was a proposal.

2.  when promoting a poc proposal, only do so if the promotion was a success.  Previously if the promotion returned an error we would still include the POC in the event published for downstream components such as sibyl and miner.  This could result in a POC being initiated which does not actually exist on the ledger


it is hoped that these fixes will address the error seen when a validator is in consensus and it attempts to submit a v2 receipt:

2022-05-09 17:06:27.183 [warning] <0.7699.31>@blockchain_txn_poc_receipts_v2:check_is_valid_poc:{195,13} poc_id=7Lt1mh7M8vugeGWQAd-zq1t7CogtNORGVID8eqPGTeE poc_receipts error find_public_poc, poc_onion_key_hash: <<236,187,117,154,30,204,242,251,160,120,101,144,1,223,179,171,91,123,10,136,45,52,228,70,84,128,252,122,163,198,77,225>>, reason: not_found
2022-05-09 17:06:27.183 [warning] <0.4286.0>@miner_hbbft_sidecar:handle_info:{247,25} is_valid failed for type=poc_receipts_v2 hash="12SCj9T6GcjxUPDwSPjroRrP3rizpyTMo8utW86ATVTuNqriMF8" challenger="delightful-mahogany-kitten" onion="12oG1ThKEPP6Du3aoLubtXqAwKSqennSp3hXAwZWSQife53eF4M" path:
	type=element challengee: cheery-mandarin-terrier, receipt: type=receipt gateway: cheery-mandarin-terrier timestamp: 1652113826963722514 signal: 0 snr: 0.0 freq: 0.0 origin: p2p, tx_power: 19
		witnesses: , error: {error,not_found}
2022-05-09 17:06:27.184 [error] <0.5049.31>@miner_poc_mgr:-purge_local_pocs/2-fun-0-:660 CRASH REPORT Process miner_poc_mgr with 0 neighbours crashed with reason: no match of right hand value {{error,not_found},17319} in miner_poc_mgr:'-purge_local_pocs/2-fun-0-'/7 line 660		


I am not 100% the fixes here will address this completely, I have not been able to reproduce. Will monitor again once deployed