### PR TITLE
var gated bypass of witness validation

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -218,6 +218,9 @@
 %% the number of random hexes to utilize when targeting: integer
 -define(poc_target_pool_size, poc_target_pool_size).
 
+%% whether or not to process validation of poc receipt witnesses
+-define(poc_receipt_witness_validation, poc_receipt_witness_validation).
+
 %%%
 %%% score vars
 %%%

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1132,6 +1132,8 @@ validate_var(?poc_hexing_type, Value) ->
   end;
 validate_var(?poc_validator_ct_scale, Value) ->
     validate_float(Value, "poc_validator_ct_scale", 0.1, 1.0);
+validate_var(?poc_receipt_witness_validation, Value) when is_boolean(Value) -> ok;
+validate_var(?poc_receipt_witness_validation, Value) -> throw({error, poc_receipt_witness_validation, Value});
 
 %% score vars
 validate_var(?alpha_decay, Value) ->

--- a/src/transactions/v2/blockchain_txn_rewards_v2.erl
+++ b/src/transactions/v2/blockchain_txn_rewards_v2.erl
@@ -1223,8 +1223,7 @@ poc_witness_reward(Txn, AccIn,
                         ValidWitnesses =
                             case get({KeyHash, ElemHash}) of
                                 undefined ->
-                                    VW = TxnType:valid_witnesses(Elem, WitnessChannel,
-                                                                                        RegionVars, Ledger),
+                                    VW = TxnType:valid_witnesses(Elem, WitnessChannel, RegionVars, Ledger),
                                     put({KeyHash, ElemHash}, VW),
                                     VW;
                                 VW -> VW

--- a/test/blockchain_simple_SUITE.erl
+++ b/test/blockchain_simple_SUITE.erl
@@ -55,7 +55,8 @@
     genesis_no_var_validation_stay_invalid_test/1,
     genesis_no_var_validation_make_valid_test/1,
     receipts_txn_reject_empty_receipt_test/1,
-    receipts_txn_dont_reject_empty_receipt_test/1
+    receipts_txn_dont_reject_empty_receipt_test/1,
+    receipts_txn_validate_witnesses_test/1
 ]).
 
 -import(blockchain_utils, [normalize_float/1]).
@@ -113,7 +114,8 @@ all() ->
          genesis_no_var_validation_stay_invalid_test,
          genesis_no_var_validation_make_valid_test,
          receipts_txn_reject_empty_receipt_test,
-         receipts_txn_dont_reject_empty_receipt_test
+         receipts_txn_dont_reject_empty_receipt_test,
+         receipts_txn_validate_witnesses_test
     ].
 
 %%--------------------------------------------------------------------
@@ -127,6 +129,7 @@ init_per_testcase(TestCase, Config) ->
             poc_v2_unset_challenger_type_chain_var_test -> ?bones(15000);
             receipts_txn_reject_empty_receipt_test -> ?bones(15000);
             receipts_txn_dont_reject_empty_receipt_test -> ?bones(15000);
+            receipts_txn_validate_witnesses_test -> ?bones(15000);
             _ -> 5000
         end,
     {ok, Sup, {PrivKey, PubKey}, Opts} = test_utils:init(?config(base_dir, Config0)),
@@ -210,6 +213,23 @@ init_per_testcase(TestCase, Config) ->
                         #{
                             ?poc_challenger_type => validator,
                             ?poc_reject_empty_receipts => false,
+                            ?election_version => 5,
+                            ?validator_version => 3,
+                            ?validator_minimum_stake => ?bones(10000),
+                            ?validator_liveness_grace_period => 10,
+                            ?validator_liveness_interval => 5,
+                            ?validator_key_check => true,
+                            ?stake_withdrawal_cooldown => 10,
+                            ?stake_withdrawal_max => 500,
+                            ?dkg_penalty => 1.0,
+                            ?penalty_history_limit => 100,
+                            ?election_bba_penalty => 0.01,
+                            ?election_seen_penalty => 0.03
+                        };
+                    receipts_txn_validate_witnesses_test ->
+                        #{
+                            ?poc_challenger_type => validator,
+                            ?poc_reject_empty_receipts => true,
                             ?election_version => 5,
                             ?validator_version => 3,
                             ?validator_minimum_stake => ?bones(10000),
