### PR TITLE
separate out purging of active and proposed POCs

### DIFF
--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -94,6 +94,7 @@
     pocs/2,
     delete_poc/3,
     purge_pocs/1,
+    purge_poc_proposals/1,
     maybe_gc_pocs/2,
     maybe_gc_scs/2,
     maybe_gc_h3dex/1,
@@ -2321,7 +2322,6 @@ pocs_(CF, Ledger) ->
 -spec purge_pocs(ledger()) -> ok.
 purge_pocs(Ledger) ->
     PoCsCF = pocs_cf(Ledger),
-    ProposedPoCsCF = proposed_pocs_cf(Ledger),
     PurgeFun = fun(CF) ->
                        cache_fold(
                          Ledger,
@@ -2333,6 +2333,21 @@ purge_pocs(Ledger) ->
                         )
                end,
     PurgeFun(PoCsCF),
+    ok.
+
+-spec purge_poc_proposals(ledger()) -> ok.
+purge_poc_proposals(Ledger) ->
+    ProposedPoCsCF = proposed_pocs_cf(Ledger),
+    PurgeFun = fun(CF) ->
+                       cache_fold(
+                         Ledger,
+                         CF,
+                         fun({KeyHash, _}, _Acc) ->
+                                 cache_delete(Ledger, CF, KeyHash)
+                         end,
+                         []
+                        )
+               end,
     PurgeFun(ProposedPoCsCF),
     ok.
 

--- a/src/poc/blockchain_poc_target_v6.erl
+++ b/src/poc/blockchain_poc_target_v6.erl
@@ -254,7 +254,7 @@ is_active(true, undefined, _MaxActivityAge, _Height) ->
     false;
 is_active(true, LastActivity, MaxActivityAge, Height) ->
     (Height - LastActivity) < MaxActivityAge;
-is_active(_ActivityFilterEnabled, _Gateway, _Height, _Vars) ->
+is_active(_ActivityFilterEnabled, _LastActivity, _MaxActivityAge, _Height) ->
     true.
 
 -spec max_activity_age(Vars :: map()) -> pos_integer().

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -689,14 +689,14 @@ process_hooks(Vars, Unsets, Ledger) ->
 -spec var_hook(Var :: atom(), Value :: any(), Ledger :: blockchain_ledger_v1:ledger()) -> ok.
 var_hook(?poc_targeting_version, 6, Ledger) ->
     %% purge any active POCs
-    purge_pocs(Ledger),
+    blockchain_ledger_v1:purge_pocs(Ledger),
     %% build the h3dex lookup
     {ok, Res} = blockchain_ledger_v1:config(?poc_target_hex_parent_res, Ledger),
     blockchain_ledger_v1:build_random_hex_targeting_lookup(Res, Ledger),
     ok;
 var_hook(?poc_targeting_version, 5, Ledger) ->
     %% purge any active POCs
-    purge_pocs(Ledger),
+    blockchain_ledger_v1:purge_pocs(Ledger),
     %% v3 targeting enabled, remove the h3dex lookup
     blockchain_ledger_v1:clean_random_hex_targeting_lookup(Ledger),
     ok;
@@ -743,7 +743,8 @@ var_hook(?poc_challenger_type, Type, Ledger) ->
             blockchain_ledger_v1:validator_count(Ct, Ledger);
         _ -> ok
     end,
-    purge_pocs(Ledger),
+    blockchain_ledger_v1:purge_pocs(Ledger),
+    blockchain_ledger_v1:purge_poc_proposals(Ledger),
     ok;
 var_hook(_Var, _Value, _Ledger) ->
     ok.
@@ -758,7 +759,8 @@ unset_hook(?poc_hexing_type, Ledger) ->
     blockchain:bootstrap_hexes(Ledger),
     ok;
 unset_hook(?poc_challenger_type, Ledger) ->
-    purge_pocs(Ledger),
+    blockchain_ledger_v1:purge_pocs(Ledger),
+    blockchain_ledger_v1:purge_poc_proposals(Ledger),
     ok;
 unset_hook(_Var, _Ledger) ->
     ok.
@@ -1635,9 +1637,6 @@ validate_region_params(Var, Value) when is_binary(Value) ->
     end;
 validate_region_params(Var, Value) ->
     throw({error, {invalid_region_param_not_binary, Var, Value}}).
-
-purge_pocs(Ledger) ->
-    blockchain_ledger_v1:purge_pocs(Ledger).
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests


### PR DESCRIPTION
This breaks out the purging of active and proposed POCs into two functions allowing each to be called independently.  

Doing so prevents the proposed POCs being wiped when we change targeting.  This avoids all poc proposals being lost when we enabled h3dex on mainnet

The only time we wipe the poc proposals with this fix is when poc_challenger_type is changed or unset. 