### PR TITLE
ensure construct compressed snap filename

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -66,8 +66,7 @@
     add_snapshot/2, add_bin_snapshot/4,
     have_snapshot/2, get_snapshot/2, find_last_snapshot/1,
     find_last_snapshots/2,
-    save_bin_snapshots/2,
-    save_bin_snapshot/2,  hash_bin_snapshot/1, size_bin_snapshot/1,
+    hash_bin_snapshot/1, size_bin_snapshot/1,
     save_compressed_bin_snapshot/2, maybe_get_compressed_snapdata/1,
 
     add_implicit_burn/3,
@@ -1972,11 +1971,11 @@ add_bin_snapshot(BinSnap, Height, Hash, #blockchain{db=DB, dir=Dir, snapshots=Sn
         SnapDir = filename:join(Dir, "saved-snaps"),
         SnapFile = io_lib:format("snap-~s", [blockchain_utils:bin_to_hex(Hash)]),
         OhSnap = filename:join(SnapDir, SnapFile),
-        ok = save_bin_snapshots(OhSnap, BinSnap),
+        {ok, CompressedSnapFile} = save_compressed_bin_snapshot(OhSnap, BinSnap),
         {ok, Batch} = rocksdb:batch(),
         %% store the snap as a filename, which might be wrong if compressed
         ok = rocksdb:batch_put(Batch, SnapshotsCF, Hash,
-                               <<"file:", (iolist_to_binary(SnapFile))/binary>>),
+                               <<"file:", (iolist_to_binary(CompressedSnapFile))/binary>>),
         %% lexiographic ordering works better with big endian
         ok = rocksdb:batch_put(Batch, SnapshotsCF, <<Height:64/integer-unsigned-big>>, Hash),
         ok = rocksdb:write_batch(DB, Batch, [])
