### PR TITLE
Always process gw reactivation list

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -173,6 +173,10 @@
 %% from POC targets :: boolean()
 -define(poc_activity_filter_enabled, poc_activity_filter_enabled).
 
+%% enables or disables processing gateway reactivations regardless of
+%% consensus status (GH#1357)
+-define(poc_always_process_reactivations, poc_always_process_reactivations).
+
 %% Number of blocks to wait before a hotspot can be eligible to participate in a poc
 %% challenge. This would avoid new hotspots getting challenged before they sync to an
 %% acceptable height.

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1018,6 +1018,12 @@ validate_var(?poc_activity_filter_enabled, Value) ->
         false -> ok;
         _ -> throw({error, {poc_activity_filter_enabled, Value}})
     end;
+validate_var(?poc_always_process_reactivations, Value) ->
+    case Value of
+        true -> ok;
+        false -> ok;
+        _ -> throw({error, {poc_always_process_reactivations, Value}})
+    end;
 validate_var(?poc_reject_empty_receipts, Value) ->
     case Value of
         true -> ok;


### PR DESCRIPTION
Problem to solve: Currently, gateway "last activity" is updated only when a validator is _not_ in consensus. But this behavior is incorrect. The reactivation list must always be processed so that gateways are properly marked as "active again" and thus may be considered for POC targeting in the future.

Solution: Always process the reactivation list, even if a node is in consensus.

Fixes #1357