@@ -3724,6 +3744,43 @@ receipts_txn_dont_reject_empty_receipt_test(Config) ->
     meck:unload(blockchain_poc_packet_v2),
 
     ok.
+
+receipts_txn_validate_witnesses_test(Config) ->
+    %% test behaviour enabled via poc_receipt_witness_validation chain var
+    %% when set to true receipts v2 txns will be rejected if they
+    %% have have witnesses that do not pass any of the validation checks.
+    Chain = ?config(chain, Config),
+
+    %% hardcode much of the poc data
+    IVBytes = crypto:strong_rand_bytes(16),
+    Data = <<"data">>,
+    Layer = <<119,199,206,154,93,134,187,56,109>>,
+
+    {Gateway, SignedPoCReceiptsTxn1, SignedPoCReceiptsTxn2} =
+        setup_receipts_witness_validation(Config, Data, Layer),
+
+    %% meck out all the things
+    %% remove any checks we dont care about
+    %% hardcode the poc packet, save having to create a real poc
+    meck:new(blockchain_txn_poc_receipts_v2, [passthrough]),
+    meck:expect(blockchain_txn_poc_receipts_v2, get_path, fun(_,_,_,_,_,_,_,_,_) -> {[Gateway], erlang:monotonic_time(microsecond)} end),
+    meck:expect(blockchain_txn_poc_receipts_v2, get_channels, fun(_,_,_,_,_) -> {ok, [1]} end),
+    meck:expect(blockchain_txn_poc_receipts_v2, create_secret_hash, fun(_,_) -> [IVBytes, Data] end),
+    meck:new(blockchain_poc_packet_v2, [passthrough]),
+    meck:expect(blockchain_poc_packet_v2, build, fun(_,_,_) -> {<<"ignored_onion">>, [<<"ignored_layer">>,Layer]} end),
+
+    %%
+    %% validate the 2 receipts v2 txns
+    %% receipts v2 txn1 will be declared valid as it has the valid witness
+    ?assertEqual(ok, blockchain_txn_poc_receipts_v2:is_valid(SignedPoCReceiptsTxn1, Chain)),
+    %% receipts v2 txn2 will be declared invalid as it has the invalid witness
+    ?assertEqual({error, empty_path}, blockchain_txn_poc_receipts_v2:is_valid(SignedPoCReceiptsTxn2, Chain)),
+
+    meck:unload(blockchain_txn_poc_receipts_v2),
+    meck:unload(blockchain_poc_packet_v2),
+
+    ok.
+
 %%--------------------------------------------------------------------
 %% Helper functions
 %%--------------------------------------------------------------------
@@ -3918,3 +3975,165 @@ setup_receipts_txn_empty_receipt(Config, Data, Layer) ->
     SignedPoCReceiptsTxn3 = blockchain_txn_poc_receipts_v2:sign(PoCReceiptsTxn3, ValSigFun),
 
     {Gateway, SignedPoCReceiptsTxn1, SignedPoCReceiptsTxn2, SignedPoCReceiptsTxn3}.
