### PR TITLE
Fix dialyzer, no error on cache_put

### DIFF
--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -2189,10 +2189,8 @@ promote_proposals(K, BlockHash, BlockHeight, POCValKeyProposalTimeout,
                                 ActivePOC0 = blockchain_ledger_poc_v3:status(active, POC),
                                 ActivePOC1 = blockchain_ledger_poc_v3:block_hash(BlockHash, ActivePOC0),
                                 ActivePOC2 = blockchain_ledger_poc_v3:start_height(BlockHeight, ActivePOC1),
-                                case promote_to_public_poc(ActivePOC2, Ledger) of
-                                    ok -> [ActivePOC2 | Acc];
-                                    _ -> Acc
-                                end;
+                                ok = promote_to_public_poc(ActivePOC2, Ledger),
+                                [ActivePOC2 | Acc];
                             _ ->
                                 Acc
                         end
@@ -2291,7 +2289,7 @@ promote_to_public_poc(POC, Ledger) ->
     update_public_poc(POC, Ledger).
 
 -spec update_public_poc(POC :: blockchain_ledger_poc_v3:poc(),
-                     Ledger :: ledger()) -> ok | {error, _}.
+                     Ledger :: ledger()) -> ok.
 update_public_poc(POC, Ledger) ->
     POCAddr = blockchain_ledger_poc_v3:onion_key_hash(POC),
     Bin = blockchain_ledger_poc_v3:serialize(POC),


### PR DESCRIPTION
Problem
----
Dialyzer complains on master branch with:

```
src/ledger/v1/blockchain_ledger_v1.erl
Line 2194 Column 37: The variable _ can never match since previous clauses completely covered the type 'ok'
```

Solution
----

`blockchain_ledger_v1:cache_put` can never actually return any error, this propagates that up the stack and fixes the call to `promote_to_public_poc/2`.