### PR TITLE
Pulling out additional uses of the chain in favor of the ledger

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -3029,9 +3029,9 @@ get_plausible_blocks(Itr, {ok, _Key, BinBlock}, Acc) ->
 run_gc_hooks(Blockchain, _Block) ->
     Ledger = blockchain:ledger(Blockchain),
     try
-        ok = blockchain_ledger_v1:maybe_gc_pocs(Blockchain, Ledger),
+        ok = blockchain_ledger_v1:maybe_gc_pocs(Ledger),
 
-        ok = blockchain_ledger_v1:maybe_gc_scs(Blockchain, Ledger),
+        ok = blockchain_ledger_v1:maybe_gc_scs(Ledger),
 
         ok = blockchain_ledger_v1:maybe_gc_h3dex(Ledger),
 

--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -730,8 +730,8 @@ load_blocks(Ledger0, Chain, Snapshot) ->
                       Chain1 = blockchain:ledger(Ledger2, Chain),
                       Rescue = blockchain_block:is_rescue_block(Block),
                       {ok, _Chain, _} = blockchain_txn:absorb_block(Block, Rescue, Chain1),
-                      ok = blockchain_ledger_v1:maybe_gc_pocs(Chain1, Ledger2),
-                      ok = blockchain_ledger_v1:maybe_gc_scs(Chain1, Ledger2),
+                      ok = blockchain_ledger_v1:maybe_gc_pocs(Ledger2),
+                      ok = blockchain_ledger_v1:maybe_gc_scs(Ledger2),
                       %% ok = blockchain_ledger_v1:refresh_gateway_witnesses(Hash, Ledger2),
                       ok = blockchain_ledger_v1:maybe_recalc_price(Chain1, Ledger2),
                       %% TODO Q: Why no match result?

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -924,8 +924,8 @@ plain_absorb_(Block, Chain0) ->
     case ?MODULE:absorb_block(Block, Chain0) of
         {ok, _, KeysPayload} ->
             Ledger0 = blockchain:ledger(Chain0),
-            ok = blockchain_ledger_v1:maybe_gc_pocs(Chain0, Ledger0),
-            ok = blockchain_ledger_v1:maybe_gc_scs(Chain0, Ledger0),
+            ok = blockchain_ledger_v1:maybe_gc_pocs(Ledger0),
+            ok = blockchain_ledger_v1:maybe_gc_scs(Ledger0),
             ok = blockchain_ledger_v1:maybe_gc_h3dex(Ledger0),
             %% ok = blockchain_ledger_v1:refresh_gateway_witnesses(Hash, Ledger0),
             ok = blockchain_ledger_v1:maybe_recalc_price(Chain0, Ledger0),


### PR DESCRIPTION
Delegate operations to the ledger where possible.
These changes should be safe from the perspective of function calls in other projects as none of them are called from outside of Core but there may be nuances to some of the calls to the chain that are still preferable to getting the information out of the ledger that I'm not aware of.