### PR TITLE
export poc gc interval as function

### DIFF
--- a/src/ledger/v1/blockchain_ledger_v1.hrl
+++ b/src/ledger/v1/blockchain_ledger_v1.hrl
@@ -95,6 +95,7 @@
 -define(BITS_23, 8388607). %% biggest unsigned number in 23 bits
 -define(BITS_25, 33554431). %% biggest unsigned number in 25 bits
 -define(DEFAULT_ORACLE_PRICE, 0).
+-define(DEFAULT_POC_GC_INTERVAL, 101). %% in blocks
 
 -type ledger() :: #ledger_v1{}.
 -type sub_ledger() :: #sub_ledger_v1{}.


### PR DESCRIPTION
provide a public api function off the ledger for determining the correct interval in blocks for poc garbage collection. this allows us to avoid extra effort in keeping consistent values across repos and files.