### PR TITLE
close dangling zreference

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -2009,6 +2009,7 @@ save_compressed_bin_snapshot(DestFilename, {file, Filename}) ->
             end,
    file:close(In),
    file:close(Out),
+   zlib:close(Z),
    RetVal;
 save_compressed_bin_snapshot(DestFilename, BinSnap) ->
    ok = filelib:ensure_dir(DestFilename),
@@ -2026,6 +2027,7 @@ save_compressed_bin_snapshot(DestFilename, BinSnap) ->
          end,
    RetVal = blockchain_utils:streaming_transform_iolist(BinSnap, Fun),
    file:close(Out),
+   zlib:close(Z),
    {RetVal, CompressedFile}.
 
 do_compress(In, Out, Z) ->


### PR DESCRIPTION
Closes the dangling zlib reference when saving compressed snapshots to files