### PR TITLE
Identify connected nodes instead of forcing connections.

### DIFF
--- a/test/blockchain_ct_utils.erl
+++ b/test/blockchain_ct_utils.erl
@@ -28,7 +28,8 @@
          join_packet/3,
          ledger/2,
          destroy_ledger/0,
-         download_serialized_region/1
+         download_serialized_region/1,
+         find_connected_node_pair/1
         ]).
 
 -ifdef(EQC).
@@ -582,3 +583,53 @@ download_serialized_region(URL) ->
     {ok, Data} = file:read_file(FPath),
     Data.
 
+
+% [{Node, PubKey}]
+find_connected_node_pair(NodeAddrList) ->
+    AddrMap =
+        lists:foldl(
+            fun({Node, Addr}, Acc) ->
+                AddrStr = libp2p_crypto:pubkey_bin_to_p2p(Addr),
+                Acc#{AddrStr => Node}
+            end, #{}, NodeAddrList),
+    ct:pal("Node map: ~p", [AddrMap]),
+    find_connected_node_pair(maps:next(maps:iterator(AddrMap)), AddrMap, #{}).
+
+find_connected_node_pair(none, _, NetworkMap) ->
+    ct:pal("Final Network Map~n~p", [NetworkMap]),
+    disjoint_network;
+
+% NetworkMap - #{ConnectedToNode => [ConnectedFromNode]}
+find_connected_node_pair({_, Node, Iter}, AddrToNodeMap, NetworkMap) ->
+    GossipPeerNodes =
+        addr_to_node(
+            lists:usort(
+                ct_rpc:call(Node, blockchain_swarm, gossip_peers, [], 500)),
+            AddrToNodeMap),
+    ct:pal("Node ~p connected to:~n~p", [Node, GossipPeerNodes]),
+
+    % Is Node connected to a node in NetworkMap?
+    case maps:get(Node, NetworkMap, []) of
+        [] ->
+            % Nope, try checking the next node
+            find_connected_node_pair(
+                maps:next(Iter),
+                AddrToNodeMap,
+                add_to_network_map(Node, GossipPeerNodes, NetworkMap));
+        [ConnectedNode | _] ->
+            ct:pal("Found connected pair ~p <-> ~p", [Node, ConnectedNode]),
+            [Node, ConnectedNode]
+    end.
+
+addr_to_node(Addrs, AddrToNodeMap) ->
+    [maps:get(Addr, AddrToNodeMap, undefined) || Addr <- Addrs].
+
+% Remember which nodes a peer node is connected to
+add_to_network_map(Node, GossipPeerNodes, NetworkMap) ->
+    lists:foldl(
+        fun(PeerNode, Acc) ->
+            maps:update_with(PeerNode,
+                fun(NodeList) ->
+                    [Node | NodeList]
+                end, [Node], Acc)
+        end, NetworkMap, GossipPeerNodes).


### PR DESCRIPTION
Many tests randomly fail to run when `blockchain_state_channel_SUITE:init_per_testcase/2` fails. `init_per_testcase` tries to make sure the first two nodes set up by `blockchain_ct_utils:init_per_testcase/2`, the `?config(nodes, Config)` value, are connected to each other as many tests expect this. If the two nodes are not connected to each other, `blockchain_state_channel_SUITE:init_per_testcase` tries to force a connection. The set up code uses `ct_rpc:call(Node, blockchain_swarm, gossip_peers, [], 500)` to see if a node is connected to another node and `ct_rpc:call(Node, libp2p_swarm, connect, [Swarm, libp2p_crypto:pubkey_bin_to_p2p(AddrToConnectToo)], 500)` to force a connection. Even if `libp2p_swarm:connect` succeeds, it's not clear that the `gossip_peers` returns the new connection. As a result, the setup always fails if the first to nodes are not connected.

Rather than change how setup forces a connection, this PR inspects the list of nodes and finds two nodes that are connected to each other for the tests to use.

For better clarity, the router and gateway nodes are added explicitly to `Config`. Also, a new config is added for a connected pair of nodes.

With these changes, all tests in `blockchain_state_channel_SUITE` are consistently running, however, not all tests are passing consistently. Getting all the tests to pass can be addressed in other PRs.