### PR TITLE
include telemetry in app src

### DIFF
--- a/src/blockchain.app.src
+++ b/src/blockchain.app.src
@@ -29,7 +29,8 @@
         jsx,
         erbloom,
         grpc_client,
-        hackney
+        hackney,
+        telemetry
     ]},
     {env,[]},
     {modules, []},


### PR DESCRIPTION
telemetry app is not loaded by default on core currently, leading to crash below:


2022-05-31 10:18:02.694 [warning] <0.6286.0>@miner:handle_info:{496,5} unhandled info message {'DOWN',#Ref<0.1669751320.380633090.44130>,process,{blockchain_worker,'val_miner@127.0.0.1'},{undef,[{telemetry,execute,[[blockchain,block,absorb],#{duration => 39},#{stage => validation}],[]},{blockchain_txn,absorb_and_commit,4,[{file,"/var/data/home/ubuntu/miner/_build/default/lib/blockchain/src/transactions/blockchain_txn.erl"},{line,447}]},{blockchain,integrate_genesis,2,[{file,"/var/data/home/ubuntu/miner/_build/default/lib/blockchain/src/blockchain.erl"},{line,407}]},{blockchain_worker,integrate_genesis_block_,2,[{file,"/var/data/home/ubuntu/miner/_build/default/lib/blockchain/src/blockchain_worker.erl"},{line,774}]},{blockchain_worker,handle_cast,2,[{file,"/var/data/home/ubuntu/miner/_build/default/lib/blockchain/src/blockchain_worker.erl"},{line,555}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,695}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,771}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}}
2022-05-31 10:18:02.694 [warning] <0.6241.0>@blockchain_event:terminate:{108,5} terminating remove_handler
2022-05-31 10:18:02.694 [error] <0.6244.0> gen_server blockchain_worker terminated with reason: {'module could not be loaded',[{telemetry,execute,[[blockchain,block,absorb],#{duration => 39},#{stage => validation}],[]},{blockchain_txn,absorb_and_commit,4,[{file,"/var/data/home/ubuntu/miner/_build/default/lib/blockchain/src/transactions/blockchain_txn.erl"},{line,447}]},{blockchain,integrate_genesis,2,[{file,"/var/data/home/ubuntu/miner/_build/default/lib/blockchain/src/blockchain.erl"},{line,407}]},{blockchain_worker,integrate_genesis_block_,2,[{file,"/var/data/home/ubuntu/miner/_buil..."},...]},...]}