+
+setup_receipts_witness_validation(Config, Data, Layer) ->
+    %% perform setup, adds validator, 3 gateways & fakes a POC
+    %% returns 2 receipts v2 txns
+    %% 1 whereby the path has a valid witness reports
+    %% 1 whereby the path has an invalid witness report
+    ConsensusMembers = ?config(consensus_members, Config),
+    Chain = ?config(chain, Config),
+    Ledger = blockchain:ledger(Chain),
+
+    Keys = libp2p_crypto:generate_keys(ecc_compact),
+    Secret = libp2p_crypto:keys_to_bin(Keys),
+    #{public := OnionCompactKey} = Keys,
+    OnionKeyHash = crypto:hash(sha256, libp2p_crypto:pubkey_to_bin(OnionCompactKey)),
+
+    %% Get an owner of our actors
+    [{OwnerPubkeyBin, {_OwnerPub, _OwnerPriv, OwnerSigFun}} | _] = ?config(genesis_members, Config),
+
+    %%
+    %% Create and add three Gateways
+    %%
+    #{public := GatewayPubKey, secret := GatewayPrivKey} = libp2p_crypto:generate_keys(ecc_compact),
+    Gateway = libp2p_crypto:pubkey_to_bin(GatewayPubKey),
+    GatewaySigFun = libp2p_crypto:mk_sig_fun(GatewayPrivKey),
+
+    #{public := Gateway2PubKey, secret := Gateway2PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
+    Gateway2 = libp2p_crypto:pubkey_to_bin(Gateway2PubKey),
+    Gateway2SigFun = libp2p_crypto:mk_sig_fun(Gateway2PrivKey),
+
+    #{public := Gateway3PubKey, secret := Gateway3PrivKey} = libp2p_crypto:generate_keys(ecc_compact),
+    Gateway3 = libp2p_crypto:pubkey_to_bin(Gateway3PubKey),
+    Gateway3SigFun = libp2p_crypto:mk_sig_fun(Gateway3PrivKey),
+
+    % Add & assert Gateway1
+    AddGatewayTx = blockchain_txn_add_gateway_v1:new(OwnerPubkeyBin, Gateway),
+    SignedOwnerAddGatewayTx = blockchain_txn_add_gateway_v1:sign(AddGatewayTx, OwnerSigFun),
+    SignedGatewayAddGatewayTx = blockchain_txn_add_gateway_v1:sign_request(SignedOwnerAddGatewayTx, GatewaySigFun),
+
+    AssertLocationRequestTx = blockchain_txn_assert_location_v1:new(Gateway, OwnerPubkeyBin, ?TEST_LOCATION, 1),
+    PartialAssertLocationTxn = blockchain_txn_assert_location_v1:sign_request(AssertLocationRequestTx, GatewaySigFun),
+    SignedAssertLocationTx = blockchain_txn_assert_location_v1:sign(PartialAssertLocationTxn, OwnerSigFun),
+
+    % Add & assert Gateway2
+    AddGateway2Tx = blockchain_txn_add_gateway_v1:new(OwnerPubkeyBin, Gateway2),
+    SignedOwnerAddGateway2Tx = blockchain_txn_add_gateway_v1:sign(AddGateway2Tx, OwnerSigFun),
+    SignedGatewayAddGateway2Tx = blockchain_txn_add_gateway_v1:sign_request(SignedOwnerAddGateway2Tx, Gateway2SigFun),
+
+    AssertLocationRequestTx2 = blockchain_txn_assert_location_v1:new(Gateway2, OwnerPubkeyBin, ?TEST_LOCATION, 1),
+    PartialAssertLocationTxn2 = blockchain_txn_assert_location_v1:sign_request(AssertLocationRequestTx2, Gateway2SigFun),
+    SignedAssertLocationTx2 = blockchain_txn_assert_location_v1:sign(PartialAssertLocationTxn2, OwnerSigFun),
+
+    % Add & assert Gateway3
+    AddGateway3Tx = blockchain_txn_add_gateway_v1:new(OwnerPubkeyBin, Gateway3),
+    SignedOwnerAddGateway3Tx = blockchain_txn_add_gateway_v1:sign(AddGateway3Tx, OwnerSigFun),
+    SignedGatewayAddGateway3Tx = blockchain_txn_add_gateway_v1:sign_request(SignedOwnerAddGateway3Tx, Gateway3SigFun),
+
+    AssertLocationRequestTx3 = blockchain_txn_assert_location_v1:new(Gateway3, OwnerPubkeyBin, ?TEST_LOCATION, 1),
+    PartialAssertLocationTxn3 = blockchain_txn_assert_location_v1:sign_request(AssertLocationRequestTx3, Gateway3SigFun),
+    SignedAssertLocationTx3 = blockchain_txn_assert_location_v1:sign(PartialAssertLocationTxn3, OwnerSigFun),
+
+    {ok, Block1} = test_utils:create_block(ConsensusMembers, [SignedGatewayAddGatewayTx,
+                                                              SignedAssertLocationTx,
+                                                              SignedGatewayAddGateway2Tx,
+                                                              SignedAssertLocationTx2,
+                                                              SignedGatewayAddGateway3Tx,
+                                                              SignedAssertLocationTx3]),
+    _ = blockchain_gossip_handler:add_block(Block1, Chain, self(), blockchain_swarm:tid()),
+    {ok, _GWInfo} = blockchain_ledger_v1:find_gateway_info(Gateway, Ledger),
+
+    %%
+    %% stake a validator
+    %%
+
+    %% make a validator
+    [{ValPubkeyBin, {_ValPub, _ValPriv, ValSigFun}}] = test_utils:generate_keys(1),
+    ct:pal("StakePubkeyBin: ~p~nOwnerPubkeyBin: ~p", [ValPubkeyBin, OwnerPubkeyBin]),
+
+    ValTxn = blockchain_txn_stake_validator_v1:new(
+        ValPubkeyBin,
+        OwnerPubkeyBin,
+        ?bones(10000),
+        ?bones(5)
+    ),
+    SignedValTxn = blockchain_txn_stake_validator_v1:sign(ValTxn, OwnerSigFun),
+    ct:pal("SignedStakeTxn: ~p", [SignedValTxn]),
+
+    {ok, Block2} = test_utils:create_block(ConsensusMembers, [SignedValTxn]),
+    _ = blockchain_gossip_handler:add_block(Block2, Chain, self(), blockchain_swarm:tid()),
+
+    %% fake a validator poc by manually populating the ledger
+    {ok, Height2} = blockchain:height(Chain),
+    {ok, BlockHash} = blockchain:get_block_hash(Height2, Chain),
+    Ledger1 = blockchain_ledger_v1:new_context(Ledger),
+    fake_public_poc(OnionKeyHash, ValPubkeyBin, BlockHash, Height2, Ledger1),
+    blockchain_ledger_v1:commit_context(Ledger1),
+
+    %% confirm the poc data exists
+    [_ValidatorPOC1 | _] = blockchain_ledger_v1:pocs(active, Ledger),
+
+    %%
+    %% Create version of the receipts txn with and without valid witnesses in the path
+    %%
+    R1 = blockchain_poc_receipt_v1:new(
+        Gateway,
+        1000,
+        10,
+        Data,
+        p2p
+    ),
+    SignedR1 = blockchain_poc_receipt_v1:sign(R1, GatewaySigFun),
+
+    Witness1 = blockchain_poc_witness_v1:new(
+        Gateway2,
+        1001,
+        10,
+        crypto:hash(sha256, Layer),
+        9.8,
+        915.2,
+        10,
+        <<"data_rate">>
+    ),
+    SignedWitness1 = blockchain_poc_witness_v1:sign(Witness1, Gateway2SigFun),
+
+    Witness2 = blockchain_poc_witness_v1:new(
+        Gateway3,
+        1001,
+        10,
+        crypto:hash(sha256, Layer),
+        9.8,
+        0.0, %% <---- Invalid frequency
+        10,
+        <<"data_rate">>
+    ),
+    SignedWitness2 = blockchain_poc_witness_v1:sign(Witness2, Gateway3SigFun),
+
+    %% generate path with the valid witnesses
+    P1 = blockchain_poc_path_element_v1:new(Gateway, SignedR1, [SignedWitness1]),
+    ct:pal("P1: ~p", [P1]),
+
+    %% generate path with the invalid witnesses
+    P2 = blockchain_poc_path_element_v1:new(Gateway, SignedR1, [SignedWitness2]),
+    ct:pal("P2: ~p", [P2]),
+
+    %% include the path in receipts v2 txns
+    PoCReceiptsTxn1 = blockchain_txn_poc_receipts_v2:new(
+        ValPubkeyBin,
+        Secret,
+        OnionKeyHash,
+        [P1],
+        BlockHash
+    ),
+    PoCReceiptsTxn2 = blockchain_txn_poc_receipts_v2:new(
+        ValPubkeyBin,
+        Secret,
+        OnionKeyHash,
+        [P2],
+        BlockHash
+    ),
+    SignedPoCReceiptsTxn1 = blockchain_txn_poc_receipts_v2:sign(PoCReceiptsTxn1, ValSigFun),
+    SignedPoCReceiptsTxn2 = blockchain_txn_poc_receipts_v2:sign(PoCReceiptsTxn2, ValSigFun),
+
+    {Gateway, SignedPoCReceiptsTxn1, SignedPoCReceiptsTxn2}.


### PR DESCRIPTION
Allows skipping of witness validation when processing V2 PoC receipts, which have a heavy performance burden on receipt processing.