@@ -1985,61 +1984,18 @@ add_bin_snapshot(BinSnap, Height, Hash, #blockchain{db=DB, dir=Dir, snapshots=Sn
             {error, Why}
     end.
 
--spec save_bin_snapshots(file:filename_all(), blockchain_ledger_snapshot:snapshot()) ->
-    ok | {error, term()}.
+-spec save_compressed_bin_snapshot(file:filename_all(), blockchain_ledger_snapshot:snapshot()) ->
+   {ok, Filename} | {error, Error :: term()} when Filename :: file:filename_all().
 %% @doc This function saves a binary snapshot, compressing the image based on
-%% the setting of the erlang environment variable `snapshot_compression_mode'
-%% valid values of which may be `compressed' (default), `uncompressed' or `both'.
+%% the zlib compression library.
 %%
-%% Compressed snapshots will be saved to the destination with a ".gz" extension
+%% Snapshots will be saved to the destination with a ".gz" extension
 %% automatically appended.
 %%
 %% The return error tuple return value contains a list, the values of which may
 %% or may not themselves also be error tuples.
 %%
 %% This is the preferred function to store snapshots to disk.
-save_bin_snapshots(DestFilename, SnapshotData) ->
-   SaveFuns = case application:get_env(blockchain, snapshot_compression_mode, compressed) of
-                 compressed ->
-                    [ fun save_compressed_bin_snapshot/2 ];
-                 uncompressed ->
-                    [ fun save_bin_snapshot/2 ];
-                 both ->
-                    [ fun save_compressed_bin_snapshot/2, fun save_bin_snapshot/2 ]
-              end,
-
-   Results = lists:map(fun(SaveFunc) ->
-                               SaveFunc(DestFilename, SnapshotData)
-                       end, SaveFuns),
-
-   case lists:all(
-          fun(ok) -> true;
-             (_) -> false
-          end, Results) of
-      true -> ok;
-      false -> {error, Results}
-   end.
-
--spec save_bin_snapshot(file:filename_all(), blockchain_ledger_snapshot:snapshot()) ->
-    ok | {error, term()}.
-save_bin_snapshot(DestFilename, {file, Filename}) ->
-    ok = filelib:ensure_dir(DestFilename),
-    case filelib:is_regular(DestFilename) of
-        true ->
-            ok = file:delete(DestFilename);
-        false ->
-            ok
-    end,
-    file:make_link(Filename, DestFilename);
-save_bin_snapshot(DestFilename, BinSnap) when is_binary(BinSnap); is_list(BinSnap) ->
-    %% can be a binary or an iolist if it was generated locally
-    %% and we can avoid constructing a large binary by just dumping the
-    %% iolist to disk
-    ok = filelib:ensure_dir(DestFilename),
-    file:write_file(DestFilename, BinSnap).
-
--spec save_compressed_bin_snapshot(file:filename_all(), blockchain_ledger_snapshot:snapshot()) ->
-   ok | {error, Error :: term()}.
 save_compressed_bin_snapshot(DestFilename, {file, Filename}) ->
    ok = filelib:ensure_dir(DestFilename),
    CompressedFile = DestFilename ++ ".gz",
@@ -2048,7 +2004,7 @@ save_compressed_bin_snapshot(DestFilename, {file, Filename}) ->
    {ok, In} = file:open(Filename, [raw, read, binary, compressed]),
    {ok, Out} = file:open(CompressedFile, [raw, write, binary]),
    RetVal = case do_compress(In, Out, Z) of
-               ok -> ok;
+               ok -> {ok, CompressedFile};
                {error, _E} = Err -> Err
             end,
    file:close(In),
@@ -2070,7 +2026,7 @@ save_compressed_bin_snapshot(DestFilename, BinSnap) ->
          end,
    RetVal = blockchain_utils:streaming_transform_iolist(BinSnap, Fun),
    file:close(Out),
-   RetVal.
+   {RetVal, CompressedFile}.
 
 do_compress(In, Out, Z) ->
    case file:read(In, ?BLOCK_READ_SIZE) of
@@ -2149,13 +2105,24 @@ do_rocksdb_gc(Bytes, Itr, #blockchain{dir=Dir, db=DB, heights=HeightsCF, blocks=
                     %% check if the snap is on disk
                     SnapDir = filename:join(Dir, "saved-snaps"),
                     SnapPath = filename:join(SnapDir, SnapFile),
-                    case file:read_file_info(SnapPath) of
-                        {ok, #file_info{size=Size}} ->
-                            file:delete(SnapPath),
-                            Size;
-                        _ ->
-                            0
-                    end;
+                    CompSnapBytes =
+                        case file:read_file_info(SnapPath) of
+                            {ok, #file_info{size=Size}} ->
+                                file:delete(SnapPath),
+                                Size;
+                            _ -> 0
+                        end,
+                    %% uncompressed paths are no longer generated but check to see if an old
+                    %% one is still on disk and clean it up
+                    UncompressedPath = string:trim(SnapPath, trailing, ".gz"),
+                    UncompSnapBytes =
+                        case file:read_file_info(UncompressedPath) of
+                            {ok, #file_info{size=UncompSize}} ->
+                                file:delete(UncompressedPath),
+                                UncompSize;
+                            _ -> 0
+                        end,
+                    CompSnapBytes + UncompSnapBytes;
                 {ok, Snap} ->
                     %% snap was in rocksdb
                     byte_size(Snap);
@@ -2177,7 +2144,7 @@ get_snapshot(<<Hash/binary>>, #blockchain{db=DB, dir=Dir, snapshots=SnapshotsCF}
             {error, sentinel};
         {ok, <<"file:", SnapFile/binary>>} ->
             SnapDir = filename:join(Dir, "saved-snaps"),
-            Filename = filename:join(SnapDir, SnapFile ++ ".gz"),
+            Filename = filename:join(SnapDir, SnapFile),
             case filelib:is_file(Filename) of
                 true ->
                     {ok, {file, Filename}};

--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -2177,7 +2177,7 @@ get_snapshot(<<Hash/binary>>, #blockchain{db=DB, dir=Dir, snapshots=SnapshotsCF}
             {error, sentinel};
         {ok, <<"file:", SnapFile/binary>>} ->
             SnapDir = filename:join(Dir, "saved-snaps"),
-            Filename = filename:join(SnapDir, SnapFile),
+            Filename = filename:join(SnapDir, SnapFile ++ ".gz"),
             case filelib:is_file(Filename) of
                 true ->
                     {ok, {file, Filename}};

--- a/src/cli/blockchain_cli_snapshot.erl
+++ b/src/cli/blockchain_cli_snapshot.erl
@@ -98,7 +98,7 @@ snapshot_take(Filename) ->
             {ok, Snapshot} = blockchain_ledger_snapshot_v1:snapshot(Ledger, Blocks, Infos),
             blockchain_lock:release(),
             BinSnap = blockchain_ledger_snapshot_v1:serialize(Snapshot),
-            blockchain:save_bin_snapshots(Filename, BinSnap)
+            blockchain:save_compressed_bin_snapshot(Filename, BinSnap)
     end.
 
 snapshot_load_cmd() ->
@@ -139,7 +139,7 @@ snapshot_grab(["snapshot", "grab", HeightStr, HashStr, Filename], [], []) ->
         Hash = hex_to_binary(HashStr),
         {ok, Snapshot} = blockchain_worker:grab_snapshot(Height, Hash),
         %% NOTE: grab_snapshot returns a deserialized snapshot
-        blockchain:save_bin_snapshots(Filename, blockchain_ledger_snapshot_v1:serialize(Snapshot))
+        blockchain:save_compressed_bin_snapshot(Filename, blockchain_ledger_snapshot_v1:serialize(Snapshot))
     catch
         _Type:Error ->
             [clique_status:text(io_lib:format("failed: ~p", [Error]))]

--- a/test/blockchain_snapshot_SUITE.erl
+++ b/test/blockchain_snapshot_SUITE.erl
@@ -247,13 +247,13 @@ chain_start_from_snap(Snapshot, SnapBin, Cfg) ->
 
 snap_download(SnapHeight, Cfg) ->
     PrivDir = ?config(priv_dir, Cfg),
-    SnapFileName = lists:flatten(io_lib:format("snap-~b", [SnapHeight])),
+    SnapFileName = lists:flatten(io_lib:format("snap-~b.gz", [SnapHeight])),
     SnapFilePath = filename:join(PrivDir, SnapFileName),
     Cmd =
         %% The -c option in wget effectively memoizes the downloaded file,
         %% since priv_dir is per-suite.
         lists:flatten(io_lib:format(
-            "cd ~s && wget -c https://snapshots.helium.wtf/mainnet/~s",
+            "cd ~s && wget -c https://snapshots-dev.helium.wtf/tests/~s",
             [PrivDir, SnapFileName]
         )),
     os:cmd(Cmd),


### PR DESCRIPTION
we're now _only_ producing gzip compressed snapshots and writing them out with the `.gz` extension; the `blockchain:get_snap/2` needs to ensure it's looking for the correct filename now that we're not producing both compressed and uncompressed snapshots