### PR TITLE
Add var to harmonize a GWs activity on hip17 interactivity blocks

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -177,6 +177,10 @@
 %% consensus status (GH#1357)
 -define(poc_always_process_reactivations, poc_always_process_reactivations).
 
+%% Whether or not to always use hip17 interactivity blocks
+%% when determining if a GW is active or inactive: boolean
+-define(harmonize_activity_on_hip17_interactivity_blocks, harmonize_activity_on_hip17_interactivity_blocks).
+
 %% Number of blocks to wait before a hotspot can be eligible to participate in a poc
 %% challenge. This would avoid new hotspots getting challenged before they sync to an
 %% acceptable height.

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -4914,32 +4914,37 @@ maybe_gc_h3dex(Ledger) ->
             %% from the current block (which are sorted by *challenger* and GC the
             %% hexes the *challengee* is in.
             {ok, Height} = current_height(Ledger),
-            %% If we can't get the block, we will just crash here
-            {ok, Block} = get_block(Height, Ledger),
-            {ok, #block_info_v2{hash = BlockHash}} = get_block_info(Height, Ledger),
-            RandState = blockchain_utils:rand_from_hash(BlockHash),
-            RequestFilter = fun(T) ->
-                                    blockchain_txn:type(T) == blockchain_txn_poc_receipts_v1
-                                    orelse blockchain_txn:type(T) == blockchain_txn_poc_receipts_v2
-                            end,
-            case blockchain_utils:find_txn(Block, RequestFilter) of
-                [] ->
-                    %% no receipts, don't do any GC
-                    ok;
-                Txns ->
-                    %% take the first `Width` receipts and GC the parent hexes of the challengees
-                    {_NewRand, Selected} = blockchain_utils:deterministic_subset(Width, RandState, Txns),
-                    lists:foreach(fun(T) ->
-                                          ReceiptType = blockchain_txn:type(T),
-                                          Path = ReceiptType:path(T),
-                                          Challengee = blockchain_poc_path_element_v1:challengee(hd(Path)),
-                                          case find_gateway_location(Challengee, Ledger) of
-                                              {ok, Location} ->
-                                                  gc_h3dex_hex(Location, Height, InactivityThreshold1, Ledger);
-                                              _ ->
-                                                  ok
-                                          end
-                                  end, Selected)
+            %% note: handling block not being found here as not doing so
+            %% results in tests failing during genesis block load
+            case get_block(Height, Ledger) of
+                {ok, Block} ->
+                    {ok, #block_info_v2{hash = BlockHash}} = get_block_info(Height, Ledger),
+                    RandState = blockchain_utils:rand_from_hash(BlockHash),
+                    RequestFilter = fun(T) ->
+                                            blockchain_txn:type(T) == blockchain_txn_poc_receipts_v1
+                                            orelse blockchain_txn:type(T) == blockchain_txn_poc_receipts_v2
+                                    end,
+                    case blockchain_utils:find_txn(Block, RequestFilter) of
+                        [] ->
+                            %% no receipts, don't do any GC
+                            ok;
+                        Txns ->
+                            %% take the first `Width` receipts and GC the parent hexes of the challengees
+                            {_NewRand, Selected} = blockchain_utils:deterministic_subset(Width, RandState, Txns),
+                            lists:foreach(fun(T) ->
+                                                  ReceiptType = blockchain_txn:type(T),
+                                                  Path = ReceiptType:path(T),
+                                                  Challengee = blockchain_poc_path_element_v1:challengee(hd(Path)),
+                                                  case find_gateway_location(Challengee, Ledger) of
+                                                      {ok, Location} ->
+                                                          gc_h3dex_hex(Location, Height, InactivityThreshold1, Ledger);
+                                                      _ ->
+                                                          ok
+                                                  end
+                                          end, Selected)
+                    end;
+                _ ->
+                    ok
             end;
         _ ->
             ok

--- a/src/poc/blockchain_poc_path_v4.erl
+++ b/src/poc/blockchain_poc_path_v4.erl
@@ -469,7 +469,10 @@ poc_version(Vars) ->
 
 -spec challenge_age(Vars :: map()) -> pos_integer().
 challenge_age(Vars) ->
-    maps:get(poc_v4_target_challenge_age, Vars).
+    case maps:get(harmonize_activity_on_hip17_interactivity_blocks, Vars, false) of
+        true -> maps:get(hip17_interactivity_blocks, Vars);
+        false -> maps:get(poc_v4_target_challenge_age, Vars)
+    end.
 
 -spec poc_good_bucket_low(Vars :: map()) -> integer().
 poc_good_bucket_low(Vars) ->

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1042,6 +1042,12 @@ validate_var(?poc_proposal_gc_window_check, Value) ->
         false -> ok;
         _ -> throw({error, {poc_proposal_gc_window_check, Value}})
     end;
+validate_var(?harmonize_activity_on_hip17_interactivity_blocks, Value) ->
+    case Value of
+        true -> ok;
+        false -> ok;
+        _ -> throw({error, {harmonize_activity_on_hip17_interactivity_blocks, Value}})
+    end;
 
 validate_var(?poc_challenge_sync_interval, Value) ->
     validate_int(Value, "poc_challenge_sync_interval", 10, 1440, false);


### PR DESCRIPTION
Related PR:  https://github.com/helium/sibyl/pull/51

After 19.1 was cut it was realised that there were two vars in use to determine a GW was active or inactive, these were:

poc_v4_target_challenge_age
hip17_interactivity_blocks

This harmonises the activity determination to use the hip17 var ( which has a higher permitted threshold of 5000 compared to 1000 for the former )

An alternative approach was to add a completely new var to determine the number of blocks before a GW is marked as inactive and replace both the above vars. The only scenario in which I thought that justified was if the max value of 5000 is considered constrictive.  If that is the case then I will rework this....