### PR TITLE
Add support for multitoken rewards and subnetworks

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -625,4 +625,4 @@
 %% Var to switch off legacy security_exchange txn
 -define(deprecate_security_exchange_v1, deprecate_security_exchange_v1).
 %% How many reward server keys to allow
--define(allowed_reward_server_key_length, allowed_reward_server_key_length).
+-define(allowed_num_reward_server_keys, allowed_num_reward_server_keys).

--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -624,5 +624,5 @@
 -define(ledger_entry_version, ledger_entry_version).
 %% Var to switch off legacy security_exchange txn
 -define(deprecate_security_exchange_v1, deprecate_security_exchange_v1).
-%% Var to enable multiple reward server keys
--define(allow_multiple_reward_server_keys, allow_multiple_reward_server_keys).
+%% How many reward server keys to allow
+-define(allowed_reward_server_key_length, allowed_reward_server_key_length).

--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -624,3 +624,5 @@
 -define(ledger_entry_version, ledger_entry_version).
 %% Var to switch off legacy security_exchange txn
 -define(deprecate_security_exchange_v1, deprecate_security_exchange_v1).
+%% Var to enable multiple reward server keys
+-define(allow_multiple_reward_server_keys, allow_multiple_reward_server_keys).

--- a/rebar.lock
+++ b/rebar.lock
@@ -77,7 +77,7 @@
  {<<"hackney">>,{pkg,<<"hackney">>,<<"1.18.0">>},0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"9f443381496f8579c867647538df06f10e605b73"}},
+       {ref,"0e5924f0874377fe43c3d4c04ce4d1c87bf95b00"}},
   0},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},2},
  {<<"idna">>,{pkg,<<"idna">>,<<"6.1.1">>},1},

--- a/rebar.lock
+++ b/rebar.lock
@@ -77,7 +77,7 @@
  {<<"hackney">>,{pkg,<<"hackney">>,<<"1.18.0">>},0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"eaec234f2a556a5a70d00df5a609540eb8f7154b"}},
+       {ref,"9f443381496f8579c867647538df06f10e605b73"}},
   0},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},2},
  {<<"idna">>,{pkg,<<"idna">>,<<"6.1.1">>},1},

--- a/rebar.lock
+++ b/rebar.lock
@@ -77,7 +77,7 @@
  {<<"hackney">>,{pkg,<<"hackney">>,<<"1.18.0">>},0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"0434ee544c043e4f2e72332e1964f2e48aee4662"}},
+       {ref,"eaec234f2a556a5a70d00df5a609540eb8f7154b"}},
   0},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},2},
  {<<"idna">>,{pkg,<<"idna">>,<<"6.1.1">>},1},

--- a/rebar.lock
+++ b/rebar.lock
@@ -77,7 +77,7 @@
  {<<"hackney">>,{pkg,<<"hackney">>,<<"1.18.0">>},0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"0e5924f0874377fe43c3d4c04ce4d1c87bf95b00"}},
+       {ref,"0434ee544c043e4f2e72332e1964f2e48aee4662"}},
   0},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},2},
  {<<"idna">>,{pkg,<<"idna">>,<<"6.1.1">>},1},

--- a/rebar.lock
+++ b/rebar.lock
@@ -77,7 +77,7 @@
  {<<"hackney">>,{pkg,<<"hackney">>,<<"1.18.0">>},0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"eaec234f2a556a5a70d00df5a609540eb8f7154b"}},
+       {ref,"d1694d5ddb3801f70461921a33407b04d9df66f3"}},
   0},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},2},
  {<<"idna">>,{pkg,<<"idna">>,<<"6.1.1">>},1},

--- a/src/ledger/v1/blockchain_ledger_subnetwork_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_subnetwork_v1.erl
@@ -1,0 +1,62 @@
+%%%-------------------------------------------------------------------
+%% @doc
+%% == Blockchain Ledger Subnetwork V1 ==
+%% @end
+%%%-------------------------------------------------------------------
+-module(blockchain_ledger_subnetwork_v1).
+
+-export([
+    type/1,
+    subnetwork_treasury/1,
+    hnt_treasury/1,
+    rollup_server_keys/1,
+    nonce/1, nonce/2,
+    serialize/1,
+    deserialize/1
+]).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-include_lib("helium_proto/include/blockchain_ledger_subnetwork_v1_pb.hrl").
+
+-type subnetwork_v1() :: #blockchain_ledger_subnetwork_v1_pb{}.
+
+-export_type([subnetwork_v1/0]).
+
+%% ==================================================================
+%% API Functions
+%% ==================================================================
+
+-spec type(SN :: subnetwork_v1()) -> blockchain_token_v1:type().
+type(#blockchain_ledger_subnetwork_v1_pb{type = Type}) ->
+    Type.
+
+-spec subnetwork_treasury(SN :: subnetwork_v1()) -> non_neg_integer().
+subnetwork_treasury(#blockchain_ledger_subnetwork_v1_pb{subnetwork_treasury = SNT}) ->
+    SNT.
+
+-spec hnt_treasury(SN :: subnetwork_v1()) -> non_neg_integer().
+hnt_treasury(#blockchain_ledger_subnetwork_v1_pb{hnt_treasury = SNHT}) ->
+    SNHT.
+
+-spec rollup_server_keys(SN :: subnetwork_v1()) -> [libp2p_crypto:pubkey_bin()].
+rollup_server_keys(#blockchain_ledger_subnetwork_v1_pb{rollup_server_keys = Keys}) ->
+    Keys.
+
+-spec nonce(SN :: subnetwork_v1()) -> non_neg_integer().
+nonce(#blockchain_ledger_subnetwork_v1_pb{nonce = Nonce}) ->
+    Nonce.
+
+-spec nonce(SN :: subnetwork_v1(), Nonce :: non_neg_integer()) -> subnetwork_v1().
+nonce(SN, Nonce) ->
+    SN#blockchain_ledger_subnetwork_v1_pb{nonce = Nonce}.
+
+-spec serialize(SN :: subnetwork_v1()) -> binary().
+serialize(SN) ->
+    blockchain_ledger_subnetwork_v1_pb:encode_msg(SN).
+
+-spec deserialize(SNBin :: binary()) -> subnetwork_v1().
+deserialize(SNBin) ->
+    blockchain_ledger_subnetwork_v1_pb:decode_msg(SNBin, blockchain_ledger_subnetwork_v1_pb).

--- a/src/ledger/v1/blockchain_ledger_subnetwork_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_subnetwork_v1.erl
@@ -8,9 +8,9 @@
 -export([
     new/5,
     type/1,
-    subnetwork_treasury/1,
+    premine/1,
     hnt_treasury/1,
-    rollup_server_keys/1,
+    reward_server_keys/1,
     nonce/1, nonce/2,
     serialize/1,
     deserialize/1
@@ -35,31 +35,31 @@
     SNTreasury :: non_neg_integer(),
     HNTTreasury :: non_neg_integer(),
     SNKey :: libp2p_crypto:pubkey_bin(),
-    RollupKeys :: [libp2p_crypto:pubkey_bin()]
+    RewardServerKeys :: [libp2p_crypto:pubkey_bin()]
 ) -> subnetwork_v1().
-new(TT, SNTreasury, HNTTreasury, SNKey, RollupKeys) ->
+new(TT, SNTreasury, HNTTreasury, SNKey, RewardServerKeys) ->
     #blockchain_ledger_subnetwork_v1_pb{
         type = TT,
-        subnetwork_treasury = SNTreasury,
+        premine = SNTreasury,
         hnt_treasury = HNTTreasury,
         subnetwork_key = SNKey,
-        rollup_server_keys = lists:sort(RollupKeys)
+        reward_server_keys = lists:sort(RewardServerKeys)
     }.
 
 -spec type(SN :: subnetwork_v1()) -> blockchain_token_v1:type().
 type(#blockchain_ledger_subnetwork_v1_pb{type = Type}) ->
     Type.
 
--spec subnetwork_treasury(SN :: subnetwork_v1()) -> non_neg_integer().
-subnetwork_treasury(#blockchain_ledger_subnetwork_v1_pb{subnetwork_treasury = SNT}) ->
+-spec premine(SN :: subnetwork_v1()) -> non_neg_integer().
+premine(#blockchain_ledger_subnetwork_v1_pb{premine = SNT}) ->
     SNT.
 
 -spec hnt_treasury(SN :: subnetwork_v1()) -> non_neg_integer().
 hnt_treasury(#blockchain_ledger_subnetwork_v1_pb{hnt_treasury = SNHT}) ->
     SNHT.
 
--spec rollup_server_keys(SN :: subnetwork_v1()) -> [libp2p_crypto:pubkey_bin()].
-rollup_server_keys(#blockchain_ledger_subnetwork_v1_pb{rollup_server_keys = Keys}) ->
+-spec reward_server_keys(SN :: subnetwork_v1()) -> [libp2p_crypto:pubkey_bin()].
+reward_server_keys(#blockchain_ledger_subnetwork_v1_pb{reward_server_keys = Keys}) ->
     Keys.
 
 -spec nonce(SN :: subnetwork_v1()) -> non_neg_integer().

--- a/src/ledger/v1/blockchain_ledger_subnetwork_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_subnetwork_v1.erl
@@ -6,6 +6,7 @@
 -module(blockchain_ledger_subnetwork_v1).
 
 -export([
+    new/5,
     type/1,
     subnetwork_treasury/1,
     hnt_treasury/1,
@@ -28,6 +29,22 @@
 %% ==================================================================
 %% API Functions
 %% ==================================================================
+
+-spec new(
+    TT :: blockchain_token_v1:type(),
+    SNTreasury :: non_neg_integer(),
+    HNTTreasury :: non_neg_integer(),
+    SNKey :: libp2p_crypto:pubkey_bin(),
+    RollupKeys :: [libp2p_crypto:pubkey_bin()]
+) -> subnetwork_v1().
+new(TT, SNTreasury, HNTTreasury, SNKey, RollupKeys) ->
+    #blockchain_ledger_subnetwork_v1_pb{
+        type = TT,
+        subnetwork_treasury = SNTreasury,
+        hnt_treasury = HNTTreasury,
+        subnetwork_key = SNKey,
+        rollup_server_keys = lists:sort(RollupKeys)
+    }.
 
 -spec type(SN :: subnetwork_v1()) -> blockchain_token_v1:type().
 type(#blockchain_ledger_subnetwork_v1_pb{type = Type}) ->

--- a/src/ledger/v1/blockchain_ledger_subnetwork_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_subnetwork_v1.erl
@@ -12,6 +12,7 @@
     hnt_treasury/1,
     reward_server_keys/1,
     nonce/1, nonce/2,
+    last_rewarded_block/1, last_rewarded_block/2,
     serialize/1,
     deserialize/1
 ]).
@@ -61,6 +62,14 @@ hnt_treasury(#blockchain_ledger_subnetwork_v1_pb{hnt_treasury = SNHT}) ->
 -spec reward_server_keys(SN :: subnetwork_v1()) -> [libp2p_crypto:pubkey_bin()].
 reward_server_keys(#blockchain_ledger_subnetwork_v1_pb{reward_server_keys = Keys}) ->
     Keys.
+
+-spec last_rewarded_block(SN :: subnetwork_v1()) -> non_neg_integer().
+last_rewarded_block(#blockchain_ledger_subnetwork_v1_pb{last_rewarded_block = LRB}) ->
+    LRB.
+
+-spec last_rewarded_block(SN :: subnetwork_v1(), LRB :: non_neg_integer()) -> subnetwork_v1().
+last_rewarded_block(SN, LRB) ->
+    SN#blockchain_ledger_subnetwork_v1_pb{last_rewarded_block = LRB}.
 
 -spec nonce(SN :: subnetwork_v1()) -> non_neg_integer().
 nonce(#blockchain_ledger_subnetwork_v1_pb{nonce = Nonce}) ->

--- a/src/ledger/v1/blockchain_ledger_subnetwork_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_subnetwork_v1.erl
@@ -8,7 +8,7 @@
 -export([
     new/5,
     type/1,
-    premine/1,
+    token_treasury/1,
     hnt_treasury/1,
     reward_server_keys/1,
     nonce/1, nonce/2,
@@ -41,7 +41,7 @@
 new(TT, SNTreasury, HNTTreasury, SNKey, RewardServerKeys) ->
     #blockchain_ledger_subnetwork_v1_pb{
         type = TT,
-        premine = SNTreasury,
+        token_treasury = SNTreasury,
         hnt_treasury = HNTTreasury,
         subnetwork_key = SNKey,
         reward_server_keys = lists:sort(RewardServerKeys)
@@ -51,8 +51,8 @@ new(TT, SNTreasury, HNTTreasury, SNKey, RewardServerKeys) ->
 type(#blockchain_ledger_subnetwork_v1_pb{type = Type}) ->
     Type.
 
--spec premine(SN :: subnetwork_v1()) -> non_neg_integer().
-premine(#blockchain_ledger_subnetwork_v1_pb{premine = SNT}) ->
+-spec token_treasury(SN :: subnetwork_v1()) -> non_neg_integer().
+token_treasury(#blockchain_ledger_subnetwork_v1_pb{token_treasury = SNT}) ->
     SNT.
 
 -spec hnt_treasury(SN :: subnetwork_v1()) -> non_neg_integer().

--- a/src/ledger/v1/blockchain_ledger_subnetwork_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_subnetwork_v1.erl
@@ -8,7 +8,7 @@
 -export([
     new/5,
     type/1,
-    token_treasury/1,
+    token_treasury/1, token_treasury/2,
     hnt_treasury/1,
     reward_server_keys/1,
     nonce/1, nonce/2,
@@ -54,6 +54,10 @@ type(#blockchain_ledger_subnetwork_v1_pb{type = Type}) ->
 -spec token_treasury(SN :: subnetwork_v1()) -> non_neg_integer().
 token_treasury(#blockchain_ledger_subnetwork_v1_pb{token_treasury = SNT}) ->
     SNT.
+
+-spec token_treasury(SN :: subnetwork_v1(), TokenTreasury :: non_neg_integer()) -> subnetwork_v1().
+token_treasury(SN, TokenTreasury) ->
+    SN#blockchain_ledger_subnetwork_v1_pb{token_treasury = TokenTreasury}.
 
 -spec hnt_treasury(SN :: subnetwork_v1()) -> non_neg_integer().
 hnt_treasury(#blockchain_ledger_subnetwork_v1_pb{hnt_treasury = SNHT}) ->

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -2987,16 +2987,16 @@ migrate_sec_entries(Ledger) ->
     ).
 
 -spec add_subnetwork(TT :: blockchain_token_v1:type(),
-                     SNTreasury :: non_neg_integer(),
+                     Premine :: non_neg_integer(),
                      HNTTreasury :: non_neg_integer(),
                      SNKey :: libp2p_crypto:pubkey_bin(),
-                     RollupKeys :: [libp2p_crypto:pubkey_bin()],
+                     RewardServerKeys :: [libp2p_crypto:pubkey_bin()],
                      Ledger :: ledger()) -> ok | {error, any()}.
-add_subnetwork(TT, SNTreasury, HNTTreasury, SNKey, RollupKeys, Ledger) ->
+add_subnetwork(TT, Premine, HNTTreasury, SNKey, RewardServerKeys, Ledger) ->
     SubnetworksV1CF = subnetworks_v1_cf(Ledger),
     case ?MODULE:find_subnetwork_v1(TT, Ledger) of
         {error, address_entry_not_found} ->
-            SN = blockchain_ledger_subnetwork_v1:new(TT, SNTreasury, HNTTreasury, SNKey, RollupKeys),
+            SN = blockchain_ledger_subnetwork_v1:new(TT, Premine, HNTTreasury, SNKey, RewardServerKeys),
             Bin = blockchain_ledger_entry_v1:serialize(SN),
             cache_put(Ledger, SubnetworksV1CF, TT, Bin);
         {ok, _SN} ->

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -1364,7 +1364,7 @@ subnetworks_v1(Ledger) ->
     | {error, any()}.
 find_subnetwork_v1(TT, Ledger) ->
     SNCF = subnetworks_v1_cf(Ledger),
-    case cache_get(Ledger, SNCF, atom_to_binary(TT), []) of
+    case cache_get(Ledger, SNCF, atom_to_binary(TT, utf8), []) of
         {ok, BinEntry} ->
             {ok, blockchain_ledger_subnetwork_v1:deserialize(BinEntry)};
         not_found ->
@@ -3000,7 +3000,7 @@ add_subnetwork(TT, TokenTreasury, HNTTreasury, SNKey, RewardServerKeys, Ledger) 
             %% Only add subnetwork if it is not found on ledger
             SN = blockchain_ledger_subnetwork_v1:new(TT, TokenTreasury, HNTTreasury, SNKey, RewardServerKeys),
             Bin = blockchain_ledger_subnetwork_v1:serialize(SN),
-            cache_put(Ledger, SubnetworksV1CF, atom_to_binary(TT), Bin);
+            cache_put(Ledger, SubnetworksV1CF, atom_to_binary(TT, utf8), Bin);
         {ok, _SN} ->
             {error, subnetwork_already_exists};
         {error, _}=Error ->
@@ -3013,7 +3013,7 @@ update_subnetwork(SN, Ledger) ->
     SubnetworksV1CF = subnetworks_v1_cf(Ledger),
     TT = blockchain_ledger_subnetwork_v1:type(SN),
     Bin = blockchain_ledger_subnetwork_v1:serialize(SN),
-    cache_put(Ledger, SubnetworksV1CF, atom_to_binary(TT), Bin).
+    cache_put(Ledger, SubnetworksV1CF, atom_to_binary(TT, utf8), Bin).
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -1354,7 +1354,7 @@ subnetworks_v1(Ledger) ->
         SubnetworksV1CF,
         fun({TT, Binary}, Acc) ->
             SN = blockchain_ledger_subnetwork_v1:deserialize(Binary),
-            maps:put(binary_to_atom(TT), SN, Acc)
+            maps:put(binary_to_atom(TT, utf8), SN, Acc)
         end,
         #{}
     ).

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -2988,17 +2988,17 @@ migrate_sec_entries(Ledger) ->
     ).
 
 -spec add_subnetwork(TT :: blockchain_token_v1:type(),
-                     Premine :: non_neg_integer(),
+                     TokenTreasury :: non_neg_integer(),
                      HNTTreasury :: non_neg_integer(),
                      SNKey :: libp2p_crypto:pubkey_bin(),
                      RewardServerKeys :: [libp2p_crypto:pubkey_bin()],
                      Ledger :: ledger()) -> ok | {error, any()}.
-add_subnetwork(TT, Premine, HNTTreasury, SNKey, RewardServerKeys, Ledger) ->
+add_subnetwork(TT, TokenTreasury, HNTTreasury, SNKey, RewardServerKeys, Ledger) ->
     SubnetworksV1CF = subnetworks_v1_cf(Ledger),
     case ?MODULE:find_subnetwork_v1(TT, Ledger) of
         {error, subnetwork_not_found} ->
             %% Only add subnetwork if it is not found on ledger
-            SN = blockchain_ledger_subnetwork_v1:new(TT, Premine, HNTTreasury, SNKey, RewardServerKeys),
+            SN = blockchain_ledger_subnetwork_v1:new(TT, TokenTreasury, HNTTreasury, SNKey, RewardServerKeys),
             Bin = blockchain_ledger_subnetwork_v1:serialize(SN),
             cache_put(Ledger, SubnetworksV1CF, atom_to_binary(TT), Bin);
         {ok, _SN} ->

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -274,6 +274,7 @@
     migrate_entries/1,
 
     add_subnetwork/6,
+    update_subnetwork/2,
     subnetworks_v1/1,
     find_subnetwork_v1/2
 ]).
@@ -3006,6 +3007,11 @@ add_subnetwork(TT, Premine, HNTTreasury, SNKey, RewardServerKeys, Ledger) ->
             Error
     end.
 
+update_subnetwork(SN, Ledger) ->
+    SubnetworksV1CF = subnetworks_v1_cf(Ledger),
+    TT = blockchain_ledger_subnetwork_v1:type(SN),
+    Bin = blockchain_ledger_subnetwork_v1:serialize(SN),
+    cache_put(Ledger, SubnetworksV1CF, atom_to_binary(TT), Bin).
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -1353,7 +1353,7 @@ subnetworks_v1(Ledger) ->
         SubnetworksV1CF,
         fun({TT, Binary}, Acc) ->
             SN = blockchain_ledger_subnetwork_v1:deserialize(Binary),
-            maps:put(TT, SN, Acc)
+            maps:put(binary_to_atom(TT), SN, Acc)
         end,
         #{}
     ).
@@ -1363,7 +1363,7 @@ subnetworks_v1(Ledger) ->
     | {error, any()}.
 find_subnetwork_v1(TT, Ledger) ->
     SNCF = subnetworks_v1_cf(Ledger),
-    case cache_get(Ledger, SNCF, TT, []) of
+    case cache_get(Ledger, SNCF, atom_to_binary(TT), []) of
         {ok, BinEntry} ->
             {ok, blockchain_ledger_subnetwork_v1:deserialize(BinEntry)};
         not_found ->
@@ -2995,10 +2995,11 @@ migrate_sec_entries(Ledger) ->
 add_subnetwork(TT, Premine, HNTTreasury, SNKey, RewardServerKeys, Ledger) ->
     SubnetworksV1CF = subnetworks_v1_cf(Ledger),
     case ?MODULE:find_subnetwork_v1(TT, Ledger) of
-        {error, address_entry_not_found} ->
+        {error, subnetwork_not_found} ->
+            %% Only add subnetwork if it is not found on ledger
             SN = blockchain_ledger_subnetwork_v1:new(TT, Premine, HNTTreasury, SNKey, RewardServerKeys),
-            Bin = blockchain_ledger_entry_v1:serialize(SN),
-            cache_put(Ledger, SubnetworksV1CF, TT, Bin);
+            Bin = blockchain_ledger_subnetwork_v1:serialize(SN),
+            cache_put(Ledger, SubnetworksV1CF, atom_to_binary(TT), Bin);
         {ok, _SN} ->
             {error, subnetwork_already_exists};
         {error, _}=Error ->

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -2997,10 +2997,16 @@ add_subnetwork(TT, TokenTreasury, HNTTreasury, SNKey, RewardServerKeys, Ledger) 
     SubnetworksV1CF = subnetworks_v1_cf(Ledger),
     case ?MODULE:find_subnetwork_v1(TT, Ledger) of
         {error, subnetwork_not_found} ->
-            %% Only add subnetwork if it is not found on ledger
-            SN = blockchain_ledger_subnetwork_v1:new(TT, TokenTreasury, HNTTreasury, SNKey, RewardServerKeys),
-            Bin = blockchain_ledger_subnetwork_v1:serialize(SN),
-            cache_put(Ledger, SubnetworksV1CF, atom_to_binary(TT, utf8), Bin);
+            case lists:member(TT, blockchain_token_v1:supported_tokens()) of
+                false ->
+                    %% We do not support this token type
+                    {error, {unsupported_subnetwork, TT}};
+                true ->
+                    %% Only add subnetwork if it is not found on ledger
+                    SN = blockchain_ledger_subnetwork_v1:new(TT, TokenTreasury, HNTTreasury, SNKey, RewardServerKeys),
+                    Bin = blockchain_ledger_subnetwork_v1:serialize(SN),
+                    cache_put(Ledger, SubnetworksV1CF, atom_to_binary(TT, utf8), Bin)
+            end;
         {ok, _SN} ->
             {error, subnetwork_already_exists};
         {error, _}=Error ->

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -271,8 +271,11 @@
     dc_to_hnt/2,
     hnt_to_dc/2,
 
-    migrate_entries/1
+    migrate_entries/1,
 
+    add_subnetwork/6,
+    subnetworks_v1/1,
+    find_subnetwork_v1/2
 ]).
 
 -include("blockchain.hrl").
@@ -290,6 +293,7 @@
 
 -type entries() :: #{libp2p_crypto:pubkey_bin() => blockchain_ledger_entry_v1:entry()}.
 -type entries_v2() :: #{libp2p_crypto:pubkey_bin() => blockchain_ledger_entry_v2:entry()}.
+-type subnetworks_v1() :: #{blockchain_token_v1:type() => blockchain_ledger_subnetwork_v1:subnetwork_v1()}.
 -type dc_entries() :: #{libp2p_crypto:pubkey_bin() => blockchain_ledger_data_credits_entry_v1:data_credits_entry()}.
 -type active_gateways() :: #{libp2p_crypto:pubkey_bin() => blockchain_ledger_gateway_v2:gateway()}.
 -type htlcs() :: #{libp2p_crypto:pubkey_bin() => blockchain_ledger_htlc_v1:htlc()}.
@@ -351,11 +355,11 @@ new(Dir, ReadOnly, Options) ->
 
     [DefaultCF, AGwsCF, EntriesCF, DCEntriesCF, HTLCsCF, PoCsCF, ProposedPoCsCF,
      SecuritiesCF, RoutingCF,
-     SubnetsCF, SCsCF, H3DexCF, GwDenormCF, ValidatorsCF, EntriesV2CF,
+     SubnetsCF, SCsCF, H3DexCF, GwDenormCF, ValidatorsCF, EntriesV2CF, SubnetworksV1CF,
      DelayedDefaultCF, DelayedAGwsCF, DelayedEntriesCF,
      DelayedDCEntriesCF, DelayedHTLCsCF, DelayedPoCsCF, DelayedProposedPoCsCF,
      DelayedSecuritiesCF, DelayedRoutingCF, DelayedSubnetsCF, DelayedSCsCF,
-     DelayedH3DexCF, DelayedGwDenormCF, DelayedValidatorsCF, DelayedEntriesV2CF] = CFs,
+     DelayedH3DexCF, DelayedGwDenormCF, DelayedValidatorsCF, DelayedEntriesV2CF, DelayedSubnetworksV1CF] = CFs,
     Ledger =
     #ledger_v1{
         dir=Dir,
@@ -377,7 +381,8 @@ new(Dir, ReadOnly, Options) ->
             state_channels=SCsCF,
             h3dex=H3DexCF,
             validators=ValidatorsCF,
-            entries_v2=EntriesV2CF
+            entries_v2=EntriesV2CF,
+            subnetworks_v1=SubnetworksV1CF
         },
         delayed= #sub_ledger_v1{
             default=DelayedDefaultCF,
@@ -394,7 +399,8 @@ new(Dir, ReadOnly, Options) ->
             state_channels=DelayedSCsCF,
             h3dex=DelayedH3DexCF,
             validators=DelayedValidatorsCF,
-            entries_v2=DelayedEntriesV2CF
+            entries_v2=DelayedEntriesV2CF,
+            subnetworks_v1=DelayedSubnetworksV1CF
         }
     },
     Ledger.
@@ -912,7 +918,8 @@ atom_to_cf(Atom, Ledger) ->
             state_channels -> SL#sub_ledger_v1.state_channels;
             h3dex -> SL#sub_ledger_v1.h3dex;
             validators -> SL#sub_ledger_v1.validators;
-            entries_v2 -> SL#sub_ledger_v1.entries_v2
+            entries_v2 -> SL#sub_ledger_v1.entries_v2;
+            subnetworks_v1 -> SL#sub_ledger_v1.subnetworks_v1
         end.
 
 apply_raw_changes(Changes, #ledger_v1{db = DB} = Ledger) ->
@@ -1336,6 +1343,33 @@ write_gw_denorm_values(Address, Old, Gw, Ledger) ->
     case Gain == OldGain of
         true -> ok;
             _ -> cache_put(Ledger, GwDenormCF, <<Address/binary, "-gain">>, term_to_binary(Gain))
+    end.
+
+-spec subnetworks_v1(ledger()) -> subnetworks_v1().
+subnetworks_v1(Ledger) ->
+    SubnetworksV1CF = subnetworks_v1_cf(Ledger),
+    cache_fold(
+        Ledger,
+        SubnetworksV1CF,
+        fun({TT, Binary}, Acc) ->
+            SN = blockchain_ledger_subnetwork_v1:deserialize(Binary),
+            maps:put(TT, SN, Acc)
+        end,
+        #{}
+    ).
+
+-spec find_subnetwork_v1(TT :: blockchain_token_v1:type(), Ledger :: ledger()) ->
+    {ok, blockchain_ledger_subnetwork_v1:subnetwork_v1()}
+    | {error, any()}.
+find_subnetwork_v1(TT, Ledger) ->
+    SNCF = subnetworks_v1_cf(Ledger),
+    case cache_get(Ledger, SNCF, TT, []) of
+        {ok, BinEntry} ->
+            {ok, blockchain_ledger_subnetwork_v1:deserialize(BinEntry)};
+        not_found ->
+            {error, subnetwork_not_found};
+        Error ->
+            Error
     end.
 
 -spec entries(ledger()) -> entries() | entries_v2().
@@ -2952,6 +2986,25 @@ migrate_sec_entries(Ledger) ->
         ok
     ).
 
+-spec add_subnetwork(TT :: blockchain_token_v1:type(),
+                     SNTreasury :: non_neg_integer(),
+                     HNTTreasury :: non_neg_integer(),
+                     SNKey :: libp2p_crypto:pubkey_bin(),
+                     RollupKeys :: [libp2p_crypto:pubkey_bin()],
+                     Ledger :: ledger()) -> ok | {error, any()}.
+add_subnetwork(TT, SNTreasury, HNTTreasury, SNKey, RollupKeys, Ledger) ->
+    SubnetworksV1CF = subnetworks_v1_cf(Ledger),
+    case ?MODULE:find_subnetwork_v1(TT, Ledger) of
+        {error, address_entry_not_found} ->
+            SN = blockchain_ledger_subnetwork_v1:new(TT, SNTreasury, HNTTreasury, SNKey, RollupKeys),
+            Bin = blockchain_ledger_entry_v1:serialize(SN),
+            cache_put(Ledger, SubnetworksV1CF, TT, Bin);
+        {ok, _SN} ->
+            {error, subnetwork_already_exists};
+        {error, _}=Error ->
+            Error
+    end.
+
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -4320,6 +4373,11 @@ entries_v2_cf(Ledger) ->
     SL = subledger(Ledger),
     {entries_v2, db(Ledger), SL#sub_ledger_v1.entries_v2}.
 
+-spec subnetworks_v1_cf(ledger()) -> tagged_cf().
+subnetworks_v1_cf(Ledger) ->
+    SL = subledger(Ledger),
+    {subnetworks_v1, db(Ledger), SL#sub_ledger_v1.subnetworks_v1}.
+
 -spec dc_entries_cf(ledger()) -> tagged_cf().
 dc_entries_cf(Ledger) ->
     SL = subledger(Ledger),
@@ -4668,7 +4726,7 @@ open_db_(DBDir, DBOptions, DefaultCFs, CFOpts, ReadOnly, Retry) ->
 default_cfs() ->
     ["default", "active_gateways", "entries", "dc_entries", "htlcs",
      "pocs", "proposed_pocs", "securities", "routing", "subnets",
-     "state_channels", "h3dex", "gw_denorm", "validators", "entries_v2"].
+     "state_channels", "h3dex", "gw_denorm", "validators", "entries_v2", "subnetworks_v1"].
 
 -spec delayed_cfs() -> list().
 delayed_cfs() ->

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -3007,6 +3007,8 @@ add_subnetwork(TT, TokenTreasury, HNTTreasury, SNKey, RewardServerKeys, Ledger) 
             Error
     end.
 
+-spec update_subnetwork(SN :: blockchain_ledger_subnetwork_v1:subnetwork_v1(),
+                        Ledger :: ledger()) -> ok.
 update_subnetwork(SN, Ledger) ->
     SubnetworksV1CF = subnetworks_v1_cf(Ledger),
     TT = blockchain_ledger_subnetwork_v1:type(SN),

--- a/src/ledger/v1/blockchain_ledger_v1.hrl
+++ b/src/ledger/v1/blockchain_ledger_v1.hrl
@@ -41,7 +41,8 @@
     validators :: rocksdb:cf_handle(),
     cache :: undefined | direct | ets:tid(),
     gateway_cache :: undefined | ets:tid(),
-    entries_v2 :: rocksdb:cf_handle()
+    entries_v2 :: rocksdb:cf_handle(),
+    subnetworks_v1 :: rocksdb:cf_handle()
 }).
 
 -record(aux_ledger_v1, {

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -47,7 +47,11 @@
              | blockchain_txn_unstake_validator_v1:txn_unstake_validator()
              | blockchain_txn_unstake_validator_v1:txn_validator_heartbeat()
              | blockchain_txn_transfer_hotspot_v2:txn_transfer_hotspot_v2()
-             | blockchain_txn_poc_receipts_v2:txn_poc_receipts_v2().
+             | blockchain_txn_poc_receipts_v2:txn_poc_receipts_v2()
+             | blockchain_txn_add_subnetwork_v1:txn_add_subnetwork_v1()
+             | blockchain_txn_update_subnetwork_v1:txn_update_subnetwork_v1()
+             | blockchain_txn_subnetwork_rewards_v1:txn_subnetwork_rewards_v1()
+             | blockchain_txn_token_convert_v1:txn_token_convert_v1().
 
 -type before_commit_callback() :: fun((blockchain:blockchain(), blockchain_block:hash()) -> ok | {error, any()}).
 -type txns() :: [txn()].
@@ -139,7 +143,11 @@
     {blockchain_txn_gen_price_oracle_v1, 34},
     {blockchain_txn_consensus_group_failure_v1, 35},
     {blockchain_txn_transfer_hotspot_v2, 36},
-    {blockchain_txn_poc_receipts_v2, 37}
+    {blockchain_txn_poc_receipts_v2, 37},
+    {blockchain_txn_add_subnetwork_v1, 38},
+    {blockchain_txn_update_subnetwork_v1, 39},
+    {blockchain_txn_subnetwork_rewards_v1, 40},
+    {blockchain_txn_token_convert_v1, 41}
 ]).
 
 block_delay() ->
@@ -250,8 +258,15 @@ wrap_txn(#blockchain_txn_consensus_group_failure_v1_pb{} = Txn) ->
 wrap_txn(#blockchain_txn_transfer_hotspot_v2_pb{}=Txn) ->
     #blockchain_txn_pb{txn={transfer_hotspot_v2, Txn}};
 wrap_txn(#blockchain_txn_poc_receipts_v2_pb{}=Txn) ->
-    #blockchain_txn_pb{txn={poc_receipts_v2, Txn}}.
-
+    #blockchain_txn_pb{txn={poc_receipts_v2, Txn}};
+wrap_txn(#blockchain_txn_add_subnetwork_v1_pb{}=Txn) ->
+    #blockchain_txn_pb{txn={add_subnetwork, Txn}};
+wrap_txn(#blockchain_txn_update_subnetwork_v1_pb{}=Txn) ->
+    #blockchain_txn_pb{txn={update_subnetwork, Txn}};
+wrap_txn(#blockchain_txn_subnetwork_rewards_v1_pb{}=Txn) ->
+    #blockchain_txn_pb{txn={subnetwork_rewards, Txn}};
+wrap_txn(#blockchain_txn_token_convert_v1_pb{}=Txn) ->
+    #blockchain_txn_pb{txn={token_convert, Txn}}.
 
 -spec unwrap_txn(#blockchain_txn_pb{}) -> blockchain_txn:txn().
 unwrap_txn(#blockchain_txn_pb{txn={bundle, #blockchain_txn_bundle_v1_pb{transactions=Txns} = Bundle}}) ->
@@ -710,7 +725,15 @@ type(#blockchain_txn_validator_heartbeat_v1_pb{}) ->
 type(#blockchain_txn_transfer_hotspot_v2_pb{}) ->
     blockchain_txn_transfer_hotspot_v2;
 type(#blockchain_txn_poc_receipts_v2_pb{}) ->
-    blockchain_txn_poc_receipts_v2.
+    blockchain_txn_poc_receipts_v2;
+type(#blockchain_txn_add_subnetwork_v1_pb{}) ->
+    blockchain_txn_add_subnetwork_v1;
+type(#blockchain_txn_update_subnetwork_v1_pb{}) ->
+    blockchain_txn_update_subnetwork_v1;
+type(#blockchain_txn_subnetwork_rewards_v1_pb{}) ->
+    blockchain_txn_subnetwork_rewards_v1;
+type(#blockchain_txn_token_convert_v1_pb{}) ->
+    blockchain_txn_token_convert_v1.
 
 -spec validate_fields([{{atom(), iodata() | undefined},
                         {binary, pos_integer()} |

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -51,7 +51,7 @@
              | blockchain_txn_add_subnetwork_v1:txn_add_subnetwork_v1()
              | blockchain_txn_update_subnetwork_v1:txn_update_subnetwork_v1()
              | blockchain_txn_subnetwork_rewards_v1:txn_subnetwork_rewards_v1()
-             | blockchain_txn_token_convert_v1:txn_token_convert_v1().
+             | blockchain_txn_token_redeem_v1:txn_token_redeem_v1().
 
 -type before_commit_callback() :: fun((blockchain:blockchain(), blockchain_block:hash()) -> ok | {error, any()}).
 -type txns() :: [txn()].
@@ -147,7 +147,7 @@
     {blockchain_txn_add_subnetwork_v1, 38},
     {blockchain_txn_update_subnetwork_v1, 39},
     {blockchain_txn_subnetwork_rewards_v1, 40},
-    {blockchain_txn_token_convert_v1, 41}
+    {blockchain_txn_token_redeem_v1, 41}
 ]).
 
 block_delay() ->
@@ -265,8 +265,8 @@ wrap_txn(#blockchain_txn_update_subnetwork_v1_pb{}=Txn) ->
     #blockchain_txn_pb{txn={update_subnetwork, Txn}};
 wrap_txn(#blockchain_txn_subnetwork_rewards_v1_pb{}=Txn) ->
     #blockchain_txn_pb{txn={subnetwork_rewards, Txn}};
-wrap_txn(#blockchain_txn_token_convert_v1_pb{}=Txn) ->
-    #blockchain_txn_pb{txn={token_convert, Txn}}.
+wrap_txn(#blockchain_txn_token_redeem_v1_pb{}=Txn) ->
+    #blockchain_txn_pb{txn={token_redeem, Txn}}.
 
 -spec unwrap_txn(#blockchain_txn_pb{}) -> blockchain_txn:txn().
 unwrap_txn(#blockchain_txn_pb{txn={bundle, #blockchain_txn_bundle_v1_pb{transactions=Txns} = Bundle}}) ->
@@ -732,8 +732,8 @@ type(#blockchain_txn_update_subnetwork_v1_pb{}) ->
     blockchain_txn_update_subnetwork_v1;
 type(#blockchain_txn_subnetwork_rewards_v1_pb{}) ->
     blockchain_txn_subnetwork_rewards_v1;
-type(#blockchain_txn_token_convert_v1_pb{}) ->
-    blockchain_txn_token_convert_v1.
+type(#blockchain_txn_token_redeem_v1_pb{}) ->
+    blockchain_txn_token_redeem_v1.
 
 -spec validate_fields([{{atom(), iodata() | undefined},
                         {binary, pos_integer()} |

--- a/src/transactions/v1/blockchain_txn_add_subnetwork_v1.erl
+++ b/src/transactions/v1/blockchain_txn_add_subnetwork_v1.erl
@@ -85,12 +85,14 @@ subnetwork_signature(Txn) ->
 
 -spec sign(txn_add_subnetwork(), libp2p_crypto:sig_fun()) -> txn_add_subnetwork().
 sign(Txn, SigFun) ->
-    EncodedTxn = blockchain_txn_add_subnetwork_v1_pb:encode_msg(Txn),
+    BaseTxn = unset_signatures(Txn),
+    EncodedTxn = blockchain_txn_add_subnetwork_v1_pb:encode_msg(BaseTxn),
     Txn#blockchain_txn_add_subnetwork_v1_pb{network_signature = SigFun(EncodedTxn)}.
 
 -spec sign_subnetwork(txn_add_subnetwork(), libp2p_crypto:sig_fun()) -> txn_add_subnetwork().
 sign_subnetwork(Txn, SigFun) ->
-    EncodedTxn = blockchain_txn_add_subnetwork_v1_pb:encode_msg(Txn),
+    BaseTxn = unset_signatures(Txn),
+    EncodedTxn = blockchain_txn_add_subnetwork_v1_pb:encode_msg(BaseTxn),
     Txn#blockchain_txn_add_subnetwork_v1_pb{subnetwork_signature = SigFun(EncodedTxn)}.
 
 -spec hash(txn_add_subnetwork()) -> blockchain_txn:hash().

--- a/src/transactions/v1/blockchain_txn_add_subnetwork_v1.erl
+++ b/src/transactions/v1/blockchain_txn_add_subnetwork_v1.erl
@@ -114,7 +114,7 @@ fee_payer(_Txn, _Ledger) ->
 is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     PremineAmt = premine(Txn),
-    case PremineAmt > 0 of
+    case PremineAmt >= 0 of
         false ->
             {error, invalid_premine_amount};
         true ->

--- a/src/transactions/v1/blockchain_txn_add_subnetwork_v1.erl
+++ b/src/transactions/v1/blockchain_txn_add_subnetwork_v1.erl
@@ -121,7 +121,7 @@ is_valid(Txn, Chain) ->
         hnt ->
             {error, invalid_token_hnt};
         _ ->
-            case blockchain:config(?allowed_reward_server_key_length, Ledger) of
+            case blockchain:config(?allowed_num_reward_server_keys, Ledger) of
                 {ok, 1} ->
                     Artifact = create_artifact(Txn),
                     SubnetworkKey = ?MODULE:subnetwork_key(Txn),

--- a/src/transactions/v1/blockchain_txn_add_subnetwork_v1.erl
+++ b/src/transactions/v1/blockchain_txn_add_subnetwork_v1.erl
@@ -1,0 +1,158 @@
+%%%-------------------------------------------------------------------
+%% @doc
+%% == Blockchain Txn to add a subnetwork token to the network ==
+%% @end
+%%%-------------------------------------------------------------------
+-module(blockchain_txn_add_subnetwork_v1).
+
+-behavior(blockchain_txn).
+
+-behavior(blockchain_json).
+-include("blockchain_json.hrl").
+-include("blockchain_utils.hrl").
+
+-include_lib("helium_proto/include/blockchain_txn_add_subnetwork_v1_pb.hrl").
+
+-export([
+    new/4,
+    token_type/1,
+    subnetwork_key/1,
+    reward_server_keys/1,
+    premine/1,
+    network_signature/1,
+    subnetwork_signature/1,
+    sign/2,
+    sign_subnetwork/2,
+    hash/1,
+
+    fee/1,
+    fee_payer/2,
+    is_valid/2,
+    absorb/2,
+
+    print/1,
+    json_type/0,
+    to_json/2
+]).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-type txn_add_subnetwork() :: #blockchain_txn_add_subnetwork_v1_pb{}.
+-export_type([txn_add_subnetwork/0]).
+
+-spec new(
+    TT :: blockchain_token_v1:type(),
+    SubnetworkKey :: libp2p_crypto:pubkey_bin(),
+    RewardServerKeys :: [libp2p_crypto:pubkey_bin()],
+    PremineAmt :: non_neg_integer()
+) -> txn_add_subnetwork().
+new(TT, SubnetworkKey, RewardServerKeys, PremineAmt) ->
+    #blockchain_txn_add_subnetwork_v1_pb{
+        token_type = TT,
+        subnetwork_key = SubnetworkKey,
+        reward_server_keys = lists:sort(RewardServerKeys),
+        premine = PremineAmt,
+        network_signature = <<>>,
+        subnetwork_signature = <<>>
+    }.
+
+-spec token_type(Txn :: txn_add_subnetwork()) -> blockchain_token_v1:token_type().
+token_type(Txn) ->
+    Txn#blockchain_txn_add_subnetwork_v1_pb.token_type.
+
+-spec subnetwork_key(Txn :: txn_add_subnetwork()) -> libp2p_crypto:pubkey_bin().
+subnetwork_key(Txn) ->
+    Txn#blockchain_txn_add_subnetwork_v1_pb.subnetwork_key.
+
+-spec reward_server_keys(Txn :: txn_add_subnetwork()) -> [libp2p_crypto:pubkey_bin()].
+reward_server_keys(Txn) ->
+    Txn#blockchain_txn_add_subnetwork_v1_pb.reward_server_keys.
+
+-spec premine(Txn :: txn_add_subnetwork()) -> non_neg_integer().
+premine(Txn) ->
+    Txn#blockchain_txn_add_subnetwork_v1_pb.premine.
+
+-spec network_signature(txn_add_subnetwork()) -> binary().
+network_signature(Txn) ->
+    Txn#blockchain_txn_add_subnetwork_v1_pb.network_signature.
+
+-spec subnetwork_signature(txn_add_subnetwork()) -> binary().
+subnetwork_signature(Txn) ->
+    Txn#blockchain_txn_add_subnetwork_v1_pb.subnetwork_signature.
+
+-spec sign(txn_add_subnetwork(), libp2p_crypto:sig_fun()) -> txn_add_subnetwork().
+sign(Txn, SigFun) ->
+    EncodedTxn = blockchain_txn_add_subnetwork_v1_pb:encode_msg(Txn),
+    Txn#blockchain_txn_add_subnetwork_v1_pb{network_signature = SigFun(EncodedTxn)}.
+
+-spec sign_subnetwork(txn_add_subnetwork(), libp2p_crypto:sig_fun()) -> txn_add_subnetwork().
+sign_subnetwork(Txn, SigFun) ->
+    EncodedTxn = blockchain_txn_add_subnetwork_v1_pb:encode_msg(Txn),
+    Txn#blockchain_txn_add_subnetwork_v1_pb{subnetwork_signature = SigFun(EncodedTxn)}.
+
+-spec hash(txn_add_subnetwork()) -> blockchain_txn:hash().
+hash(Txn) ->
+    BaseTxn = Txn#blockchain_txn_add_subnetwork_v1_pb{
+        network_signature = <<>>, subnetwork_signature = <<>>
+    },
+    EncodedTxn = blockchain_txn_add_subnetwork_v1_pb:encode_msg(BaseTxn),
+    crypto:hash(sha256, EncodedTxn).
+
+-spec fee(Txn :: txn_add_subnetwork()) -> non_neg_integer().
+fee(_Txn) ->
+    0.
+
+-spec fee_payer(Txn :: txn_add_subnetwork(), Ledger :: blockchain_ledger_v1:ledger()) -> undefined.
+fee_payer(_Txn, _Ledger) ->
+    undefined.
+
+-spec is_valid(Txn :: txn_add_subnetwork(), Chain :: blockchain:blockchain()) ->
+    ok | {error, any()}.
+is_valid(Txn, Chain) ->
+    %% TODO
+    ok.
+
+-spec absorb(Txn :: txn_add_subnetwork(), Chain :: blockchain:blockchain()) -> ok | {error, any()}.
+absorb(Txn, Chain) ->
+    %% TODO
+    ok.
+
+-spec print(txn_add_subnetwork()) -> iodata().
+print(undefined) ->
+    <<"type=add_subnetwork_v1, undefined">>;
+print(
+    #blockchain_txn_add_subnetwork_v1_pb{
+        token_type = TT,
+        subnetwork_key = SKey,
+        reward_server_keys = RKeys,
+        premine = PremineAmt,
+        network_signature = NS,
+        subnetwork_signature = SS
+    }
+) ->
+    io_lib:format(
+        "type=add_subnetwork_v1, token_type=~p, premine=~p, subnetwork_key=~p, reward_server_keys=~p, network_signature=~s~n subnetwork_signature: ~s",
+        [
+            atom_to_list(TT),
+            PremineAmt,
+            ?TO_B58(SKey),
+            [?TO_B58(RKey) || RKey <- RKeys],
+            ?TO_B58(NS),
+            ?TO_B58(SS)
+        ]
+    ).
+
+json_type() ->
+    <<"add_subnetwork_v1">>.
+
+-spec to_json(txn_add_subnetwork(), blockchain_json:opts()) -> blockchain_json:json_object().
+to_json(Txn, _Opts) ->
+    #{
+        type => ?MODULE:json_type(),
+        hash => ?BIN_TO_B64(hash(Txn)),
+        token_type => atom_to_list(token_type(Txn)),
+        subnetwork_key => ?BIN_TO_B58(subnetwork_key(Txn)),
+        reward_server_keys => [?BIN_TO_B58(K) || K <- reward_server_keys(Txn)]
+    }.

--- a/src/transactions/v1/blockchain_txn_add_subnetwork_v1.erl
+++ b/src/transactions/v1/blockchain_txn_add_subnetwork_v1.erl
@@ -97,10 +97,7 @@ sign_subnetwork(Txn, SigFun) ->
 
 -spec hash(txn_add_subnetwork()) -> blockchain_txn:hash().
 hash(Txn) ->
-    BaseTxn = Txn#blockchain_txn_add_subnetwork_v1_pb{
-        network_signature = <<>>,
-        subnetwork_signature = <<>>
-    },
+    BaseTxn = unset_signatures(Txn),
     EncodedTxn = blockchain_txn_add_subnetwork_v1_pb:encode_msg(BaseTxn),
     crypto:hash(sha256, EncodedTxn).
 

--- a/src/transactions/v1/blockchain_txn_add_subnetwork_v1.erl
+++ b/src/transactions/v1/blockchain_txn_add_subnetwork_v1.erl
@@ -151,8 +151,22 @@ is_valid(Txn, Chain) ->
 
 -spec absorb(Txn :: txn_add_subnetwork(), Chain :: blockchain:blockchain()) -> ok | {error, any()}.
 absorb(Txn, Chain) ->
-    %% FIXME
-    ok.
+    Ledger = blockchain:ledger(Chain),
+    TT = ?MODULE:token_type(Txn),
+    PremineAmt = ?MODULE:premine(Txn),
+    HNTTreasury = 0,
+    SubnetworkKey = ?MODULE:subnetwork_key(Txn),
+    RewardServerKeys = ?MODULE:reward_server_keys(Txn),
+    case
+        blockchain_ledger_v1:add_subnetwork(
+            TT, PremineAmt, HNTTreasury, SubnetworkKey, RewardServerKeys, Ledger
+        )
+    of
+        ok ->
+            ok;
+        {error, _} = Error ->
+            Error
+    end.
 
 -spec print(txn_add_subnetwork()) -> iodata().
 print(undefined) ->

--- a/src/transactions/v1/blockchain_txn_add_subnetwork_v1.erl
+++ b/src/transactions/v1/blockchain_txn_add_subnetwork_v1.erl
@@ -127,7 +127,7 @@ is_valid(Txn, Chain) ->
                     case blockchain:config(?allow_multiple_reward_server_keys, Ledger) of
                         true ->
                             %% FIXME
-                            {error, todo};
+                            {error, fixme};
                         _ ->
                             %% NOTE: We are only allowing a single reward server key
                             case length(reward_server_keys(Txn)) == 1 of
@@ -143,7 +143,7 @@ is_valid(Txn, Chain) ->
 
 -spec absorb(Txn :: txn_add_subnetwork(), Chain :: blockchain:blockchain()) -> ok | {error, any()}.
 absorb(Txn, Chain) ->
-    %% TODO
+    %% FIXME
     ok.
 
 -spec print(txn_add_subnetwork()) -> iodata().

--- a/src/transactions/v1/blockchain_txn_add_subnetwork_v1.erl
+++ b/src/transactions/v1/blockchain_txn_add_subnetwork_v1.erl
@@ -98,7 +98,8 @@ sign_subnetwork(Txn, SigFun) ->
 -spec hash(txn_add_subnetwork()) -> blockchain_txn:hash().
 hash(Txn) ->
     BaseTxn = Txn#blockchain_txn_add_subnetwork_v1_pb{
-        network_signature = <<>>, subnetwork_signature = <<>>
+        network_signature = <<>>,
+        subnetwork_signature = <<>>
     },
     EncodedTxn = blockchain_txn_add_subnetwork_v1_pb:encode_msg(BaseTxn),
     crypto:hash(sha256, EncodedTxn).
@@ -153,16 +154,14 @@ absorb(Txn, Chain) ->
     HNTTreasury = 0,
     SubnetworkKey = ?MODULE:subnetwork_key(Txn),
     RewardServerKeys = ?MODULE:reward_server_keys(Txn),
-    case
-        blockchain_ledger_v1:add_subnetwork(
-            TT, PremineAmt, HNTTreasury, SubnetworkKey, RewardServerKeys, Ledger
-        )
-    of
-        ok ->
-            ok;
-        {error, _} = Error ->
-            Error
-    end.
+    blockchain_ledger_v1:add_subnetwork(
+        TT,
+        PremineAmt,
+        HNTTreasury,
+        SubnetworkKey,
+        RewardServerKeys,
+        Ledger
+    ).
 
 -spec print(txn_add_subnetwork()) -> iodata().
 print(undefined) ->
@@ -197,7 +196,7 @@ to_json(Txn, _Opts) ->
     #{
         type => ?MODULE:json_type(),
         hash => ?BIN_TO_B64(hash(Txn)),
-        token_type => atom_to_list(token_type(Txn)),
+        token_type => atom_to_binary(token_type(Txn), utf8),
         subnetwork_key => ?BIN_TO_B58(subnetwork_key(Txn)),
         reward_server_keys => [?BIN_TO_B58(K) || K <- reward_server_keys(Txn)]
     }.

--- a/src/transactions/v1/blockchain_txn_subnetwork_rewards_v1.erl
+++ b/src/transactions/v1/blockchain_txn_subnetwork_rewards_v1.erl
@@ -1,14 +1,7 @@
 %%-------------------------------------------------------------------
 %% @doc
-%% This module implements rewards v2 which track only an account and
-%% an amount. The breakdowns of rewards by type and associated gateway
-%% are not kept here.  This was done to streamline the increasing
-%% size of rewards as the network grows.
-%%
-%% In the future, we will need to work on further ways to streamline
-%% the size of this transaction. One proposal was to use the ledger
-%% as an encoding dictionary and use ledger offsets to mark the
-%% account instead of using the full sized account id.
+%% This module implements subnetwork rewards, which will be driven
+%% externally via reward server(s).
 %% @end
 %%%-------------------------------------------------------------------
 -module(blockchain_txn_subnetwork_rewards_v1).
@@ -242,14 +235,18 @@ total_rewards(Txn) ->
 
 -spec print(txn_subnetwork_rewards_v1()) -> iodata().
 print(undefined) ->
-    <<"type=rewards_v2 undefined">>;
-print(#blockchain_txn_subnetwork_rewards_v1_pb{
-    start_epoch = Start,
-    end_epoch = End
-}) ->
+    <<"type=subnetwork_rewards_v1 undefined">>;
+print(
+    #blockchain_txn_subnetwork_rewards_v1_pb{
+        start_epoch = Start,
+        end_epoch = End,
+        token_type = TT,
+        rewards = Rewards
+    } = Txn
+) ->
     io_lib:format(
-        "type=rewards_v2 start_epoch=~p end_epoch=~p",
-        [Start, End]
+        "type=subnetwork_rewards_v1 start_epoch=~p end_epoch=~p token_type=~p rewards_hash=~p total_rewards=~p",
+        [Start, End, TT, crypto:hash(sha256, term_to_binary(Rewards)), total_rewards(Txn)]
     ).
 
 json_type() ->

--- a/src/transactions/v1/blockchain_txn_subnetwork_rewards_v1.erl
+++ b/src/transactions/v1/blockchain_txn_subnetwork_rewards_v1.erl
@@ -58,14 +58,16 @@
 %% Public API
 %% ------------------------------------------------------------------
 
--spec new(blockchain_token_v1:type(), non_neg_integer(), non_neg_integer(), rewards()) -> txn_subnetwork_rewards_v1().
+-spec new(blockchain_token_v1:type(), non_neg_integer(), non_neg_integer(), rewards()) ->
+    txn_subnetwork_rewards_v1().
 new(Type, Start, End, Rewards) ->
     SortedRewards = lists:sort(Rewards),
     #blockchain_txn_subnetwork_rewards_v1_pb{
-       token_type = Type,
-       start_epoch=Start,
-       end_epoch=End,
-       rewards=SortedRewards}.
+        token_type = Type,
+        start_epoch = Start,
+        end_epoch = End,
+        rewards = SortedRewards
+    }.
 
 -spec hash(txn_subnetwork_rewards_v1()) -> blockchain_txn:hash().
 hash(Txn) ->
@@ -77,15 +79,15 @@ token_type(#blockchain_txn_subnetwork_rewards_v1_pb{token_type = Type}) ->
     Type.
 
 -spec start_epoch(txn_subnetwork_rewards_v1()) -> non_neg_integer().
-start_epoch(#blockchain_txn_subnetwork_rewards_v1_pb{start_epoch=Start}) ->
+start_epoch(#blockchain_txn_subnetwork_rewards_v1_pb{start_epoch = Start}) ->
     Start.
 
 -spec end_epoch(txn_subnetwork_rewards_v1()) -> non_neg_integer().
-end_epoch(#blockchain_txn_subnetwork_rewards_v1_pb{end_epoch=End}) ->
+end_epoch(#blockchain_txn_subnetwork_rewards_v1_pb{end_epoch = End}) ->
     End.
 
 -spec rewards(txn_subnetwork_rewards_v1()) -> rewards().
-rewards(#blockchain_txn_subnetwork_rewards_v1_pb{rewards=Rewards}) ->
+rewards(#blockchain_txn_subnetwork_rewards_v1_pb{rewards = Rewards}) ->
     Rewards.
 
 -spec reward_account(subnetwork_reward_v1()) -> binary().
@@ -96,10 +98,12 @@ reward_account(#blockchain_txn_subnetwork_reward_v1_pb{account = Account}) ->
 reward_amount(#blockchain_txn_subnetwork_reward_v1_pb{amount = Amount}) ->
     Amount.
 
--spec new_reward( Account :: libp2p_crypto:pubkey_bin(),
-                  Amount :: non_neg_integer() ) -> subnetwork_reward_v1().
+-spec new_reward(
+    Account :: libp2p_crypto:pubkey_bin(),
+    Amount :: non_neg_integer()
+) -> subnetwork_reward_v1().
 new_reward(Account, Amount) ->
-    #blockchain_txn_subnetwork_reward_v1_pb{account=Account, amount=Amount}.
+    #blockchain_txn_subnetwork_reward_v1_pb{account = Account, amount = Amount}.
 
 reward_server_signature(#blockchain_txn_subnetwork_rewards_v1_pb{reward_server_signature = RSS}) ->
     RSS.
@@ -108,49 +112,55 @@ reward_server_signature(#blockchain_txn_subnetwork_rewards_v1_pb{reward_server_s
 sign(Txn, SigFun) ->
     BaseTxn = Txn#blockchain_txn_subnetwork_rewards_v1_pb{reward_server_signature = <<>>},
     EncodedTxn = blockchain_txn_subnetwork_rewards_v1_pb:encode_msg(BaseTxn),
-    Txn#blockchain_txn_subnetwork_rewards_v1_pb{reward_server_signature=SigFun(EncodedTxn)}.
+    Txn#blockchain_txn_subnetwork_rewards_v1_pb{reward_server_signature = SigFun(EncodedTxn)}.
 
 -spec fee(txn_subnetwork_rewards_v1()) -> 0.
 fee(_Txn) ->
     0.
 
--spec fee_payer(txn_subnetwork_rewards_v1(), blockchain_ledger_v1:ledger()) -> libp2p_crypto:pubkey_bin() | undefined.
+-spec fee_payer(txn_subnetwork_rewards_v1(), blockchain_ledger_v1:ledger()) ->
+    libp2p_crypto:pubkey_bin() | undefined.
 fee_payer(_Txn, _Ledger) ->
     undefined.
 
--spec is_valid(txn_subnetwork_rewards_v1(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
+-spec is_valid(txn_subnetwork_rewards_v1(), blockchain:blockchain()) ->
+    ok | {error, atom()} | {error, {atom(), any()}}.
 is_valid(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
     Start = ?MODULE:start_epoch(Txn),
     End = ?MODULE:end_epoch(Txn),
-    %% Rewards = ?MODULE:rewards(Txn),
+    Rewards = ?MODULE:rewards(Txn),
     TokenType = token_type(Txn),
     Signature = reward_server_signature(Txn),
     %% make sure that the signature is correct
     %% make sure that the rewards are less than the amount stored
     {ok, Subnet} = blockchain_ledger_v1:find_subnetwork_v1(TokenType, Ledger),
-    %% TotalRewards = lists:foldl(
-    %%                  fun(Reward, Acc) ->
-    %%                          Acc + reward_amount(Reward)
-    %%                  end,
-    %%                  0,
-    %%                  Rewards),
-    %% Tokens = blockchain_ledger_subnetwork_v1:token_amount(Subnet),
+    TotalRewards = lists:foldl(
+        fun(Reward, Acc) ->
+            Acc + reward_amount(Reward)
+        end,
+        0,
+        Rewards
+    ),
+    Tokens = blockchain_ledger_subnetwork_v1:token_treasury(Subnet),
     LastRewardedBlock = blockchain_ledger_subnetwork_v1:last_rewarded_block(Subnet),
     try
         %% this needs to somehow limit the mint here?  but if there is only premine I don't
         %% understand how we do that.
-
-        %% case TotalRewards =< blockchain_ledger_subnetwork_v1:token_amount(Subnet) of
-        %%     true -> ok;
-        %%     false -> throw({insufficient_tokens_to_fulfil_rewards, Tokens, TotalRewards})
-        %% end
+        case TotalRewards =< blockchain_ledger_subnetwork_v1:token_treasury(Subnet) of
+            true -> ok;
+            false -> throw({insufficient_tokens_to_fulfil_rewards, Tokens, TotalRewards})
+        end,
         BaseTxn = Txn#blockchain_txn_subnetwork_rewards_v1_pb{reward_server_signature = <<>>},
         Artifact = blockchain_txn_subnetwork_rewards_v1_pb:encode_msg(BaseTxn),
-        case lists:any(
-               fun(Key) ->
-                       libp2p_crypto:verify(Artifact, Signature, libp2p_crypto:bin_to_pubkey(Key))
-               end, blockchain_ledger_subnetwork_v1:reward_server_keys(Subnet)) of
+        case
+            lists:any(
+                fun(Key) ->
+                    libp2p_crypto:verify(Artifact, Signature, libp2p_crypto:bin_to_pubkey(Key))
+                end,
+                blockchain_ledger_subnetwork_v1:reward_server_keys(Subnet)
+            )
+        of
             true -> ok;
             false -> throw(invalid_signature)
         end,
@@ -158,11 +168,13 @@ is_valid(Txn, Chain) ->
             true -> ok;
             false -> throw({invalid_reward_range, Start, End, LastRewardedBlock})
         end
-    catch throw:Err ->
+    catch
+        throw:Err ->
             {error, Err}
     end.
 
--spec absorb(txn_subnetwork_rewards_v1(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
+-spec absorb(txn_subnetwork_rewards_v1(), blockchain:blockchain()) ->
+    ok | {error, atom()} | {error, {atom(), any()}}.
 absorb(Txn, Chain) ->
     Ledger = blockchain:ledger(Chain),
 
@@ -183,9 +195,9 @@ absorb(Txn, Chain) ->
                     ok = blockchain_ledger_v1:net_overage(Overage1, Ledger);
                 %% else we may have pulled from overage to the tune of
                 %% max - burned
-                 _ ->
+                _ ->
                     %% here we pulled from overage up to max
-                    case (Max - Burned) < Overage  of
+                    case (Max - Burned) < Overage of
                         %% emitted max, pulled from overage
                         true ->
                             Overage1 = Overage - (Max - Burned),
@@ -206,22 +218,29 @@ absorb(Txn, Chain) ->
     Subnet1 = blockchain_ledger_subnetwork_v1:last_rewarded_block(Subnet, end_epoch(Txn)),
     ok = blockchain_ledger_v1:update_subnetwork(Subnet1, Ledger).
 
--spec absorb_rewards(Rewards :: rewards(),
-                     Ledger :: blockchain_ledger_v1:ledger()) -> ok.
+-spec absorb_rewards(
+    Rewards :: rewards(),
+    Ledger :: blockchain_ledger_v1:ledger()
+) -> ok.
 absorb_rewards(Rewards, Ledger) ->
     lists:foreach(
-        fun(#blockchain_txn_subnetwork_reward_v1_pb{account=Account, amount=Amount}) ->
+        fun(#blockchain_txn_subnetwork_reward_v1_pb{account = Account, amount = Amount}) ->
             ok = blockchain_ledger_v1:credit_account(Account, Amount, Ledger)
         end,
         Rewards
     ).
 
 -spec print(txn_subnetwork_rewards_v1()) -> iodata().
-print(undefined) -> <<"type=rewards_v2 undefined">>;
-print(#blockchain_txn_subnetwork_rewards_v1_pb{start_epoch=Start,
-                                               end_epoch=End}) ->
-    io_lib:format("type=rewards_v2 start_epoch=~p end_epoch=~p",
-                  [Start, End]).
+print(undefined) ->
+    <<"type=rewards_v2 undefined">>;
+print(#blockchain_txn_subnetwork_rewards_v1_pb{
+    start_epoch = Start,
+    end_epoch = End
+}) ->
+    io_lib:format(
+        "type=rewards_v2 start_epoch=~p end_epoch=~p",
+        [Start, End]
+    ).
 
 json_type() ->
     <<"subnetwork_rewards_v1">>.
@@ -235,10 +254,15 @@ to_json(Txn, Opts) ->
                     {error, _Error} ->
                         Acc;
                     {ok, GwOwner} ->
-                        [#{account => ?BIN_TO_B58(GwOwner),
-                           gateway => ?BIN_TO_B58(G),
-                           amount => Amount,
-                           type => Type} | Acc]
+                        [
+                            #{
+                                account => ?BIN_TO_B58(GwOwner),
+                                gateway => ?BIN_TO_B58(G),
+                                amount => Amount,
+                                type => Type
+                            }
+                            | Acc
+                        ]
                 end;
             ({validator, Type, V}, Amount, Ledger, Acc) ->
                 case blockchain_ledger_v1:get_validator(V, Ledger) of
@@ -246,615 +270,90 @@ to_json(Txn, Opts) ->
                         Acc;
                     {ok, Val} ->
                         Owner = blockchain_ledger_validator_v1:owner_address(Val),
-                        [#{account => ?BIN_TO_B58(Owner),
-                           gateway => ?BIN_TO_B58(V),
-                           amount => Amount,
-                           type => Type} | Acc]
+                        [
+                            #{
+                                account => ?BIN_TO_B58(Owner),
+                                gateway => ?BIN_TO_B58(V),
+                                amount => Amount,
+                                type => Type
+                            }
+                            | Acc
+                        ]
                 end;
             ({owner, Type, O}, Amount, _Ledger, Acc) ->
-                [#{account => ?BIN_TO_B58(O),
-                   gateway => undefined,
-                   amount => Amount,
-                   type => Type} | Acc]
+                [
+                    #{
+                        account => ?BIN_TO_B58(O),
+                        gateway => undefined,
+                        amount => Amount,
+                        type => Type
+                    }
+                    | Acc
+                ]
         end,
-    Rewards = case lists:keyfind(chain, 1, Opts) of
-        {chain, Chain} ->
-            Start = start_epoch(Txn),
-            End = end_epoch(Txn),
-            {ok, Ledger} = blockchain:ledger_at(End, Chain),
-            {ok, Metadata} = case lists:keyfind(rewards_metadata, 1, Opts) of
-                                {rewards_metadata, M} -> {ok, M};
-                                _ -> ?MODULE:calculate_rewards_metadata(Start, End, Chain)
-                            end,
-            maps:fold(
-                fun(overages, Amount, Acc) ->
-                        [#{amount => Amount,
-                           type => overages} | Acc];
-                   (_RewardCategory, Rewards, Acc0) ->
-                        maps:fold(
-                        fun(Entry, Amount, Acc) ->
-                            RewardToJson(Entry, Amount, Ledger, Acc)
-                        end, Acc0, Rewards)
-                end, [], Metadata);
-        _ -> [ reward_to_json(R, []) || R <- rewards(Txn)]
-    end,
+    Rewards =
+        case lists:keyfind(chain, 1, Opts) of
+            {chain, Chain} ->
+                Start = start_epoch(Txn),
+                End = end_epoch(Txn),
+                {ok, Ledger} = blockchain:ledger_at(End, Chain),
+                {ok, Metadata} =
+                    case lists:keyfind(rewards_metadata, 1, Opts) of
+                        {rewards_metadata, M} -> {ok, M};
+                        _ -> ?MODULE:calculate_rewards_metadata(Start, End, Chain)
+                    end,
+                maps:fold(
+                    fun
+                        (overages, Amount, Acc) ->
+                            [
+                                #{
+                                    amount => Amount,
+                                    type => overages
+                                }
+                                | Acc
+                            ];
+                        (_RewardCategory, Rewards, Acc0) ->
+                            maps:fold(
+                                fun(Entry, Amount, Acc) ->
+                                    RewardToJson(Entry, Amount, Ledger, Acc)
+                                end,
+                                Acc0,
+                                Rewards
+                            )
+                    end,
+                    [],
+                    Metadata
+                );
+            _ ->
+                [reward_to_json(R, []) || R <- rewards(Txn)]
+        end,
 
     #{
-      type => ?MODULE:json_type(),
-      hash => ?BIN_TO_B64(hash(Txn)),
-      start_epoch => start_epoch(Txn),
-      end_epoch => end_epoch(Txn),
-      rewards => Rewards
+        type => ?MODULE:json_type(),
+        hash => ?BIN_TO_B64(hash(Txn)),
+        start_epoch => start_epoch(Txn),
+        end_epoch => end_epoch(Txn),
+        rewards => Rewards
     }.
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions
 %% ------------------------------------------------------------------
 
-
--spec reward_to_json( Reward :: subnetwork_reward_v1(),
-                      Opts :: blockchain_json:opts() ) -> blockchain_json:json_object().
+-spec reward_to_json(
+    Reward :: subnetwork_reward_v1(),
+    Opts :: blockchain_json:opts()
+) -> blockchain_json:json_object().
 reward_to_json(#blockchain_txn_subnetwork_reward_v1_pb{account = Account, amount = Amt}, _Opts) ->
     #{
-      type => <<"subnetwork_reward_v1">>,
-      account => ?BIN_TO_B58(Account),
-      amount => Amt
-     }.
+        type => <<"subnetwork_reward_v1">>,
+        account => ?BIN_TO_B58(Account),
+        amount => Amt
+    }.
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests
 %% ------------------------------------------------------------------
 -ifdef(TEST).
-
-new_test() ->
-    Tx = #blockchain_txn_rewards_v2_pb{start_epoch=1, end_epoch=30, rewards=[]},
-    ?assertEqual(Tx, new(1, 30, [])).
-
-start_epoch_test() ->
-    Tx = new(1, 30, []),
-    ?assertEqual(1, start_epoch(Tx)).
-
-end_epoch_test() ->
-    Tx = new(1, 30, []),
-    ?assertEqual(30, end_epoch(Tx)).
-
-rewards_test() ->
-    Tx = new(1, 30, []),
-    ?assertEqual([], rewards(Tx)).
-
-poc_challengers_rewards_2_test() ->
-    ReceiptForA = blockchain_poc_receipt_v1:new(<<"a">>, 1, 1, <<"data">>, radio),
-    ElemForA = blockchain_poc_path_element_v1:new(<<"a">>, ReceiptForA, []),
-
-    Txns = [
-        blockchain_txn_poc_receipts_v2:new(<<"a">>, <<"Secret">>, <<"OnionKeyHash">>, [], <<"BlockHash">>),
-        blockchain_txn_poc_receipts_v2:new(<<"b">>, <<"Secret">>, <<"OnionKeyHash">>, [], <<"BlockHash">>),
-        blockchain_txn_poc_receipts_v2:new(<<"c">>, <<"Secret">>, <<"OnionKeyHash">>, [ElemForA], <<"BlockHash">>)
-    ],
-    Vars = #{
-        epoch_reward => 1000,
-        poc_challengers_percent => 0.15,
-        poc_witnesses_percent => 0.0,
-        poc_challengees_percent => 0.0,
-        dc_remainder => 0,
-        poc_version => 5,
-        poc_challenger_type => validator
-    },
-    Rewards = #{
-        {validator, poc_challengers, <<"a">>} => 38,
-        {validator, poc_challengers, <<"b">>} => 38,
-        {validator, poc_challengers, <<"c">>} => 75
-    },
-    ChallengerShares = lists:foldl(fun(T, Acc) -> poc_challenger_reward(T, Acc, Vars) end, #{}, Txns),
-    ?assertEqual(Rewards, normalize_challenger_rewards(ChallengerShares, Vars)),
-
-    AltVars = Vars#{ poc_challenger_type => gateway },
-    AltRewards = #{
-        {gateway, poc_challengers, <<"a">>} => 38,
-        {gateway, poc_challengers, <<"b">>} => 38,
-        {gateway, poc_challengers, <<"c">>} => 75
-    },
-    ?assertEqual(AltRewards, normalize_challenger_rewards(ChallengerShares, AltVars)).
-
-poc_challengees_rewards_3_test() ->
-    BaseDir = test_utils:tmp_dir("poc_challengees_rewards_3_test"),
-    Block = blockchain_block:new_genesis_block([]),
-    {ok, Chain} = blockchain:new(BaseDir, Block, undefined, undefined),
-    Ledger = blockchain:ledger(Chain),
-    Ledger1 = blockchain_ledger_v1:new_context(Ledger),
-
-    Vars = #{
-        epoch_reward => 1000,
-        poc_challengees_percent => 0.35,
-        poc_witnesses_percent => 0.0,
-        poc_challengers_percent => 0.0,
-        dc_remainder => 0,
-        poc_version => 5,
-        region_vars => []
-    },
-
-    LedgerVars = maps:put(?poc_version, 5, common_poc_vars()),
-
-    ok = blockchain_ledger_v1:vars(LedgerVars, [], Ledger1),
-
-    One = 631179381270930431,
-    Two = 631196173757531135,
-    Three = 631196173214364159,
-
-    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"a">>, Ledger1),
-    ok = blockchain_ledger_v1:add_gateway_location(<<"a">>, One, 1, Ledger1),
-
-    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"b">>, Ledger1),
-    ok = blockchain_ledger_v1:add_gateway_location(<<"b">>, Two, 1, Ledger1),
-
-    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"c">>, Ledger1),
-    ok = blockchain_ledger_v1:add_gateway_location(<<"c">>, Three, 1, Ledger1),
-
-    ok = blockchain_ledger_v1:commit_context(Ledger1),
-
-    ReceiptForA = blockchain_poc_receipt_v1:new(<<"a">>, 1, -120, <<"data">>, radio),
-    WitnessForA = blockchain_poc_witness_v1:new(<<"c">>, 1, -120, <<>>),
-    ReceiptForB = blockchain_poc_receipt_v1:new(<<"b">>, 1, -70, <<"data">>, radio),
-    WitnessForB = blockchain_poc_witness_v1:new(<<"c">>, 1, -120, <<>>),
-    ReceiptForC = blockchain_poc_receipt_v1:new(<<"c">>, 1, -120, <<"data">>, radio),
-
-    ElemForA = blockchain_poc_path_element_v1:new(<<"a">>, ReceiptForA, []),
-    ElemForAWithWitness = blockchain_poc_path_element_v1:new(<<"a">>, ReceiptForA, [WitnessForA]),
-    ElemForB = blockchain_poc_path_element_v1:new(<<"b">>, undefined, []),
-    ElemForBWithWitness = blockchain_poc_path_element_v1:new(<<"b">>, ReceiptForB, [WitnessForB]),
-    ElemForC = blockchain_poc_path_element_v1:new(<<"c">>, ReceiptForC, []),
-
-    Txns = [
-        %% No rewards here, Only receipt with no witness or subsequent receipt
-        blockchain_txn_poc_receipts_v2:new(<<"X">>, <<"Secret">>, <<"OnionKeyHash">>, [ElemForB, ElemForA], <<"BlockHash">>),  %% 1, 2
-        %% Reward because of witness
-        blockchain_txn_poc_receipts_v2:new(<<"X">>, <<"Secret">>, <<"OnionKeyHash">>, [ElemForAWithWitness], <<"BlockHash">>), %% 3
-        %% Reward because of next elem has receipt
-        blockchain_txn_poc_receipts_v2:new(<<"X">>, <<"Secret">>, <<"OnionKeyHash">>, [ElemForA, ElemForB, ElemForC], <<"BlockHash">>), %% 3, 2, 2
-        %% Reward because of witness (adding to make reward 50/50)
-        blockchain_txn_poc_receipts_v2:new(<<"X">>, <<"Secret">>, <<"OnionKeyHash">>, [ElemForBWithWitness], <<"BlockHash">>) %% 3
-    ],
-    Rewards = #{
-        %% a gets 8 shares
-        {gateway, poc_challengees, <<"a">>} => 175,
-        %% b gets 6 shares
-        {gateway, poc_challengees, <<"b">>} => 131,
-        %% c gets 2 shares
-        {gateway, poc_challengees, <<"c">>} => 44
-    },
-    ChallengeeShares = lists:foldl(fun(T, Acc) ->
-                                           Path = blockchain_txn_poc_receipts_v2:path(T),
-                                           poc_challengees_rewards_(Vars, Path, Path, T, Chain, Ledger, true, #{}, Acc)
-                                   end,
-                                   #{},
-                                   Txns),
-    ?assertEqual(Rewards, normalize_challengee_rewards(ChallengeeShares, Vars)),
-    test_utils:cleanup_tmp_dir(BaseDir).
-
-poc_witnesses_rewards_test() ->
-    BaseDir = test_utils:tmp_dir("poc_witnesses_rewards_test"),
-    Block = blockchain_block:new_genesis_block([]),
-    {ok, Chain} = blockchain:new(BaseDir, Block, undefined, undefined),
-    Ledger = blockchain:ledger(Chain),
-    Ledger1 = blockchain_ledger_v1:new_context(Ledger),
-    EpochVars = #{
-      epoch_reward => 1000,
-      poc_witnesses_percent => 0.05,
-      poc_challengees_percent => 0.0,
-      poc_challengers_percent => 0.0,
-      dc_remainder => 0,
-      poc_version => 5
-     },
-
-    LedgerVars = maps:merge(common_poc_vars(), EpochVars),
-
-    ok = blockchain_ledger_v1:vars(LedgerVars, [], Ledger1),
-
-    One = 631179381270930431,
-    Two = 631196173757531135,
-    Three = 631196173214364159,
-    Four = 631179381325720575,
-    Five = 631179377081096191,
-
-    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"a">>, Ledger1),
-    ok = blockchain_ledger_v1:add_gateway_location(<<"a">>, One, 1, Ledger1),
-
-    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"b">>, Ledger1),
-    ok = blockchain_ledger_v1:add_gateway_location(<<"b">>, Two, 1, Ledger1),
-
-    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"c">>, Ledger1),
-    ok = blockchain_ledger_v1:add_gateway_location(<<"c">>, Three, 1, Ledger1),
-
-    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"d">>, Ledger1),
-    ok = blockchain_ledger_v1:add_gateway_location(<<"d">>, Four, 1, Ledger1),
-
-    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"e">>, Ledger1),
-    ok = blockchain_ledger_v1:add_gateway_location(<<"e">>, Five, 1, Ledger1),
-
-    ok = blockchain_ledger_v1:commit_context(Ledger1),
-
-    Witness1 = blockchain_poc_witness_v1:new(<<"a">>, 1, -80, <<>>),
-    Witness2 = blockchain_poc_witness_v1:new(<<"b">>, 1, -80, <<>>),
-    Elem = blockchain_poc_path_element_v1:new(<<"c">>, <<"Receipt not undefined">>, [Witness1, Witness2]),
-    Txns = [
-        blockchain_txn_poc_receipts_v2:new(<<"d">>, <<"Secret">>, <<"OnionKeyHash">>, [Elem, Elem], <<"BlockHash">>),
-        blockchain_txn_poc_receipts_v2:new(<<"e">>, <<"Secret">>, <<"OnionKeyHash">>, [Elem, Elem], <<"BlockHash">>)
-    ],
-
-    Rewards = #{{gateway,poc_witnesses,<<"a">>} => 25,
-                {gateway,poc_witnesses,<<"b">>} => 25},
-
-    WitnessShares = lists:foldl(fun(T, Acc) -> poc_witness_reward(T, Acc, Chain, Ledger, EpochVars) end,
-                                #{}, Txns),
-    ?assertEqual(Rewards, normalize_witness_rewards(WitnessShares, EpochVars)),
-    test_utils:cleanup_tmp_dir(BaseDir).
-
-dc_rewards_sc_dispute_strategy_test() ->
-    BaseDir = test_utils:tmp_dir("dc_rewards_dispute_sc_test"),
-    Ledger = blockchain_ledger_v1:new(BaseDir),
-    Ledger1 = blockchain_ledger_v1:new_context(Ledger),
-
-    Vars = #{
-        epoch_reward => 100000,
-        dc_percent => 0.3,
-        consensus_percent => 0.06 + 0.025,
-        poc_challengees_percent => 0.18,
-        poc_challengers_percent => 0.0095,
-        poc_witnesses_percent => 0.0855,
-        securities_percent => 0.34,
-        sc_version => 2,
-        sc_grace_blocks => 5,
-        reward_version => 4,
-        oracle_price => 100000000, %% 1 dollar
-        consensus_members => [<<"c">>, <<"d">>],
-        %% This is the important part of what's being tested here.
-        sc_dispute_strategy_version => 1
-    },
-
-    LedgerVars = maps:merge(#{?poc_version => 5, ?sc_version => 2, ?sc_grace_blocks => 5}, common_poc_vars()),
-    ok = blockchain_ledger_v1:vars(LedgerVars, [], Ledger1),
-
-    {SC0, _} = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>, 100, <<"blockhash">>, 10),
-    SCValid = blockchain_state_channel_v1:summaries([blockchain_state_channel_summary_v1:new(<<"a">>, 1, 1), blockchain_state_channel_summary_v1:new(<<"b">>, 2, 2)], SC0),
-    SCDispute = blockchain_state_channel_v1:summaries([blockchain_state_channel_summary_v1:new(<<"a">>, 2, 2), blockchain_state_channel_summary_v1:new(<<"b">>, 3, 3)], SC0),
-
-    ok = blockchain_ledger_v1:add_state_channel(<<"id">>, <<"owner">>, 10, 1, 100, 200, Ledger1),
-    {ok, _} = blockchain_ledger_v1:find_state_channel(<<"id">>, <<"owner">>, Ledger1),
-
-    ok = blockchain_ledger_v1:close_state_channel(<<"owner">>, <<"owner">>, SCValid, <<"id">>, false, Ledger1),
-    {ok, _} = blockchain_ledger_v1:find_state_channel(<<"id">>, <<"owner">>, Ledger1),
-
-    ok = blockchain_ledger_v1:close_state_channel(<<"owner">>, <<"a">>, SCDispute, <<"id">>, true, Ledger1),
-
-    SCClose = blockchain_txn_state_channel_close_v1:new(SCValid, <<"owner">>),
-    {ok, _DCsInEpochAsHNT} = blockchain_ledger_v1:dc_to_hnt(3, 100000000), %% 3 DCs burned at HNT price of 1 dollar
-
-    DCShares = dc_reward(SCClose, 100, #{}, Ledger1, Vars),
-
-    %% We only care that no rewards are generated when sc_dispute_strategy_version is active.
-    {Res, M} = normalize_dc_rewards(DCShares, Vars),
-    ?assertEqual(#{}, M, "no summaries in rewards map"),
-    ?assertEqual(30000, Res),
-    test_utils:cleanup_tmp_dir(BaseDir).
-
-dc_rewards_v3_test() ->
-    BaseDir = test_utils:tmp_dir("dc_rewards_v3_test"),
-    Ledger = blockchain_ledger_v1:new(BaseDir),
-    Ledger1 = blockchain_ledger_v1:new_context(Ledger),
-
-    Vars = #{
-        epoch_reward => 100000,
-        dc_percent => 0.3,
-        consensus_percent => 0.06 + 0.025,
-        poc_challengees_percent => 0.18,
-        poc_challengers_percent => 0.0095,
-        poc_witnesses_percent => 0.0855,
-        securities_percent => 0.34,
-        sc_version => 2,
-        sc_grace_blocks => 5,
-        sc_dispute_strategy_version => 0,
-        reward_version => 3,
-        oracle_price => 100000000, %% 1 dollar
-        consensus_members => [<<"c">>, <<"d">>]
-    },
-
-    LedgerVars = maps:merge(#{?poc_version => 5, ?sc_version => 2, ?sc_grace_blocks => 5}, common_poc_vars()),
-
-    ok = blockchain_ledger_v1:vars(LedgerVars, [], Ledger1),
-
-    {SC0, _} = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>, 100, <<"blockhash">>, 10),
-    SC = blockchain_state_channel_v1:summaries([blockchain_state_channel_summary_v1:new(<<"a">>, 1, 1), blockchain_state_channel_summary_v1:new(<<"b">>, 2, 2)], SC0),
-
-    ok = blockchain_ledger_v1:add_state_channel(<<"id">>, <<"owner">>, 10, 1, 100, 200, Ledger1),
-
-    {ok, _} = blockchain_ledger_v1:find_state_channel(<<"id">>, <<"owner">>, Ledger1),
-
-    ok = blockchain_ledger_v1:close_state_channel(<<"owner">>, <<"owner">>, SC, <<"id">>, false, Ledger1),
-
-    {ok, _} = blockchain_ledger_v1:find_state_channel(<<"id">>, <<"owner">>, Ledger1),
-
-
-    SCClose = blockchain_txn_state_channel_close_v1:new(SC, <<"owner">>),
-    {ok, DCsInEpochAsHNT} = blockchain_ledger_v1:dc_to_hnt(3, 100000000), %% 3 DCs burned at HNT price of 1 dollar
-    %% NOTE: Rewards are split 33-66%
-    Rewards = #{
-        {gateway, data_credits, <<"a">>} => round(DCsInEpochAsHNT * (1/3)),
-        {gateway, data_credits, <<"b">>} => round(DCsInEpochAsHNT * (2/3))
-    },
-    DCShares = dc_reward(SCClose, 100, #{}, Ledger1, Vars),
-    ?assertEqual({26999, Rewards}, normalize_dc_rewards(DCShares, Vars)),
-    test_utils:cleanup_tmp_dir(BaseDir).
-
-dc_rewards_v3_spillover_test() ->
-    BaseDir = test_utils:tmp_dir("dc_rewards_v3_spillover_test"),
-    Block = blockchain_block:new_genesis_block([]),
-    {ok, Chain} = blockchain:new(BaseDir, Block, undefined, undefined),
-    Ledger = blockchain:ledger(Chain),
-    Ledger1 = blockchain_ledger_v1:new_context(Ledger),
-
-    Vars = #{
-        epoch_reward => 100000,
-        dc_percent => 0.05,
-        consensus_percent => 0.1,
-        poc_challengees_percent => 0.20,
-        poc_challengers_percent => 0.15,
-        poc_witnesses_percent => 0.15,
-        securities_percent => 0.35,
-        poc_challenger_type => validator,
-        sc_version => 2,
-        sc_grace_blocks => 5,
-        reward_version => 3,
-        poc_version => 5,
-        dc_remainder => 0,
-        oracle_price => 100000000, %% 1 dollar
-        var_map => undefined,
-        region_vars => [],
-        consensus_members => [<<"c">>, <<"d">>]
-    },
-
-    LedgerVars = maps:merge(#{?poc_version => 5, ?sc_version => 2, ?sc_grace_blocks => 5}, common_poc_vars()),
-
-    ok = blockchain_ledger_v1:vars(LedgerVars, [], Ledger1),
-
-    One = 631179381270930431,
-    Two = 631196173757531135,
-    Three = 631196173214364159,
-
-    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"a">>, Ledger1),
-    ok = blockchain_ledger_v1:add_gateway_location(<<"a">>, One, 1, Ledger1),
-
-    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"b">>, Ledger1),
-    ok = blockchain_ledger_v1:add_gateway_location(<<"b">>, Two, 1, Ledger1),
-
-    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"c">>, Ledger1),
-    ok = blockchain_ledger_v1:add_gateway_location(<<"c">>, Three, 1, Ledger1),
-
-    ReceiptForA = blockchain_poc_receipt_v1:new(<<"a">>, 1, -120, <<"data">>, radio),
-    WitnessForA = blockchain_poc_witness_v1:new(<<"c">>, 1, -120, <<>>),
-    ReceiptForB = blockchain_poc_receipt_v1:new(<<"b">>, 1, -70, <<"data">>, radio),
-    WitnessForB = blockchain_poc_witness_v1:new(<<"c">>, 1, -120, <<>>),
-    ReceiptForC = blockchain_poc_receipt_v1:new(<<"c">>, 1, -120, <<"data">>, radio),
-
-    ElemForA = blockchain_poc_path_element_v1:new(<<"a">>, ReceiptForA, []),
-    ElemForAWithWitness = blockchain_poc_path_element_v1:new(<<"a">>, ReceiptForA, [WitnessForA]),
-    ElemForB = blockchain_poc_path_element_v1:new(<<"b">>, undefined, []),
-    ElemForBWithWitness = blockchain_poc_path_element_v1:new(<<"b">>, ReceiptForB, [WitnessForB]),
-    ElemForC = blockchain_poc_path_element_v1:new(<<"c">>, ReceiptForC, []),
-
-    Txns = [
-        %% No rewards here, Only receipt with no witness or subsequent receipt
-        blockchain_txn_poc_receipts_v2:new(<<"X">>, <<"Secret">>, <<"OnionKeyHash">>, [ElemForB, ElemForA], <<"BlockHash">>),  %% 1, 2
-        %% Reward because of witness
-        blockchain_txn_poc_receipts_v2:new(<<"X">>, <<"Secret">>, <<"OnionKeyHash">>, [ElemForAWithWitness], <<"BlockHash">>), %% 3
-        %% Reward because of next elem has receipt
-        blockchain_txn_poc_receipts_v2:new(<<"X">>, <<"Secret">>, <<"OnionKeyHash">>, [ElemForA, ElemForB, ElemForC], <<"BlockHash">>), %% 3, 2, 2
-        %% Reward because of witness (adding to make reward 50/50)
-        blockchain_txn_poc_receipts_v2:new(<<"X">>, <<"Secret">>, <<"OnionKeyHash">>, [ElemForBWithWitness], <<"BlockHash">>) %% 3
-    ],
-
-
-    {SC0, _} = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>, 100, <<"blockhash">>, 10),
-    SC = blockchain_state_channel_v1:summaries([blockchain_state_channel_summary_v1:new(<<"a">>, 1, 1), blockchain_state_channel_summary_v1:new(<<"b">>, 2, 2)], SC0),
-
-    ok = blockchain_ledger_v1:add_state_channel(<<"id">>, <<"owner">>, 10, 1, 100, 200, Ledger1),
-
-    {ok, _} = blockchain_ledger_v1:find_state_channel(<<"id">>, <<"owner">>, Ledger1),
-
-    ok = blockchain_ledger_v1:close_state_channel(<<"owner">>, <<"owner">>, SC, <<"id">>, false, Ledger1),
-
-    {ok, _} = blockchain_ledger_v1:find_state_channel(<<"id">>, <<"owner">>, Ledger1),
-
-    ok = blockchain_ledger_v1:commit_context(Ledger1),
-
-    Txns2 = [
-         blockchain_txn_state_channel_close_v1:new(SC, <<"owner">>)
-    ],
-    AllTxns = Txns ++ Txns2,
-    {ok, DCsInEpochAsHNT} = blockchain_ledger_v1:dc_to_hnt(3, 100000000), %% 3 DCs burned at HNT price of 1 dollar
-    %% NOTE: Rewards are split 33-66%
-    Rewards = #{
-        {gateway, data_credits, <<"a">>} => round(DCsInEpochAsHNT * (1/3)),
-        {gateway, data_credits, <<"b">>} => round(DCsInEpochAsHNT * (2/3))
-    },
-
-    RewardSharesInit = #{
-      dc_rewards => #{},
-      poc_challenger => #{},
-      poc_challengee => #{},
-      poc_witness => #{}
-     },
-
-    NoSpillover = lists:foldl(fun(T, Acc) -> calculate_reward_for_txn(
-                                               blockchain_txn:type(T), T, 100,
-                                               Acc, Chain, Ledger, Vars)
-                                    end,
-                                    RewardSharesInit,
-                                    AllTxns),
-    DCShares = maps:get(dc_rewards, NoSpillover),
-    {DCRemainder, DCRewards} = normalize_dc_rewards(DCShares, Vars),
-    DCAward = trunc(maps:get(epoch_reward, Vars) * maps:get(dc_percent, Vars)),
-    ?assertEqual({DCAward - DCsInEpochAsHNT, Rewards}, {DCRemainder, DCRewards}),
-
-    NewVars = maps:put(dc_remainder, DCRemainder, Vars),
-
-    Spillover = lists:foldl(fun(T, Acc) -> calculate_reward_for_txn(
-                                               blockchain_txn:type(T), T, 100,
-                                               Acc, Chain, Ledger, NewVars)
-                                    end,
-                                    RewardSharesInit,
-                                    AllTxns),
-
-    ChallengerShares = maps:get(poc_challenger, NoSpillover),
-    ChallengeeShares = maps:get(poc_challengee, NoSpillover),
-    WitnessShares = maps:get(poc_witness, NoSpillover),
-
-    ChallengerRewards = normalize_challenger_rewards(ChallengerShares, Vars),
-    ChallengeeRewards = normalize_challengee_rewards(ChallengeeShares, Vars),
-    WitnessRewards = normalize_witness_rewards(WitnessShares, Vars),
-
-    ChallengersAward = trunc(maps:get(epoch_reward, Vars) * maps:get(poc_challengers_percent, Vars)),
-    ?assertEqual(#{{validator,poc_challengers,<<"X">>} =>  ChallengersAward}, ChallengerRewards), %% entire 15% allocation
-    ChallengeesAward = trunc(maps:get(epoch_reward, Vars) * maps:get(poc_challengees_percent, Vars)),
-    ?assertEqual(#{{gateway,poc_challengees,<<"a">>} => trunc(ChallengeesAward * 4/8), %% 4 of 8 shares of 20% allocation
-                   {gateway,poc_challengees,<<"b">>} => trunc(ChallengeesAward * 3/8), %% 3 shares
-                   {gateway,poc_challengees,<<"c">>} => trunc(ChallengeesAward * 1/8)}, %% 1 share
-                 ChallengeeRewards),
-    WitnessesAward = trunc(maps:get(epoch_reward, Vars) * maps:get(poc_witnesses_percent, Vars)),
-    ?assertEqual(#{{gateway,poc_witnesses,<<"c">>} => WitnessesAward}, %% entire 15% allocation
-                 WitnessRewards),
-
-
-    %% apply the DC remainder, if any to the other PoC categories pro rata
-    SpilloverChallengerShares = maps:get(poc_challenger, Spillover),
-    SpilloverChallengeeShares = maps:get(poc_challengee, Spillover),
-    SpilloverWitnessShares = maps:get(poc_witness, Spillover),
-
-    SpilloverChallengerRewards = normalize_challenger_rewards(SpilloverChallengerShares, NewVars),
-    SpilloverChallengeeRewards = normalize_challengee_rewards(SpilloverChallengeeShares, NewVars),
-    SpilloverWitnessRewards = normalize_witness_rewards(SpilloverWitnessShares, NewVars),
-
-    ChallengerSpilloverAward = 0,
-
-    ?assertEqual(#{{validator,poc_challengers,<<"X">>} =>  ChallengersAward + ChallengerSpilloverAward}, SpilloverChallengerRewards), %% entire 15% allocation
-    ChallengeeSpilloverAward = erlang:round(DCRemainder * ((maps:get(poc_challengees_percent, Vars) / (maps:get(poc_challengees_percent, Vars) +
-                                                                                                       maps:get(poc_witnesses_percent, Vars))))),
-    ?assertEqual(#{{gateway,poc_challengees,<<"a">>} => trunc((ChallengeesAward + ChallengeeSpilloverAward) * 4/8), %% 4 of 8 shares of 20% allocation
-                   {gateway,poc_challengees,<<"b">>} => trunc((ChallengeesAward + ChallengeeSpilloverAward) * 3/8), %% 3 shares
-                   {gateway,poc_challengees,<<"c">>} => round((ChallengeesAward + ChallengeeSpilloverAward) * 1/8)}, %% 1 share
-                 SpilloverChallengeeRewards),
-    WitnessesSpilloverAward = erlang:round(DCRemainder * ((maps:get(poc_witnesses_percent, Vars) / (maps:get(poc_challengees_percent, Vars) +
-                                                                                                       maps:get(poc_witnesses_percent, Vars))))),
-    ?assertEqual(#{{gateway,poc_witnesses,<<"c">>} => WitnessesAward + WitnessesSpilloverAward}, %% entire 15% allocation
-                 SpilloverWitnessRewards),
-    test_utils:cleanup_tmp_dir(BaseDir).
-
-to_json_test() ->
-    Tx = #blockchain_txn_rewards_v2_pb{start_epoch=1, end_epoch=30, rewards=[]},
-    Json = to_json(Tx, []),
-    ?assert(lists:all(fun(K) -> maps:is_key(K, Json) end,
-                      [type, start_epoch, end_epoch, rewards])).
-
-
-fixed_normalize_reward_unit_test() ->
-    Rewards = [0.1, 0.9, 1.0, 1.8, 2.5, 2000, 0],
-
-    %% Expectation: reward should get capped at 2.0
-    Correct = lists:foldl(
-                fun(Reward, Acc) ->
-                        %% Set cap=2.0
-                        maps:put(Reward, normalize_reward_unit(2.0, Reward), Acc)
-                end, #{}, Rewards),
-
-    Incorrect = lists:foldl(
-                  fun(Reward, Acc) ->
-                          %% Set cap=undefined (old behavior)
-                          maps:put(Reward, normalize_reward_unit(undefined, Reward), Acc)
-                  end, #{}, Rewards),
-
-    ?assertEqual(1.8, maps:get(1.8, Correct)),          %% 1.8 -> 1.8
-    ?assertEqual(0.1, maps:get(0.1, Correct)),          %% 0.1 -> 0.1
-    ?assertEqual(0.9, maps:get(0.9, Correct)),          %% 0.9 -> 0.9
-    ?assertEqual(2.0, maps:get(2.5, Correct)),          %% 2.5 -> 2.0
-    ?assertEqual(1.0, maps:get(2.5, Incorrect)),        %% 2.5 -> 1.0 (incorrect)
-    ?assertEqual(1.0, maps:get(1.8, Incorrect)),        %% 1.8 -> 1.0 (incorrect)
-    ?assertEqual(0.1, maps:get(0.1, Incorrect)),        %% 0.1 -> 0.1
-    ?assertEqual(0.9, maps:get(0.9, Incorrect)),        %% 0.9 -> 0.9
-
-    ok.
-
-common_poc_vars() ->
-    #{
-        ?poc_v4_exclusion_cells => 10,
-        ?poc_v4_parent_res => 11,
-        ?poc_v4_prob_bad_rssi => 0.01,
-        ?poc_v4_prob_count_wt => 0.3,
-        ?poc_v4_prob_good_rssi => 1.0,
-        ?poc_v4_prob_no_rssi => 0.5,
-        ?poc_v4_prob_rssi_wt => 0.3,
-        ?poc_v4_prob_time_wt => 0.3,
-        ?poc_v4_randomness_wt => 0.1,
-        ?poc_v4_target_challenge_age => 300,
-        ?poc_v4_target_exclusion_cells => 6000,
-        ?poc_v4_target_prob_edge_wt => 0.2,
-        ?poc_v4_target_prob_score_wt => 0.8,
-        ?poc_v4_target_score_curve => 5,
-        ?poc_v5_target_prob_randomness_wt => 0.0
-    }.
-
-
-hip28_calc_test() ->
-    {timeout, 30000,
-     fun() ->
-             meck:new(blockchain_ledger_v1, [passthrough]),
-             meck:expect(blockchain_ledger_v1, hnt_burned,
-                         fun(_Ledger) ->
-                                 0
-                         end),
-             meck:expect(blockchain_ledger_v1, net_overage,
-                         fun(_Ledger) ->
-                                 0
-                         end),
-             meck:expect(blockchain_ledger_v1, config,
-                         fun(_, _Ledger) ->
-                                 0
-                         end),
-
-                                                % set test vars such that rewards are 1 per block
-             Vars = #{ block_time => 60000,
-                       election_interval => 30,
-                       election_restart_interval => 5,
-                       monthly_reward => 43200,
-                       reward_version => 6 },
-             ?assertEqual(30.0, calculate_consensus_epoch_reward(1, 30, Vars, ledger)),
-             ?assertEqual(35.0, calculate_consensus_epoch_reward(1, 50, Vars, ledger)),
-             meck:unload(blockchain_ledger_v1),
-             ok
-     end}.
-
-consensus_epoch_reward_test() ->
-    {timeout, 30000,
-     fun() ->
-             meck:new(blockchain_ledger_v1, [passthrough]),
-             meck:expect(blockchain_ledger_v1, hnt_burned,
-                         fun(_Ledger) ->
-                                 0
-                         end),
-             meck:expect(blockchain_ledger_v1, net_overage,
-                         fun(_Ledger) ->
-                                 0
-                         end),
-             meck:expect(blockchain_ledger_v1, config,
-                         fun(_, _Ledger) ->
-                                 0
-                         end),
-
-             %% using test values such that reward is 1 per block
-             %% should always return the election interval as the answer
-             ?assertEqual(30.0,calculate_epoch_reward(1, 1, 25, 60000, 30, 43200, ledger)),
-
-             %% more than 30 blocks should return 30
-             ?assertEqual(30.0,calculate_epoch_reward(1, 1, 50, 60000, 30, 43200, ledger)),
-             meck:unload(blockchain_ledger_v1)
-     end}.
 
 -endif.

--- a/src/transactions/v1/blockchain_txn_subnetwork_rewards_v1.erl
+++ b/src/transactions/v1/blockchain_txn_subnetwork_rewards_v1.erl
@@ -1,0 +1,2193 @@
+%%-------------------------------------------------------------------
+%% @doc
+%% This module implements rewards v2 which track only an account and
+%% an amount. The breakdowns of rewards by type and associated gateway
+%% are not kept here.  This was done to streamline the increasing
+%% size of rewards as the network grows.
+%%
+%% In the future, we will need to work on further ways to streamline
+%% the size of this transaction. One proposal was to use the ledger
+%% as an encoding dictionary and use ledger offsets to mark the
+%% account instead of using the full sized account id.
+%% @end
+%%%-------------------------------------------------------------------
+-module(blockchain_txn_subnetwork_rewards_v1).
+
+-behavior(blockchain_txn).
+
+-behavior(blockchain_json).
+-include("blockchain_json.hrl").
+
+-include("blockchain_vars.hrl").
+-include_lib("helium_proto/include/blockchain_txn_subnetwork_rewards_v1_pb.hrl").
+
+-export([
+    new/3,
+    hash/1,
+    start_epoch/1,
+    end_epoch/1,
+    rewards/1,
+
+    %% reward v2 accessors
+    reward_account/1,
+    reward_amount/1,
+
+    sign/2,
+    fee/1,
+    fee_payer/2,
+    is_valid/2,
+    absorb/2,
+    print/1,
+    json_type/0,
+    to_json/2
+]).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-type txn_subnetwork_rewards_v1() :: #blockchain_txn_subnetwork_rewards_v1_pb{}.
+-type subnetwork_reward_v1() :: #blockchain_txn_subnetwork_reward_v1_pb{}.
+-type rewards() :: [subnetwork_reward_v1()].
+-type reward_vars() :: map().
+
+-export_type([txn_subnetwork_rewards_v1/0]).
+
+%% ------------------------------------------------------------------
+%% Public API
+%% ------------------------------------------------------------------
+
+-spec new(non_neg_integer(), non_neg_integer(), rewards()) -> txn_subnetwork_rewards_v1().
+new(Start, End, Rewards) ->
+    SortedRewards = lists:sort(Rewards),
+    #blockchain_txn_rewards_v2_pb{start_epoch=Start, end_epoch=End, rewards=SortedRewards}.
+
+-spec hash(txn_subnetwork_rewards_v1()|reward_v2()) -> blockchain_txn:hash().
+hash(Txn) ->
+    EncodedTxn = blockchain_txn_rewards_v2_pb:encode_msg(Txn),
+    crypto:hash(sha256, EncodedTxn).
+
+-spec start_epoch(txn_subnetwork_rewards_v1()) -> non_neg_integer().
+start_epoch(#blockchain_txn_rewards_v2_pb{start_epoch=Start}) ->
+    Start.
+
+-spec end_epoch(txn_subnetwork_rewards_v1()) -> non_neg_integer().
+end_epoch(#blockchain_txn_rewards_v2_pb{end_epoch=End}) ->
+    End.
+
+-spec rewards(txn_subnetwork_rewards_v1()) -> rewards().
+rewards(#blockchain_txn_rewards_v2_pb{rewards=Rewards}) ->
+    Rewards.
+
+-spec reward_account(reward_v2()) -> binary().
+reward_account(#blockchain_txn_reward_v2_pb{account = Account}) ->
+    Account.
+
+-spec reward_amount(reward_v2()) -> non_neg_integer().
+reward_amount(#blockchain_txn_reward_v2_pb{amount = Amount}) ->
+    Amount.
+
+-spec sign(txn_subnetwork_rewards_v1(), libp2p_crypto:sig_fun()) -> txn_subnetwork_rewards_v1().
+sign(Txn, SigFun) ->
+    Txn.
+
+-spec fee(txn_subnetwork_rewards_v1()) -> 0.
+fee(_Txn) ->
+    0.
+
+-spec fee_payer(txn_subnetwork_rewards_v1(), blockchain_ledger_v1:ledger()) -> libp2p_crypto:pubkey_bin() | undefined.
+fee_payer(_Txn, _Ledger) ->
+    undefined.
+
+-spec is_valid(txn_subnetwork_rewards_v1(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
+is_valid(Txn, Chain) ->
+    Start = ?MODULE:start_epoch(Txn),
+    End = ?MODULE:end_epoch(Txn),
+    TxnRewards = ?MODULE:rewards(Txn),
+    %% TODO: REMOVE THIS ENTIRE CASE STATEMENT AT NEXT RESTART
+    case TxnRewards of
+        [] ->
+            ok;
+        _ ->
+            case ?MODULE:calculate_rewards(Start, End, Chain) of
+                {error, _Reason}=Error ->
+                    Error;
+                {ok, CalRewards} ->
+                    CalRewardsHashes = [hash(R)|| R <- CalRewards],
+                    TxnRewardsHashes = [hash(R)|| R <- TxnRewards],
+                    case CalRewardsHashes == TxnRewardsHashes of
+                        false -> {error, invalid_rewards_v2};
+                        true -> ok
+                    end
+            end
+    end.
+
+-spec absorb(txn_subnetwork_rewards_v1(), blockchain:blockchain()) -> ok | {error, atom()} | {error, {atom(), any()}}.
+absorb(Txn, Chain) ->
+    Ledger = blockchain:ledger(Chain),
+
+    case blockchain:config(?net_emissions_enabled, Ledger) of
+        {ok, true} ->
+            %% initial proposed max 34.24
+            {ok, Max} = blockchain:config(?net_emissions_max_rate, Ledger),
+            {ok, Burned} = blockchain_ledger_v1:hnt_burned(Ledger),
+            {ok, Overage} = blockchain_ledger_v1:net_overage(Ledger),
+
+            %% clear this since we have it already
+            ok = blockchain_ledger_v1:clear_hnt_burned(Ledger),
+
+            case Burned > Max of
+                %% if burned > max, then add (burned - max) to overage
+                true ->
+                    Overage1 = Overage + (Burned - Max),
+                    ok = blockchain_ledger_v1:net_overage(Overage1, Ledger);
+                %% else we may have pulled from overage to the tune of
+                %% max - burned
+                 _ ->
+                    %% here we pulled from overage up to max
+                    case (Max - Burned) < Overage  of
+                        %% emitted max, pulled from overage
+                        true ->
+                            Overage1 = Overage - (Max - Burned),
+                            ok = blockchain_ledger_v1:net_overage(Overage1, Ledger);
+                        %% not enough overage to emit up to max, 0 overage
+                        _ ->
+                            ok = blockchain_ledger_v1:net_overage(0, Ledger)
+                    end
+            end;
+        _ ->
+            ok
+    end,
+
+    case blockchain_ledger_v1:mode(Ledger) == aux of
+        false ->
+            %% only absorb in the main ledger
+            absorb_(Txn, Ledger);
+        true ->
+            aux_absorb(Txn, Ledger, Chain)
+    end.
+
+-spec absorb_(Txn :: txn_subnetwork_rewards_v1(), Ledger :: blockchain_ledger_v1:ledger()) -> ok.
+absorb_(Txn, Ledger) ->
+    Rewards = ?MODULE:rewards(Txn),
+    absorb_rewards(Rewards, Ledger).
+
+-spec absorb_rewards(Rewards :: rewards(),
+                     Ledger :: blockchain_ledger_v1:ledger()) -> ok.
+absorb_rewards(Rewards, Ledger) ->
+    lists:foreach(
+        fun(#blockchain_txn_reward_v2_pb{account=Account, amount=Amount}) ->
+            ok = blockchain_ledger_v1:credit_account(Account, Amount, Ledger)
+        end,
+        Rewards
+    ).
+
+-spec aux_absorb(Txn :: txn_subnetwork_rewards_v1(),
+                 AuxLedger :: blockchain_ledger_v1:ledger(),
+                 Chain :: blockchain:blockchain()) -> ok | {error, any()}.
+aux_absorb(Txn, AuxLedger, Chain) ->
+    Start = ?MODULE:start_epoch(Txn),
+    End = ?MODULE:end_epoch(Txn),
+    %% NOTE: This is an aux ledger, we don't use rewards(txn) here, instead we calculate them manually
+    %% and do 0 verification for absorption
+    case calculate_rewards_(Start, End, AuxLedger, Chain, true) of
+        {error, _}=E -> E;
+        {ok, AuxRewards, AuxMD} ->
+            TxnRewards = rewards(Txn),
+            %% absorb the rewards attached to the txn (real)
+            absorb_rewards(TxnRewards, AuxLedger),
+            %% set auxiliary rewards in the aux ledger also
+            lager:info("are aux rewards equal?: ~p", [lists:sort(TxnRewards) == lists:sort(AuxRewards)]),
+            %% rewards appear in (End + 1) block
+            blockchain_aux_ledger_v1:set_rewards(End + 1, TxnRewards, AuxRewards, AuxLedger),
+            case calculate_rewards_(Start, End, blockchain_ledger_v1:mode(active, AuxLedger), Chain, true) of
+                {error, _}=E -> E;
+                {ok, _, OrigMD} ->
+                    blockchain_aux_ledger_v1:set_rewards_md(End + 1, OrigMD, AuxMD, AuxLedger)
+            end
+    end.
+
+
+-spec calculate_rewards(non_neg_integer(), non_neg_integer(), blockchain:blockchain()) ->
+    {ok, rewards()} | {error, any()}.
+%% @doc Calculate and return an ordered list (as ordered by lists:sort/1) of
+%% rewards for use in a rewards_v2 transaction. Given how lists:sort/1 works,
+%% ordering will depend on (binary) account information.
+calculate_rewards(Start, End, Chain) ->
+    {ok, Ledger} = blockchain:ledger_at(End, Chain),
+    calculate_rewards_(Start, End, Ledger, Chain, false).
+
+-spec calculate_rewards_(
+        Start :: non_neg_integer(),
+        End :: non_neg_integer(),
+        Ledger :: blockchain_ledger_v1:ledger(),
+        Chain :: blockchain:blockchain(),
+        ReturnMD :: boolean()
+       ) -> {error, any()} | {ok, rewards()} | {ok, rewards(), rewards_metadata()}.
+calculate_rewards_(Start, End, Ledger, Chain, ReturnMD) ->
+    {ok, Results} = calculate_rewards_metadata(Start, End, blockchain:ledger(Ledger, Chain)),
+    try
+        case ReturnMD of
+            false ->
+                {ok, prepare_rewards_v2_txns(Results, Ledger)};
+            true ->
+                {ok, prepare_rewards_v2_txns(Results, Ledger), Results}
+        end
+    catch
+        C:Error:Stack ->
+            lager:error("Caught ~p; couldn't prepare rewards txn because: ~p~n~p", [C, Error, Stack]),
+            Error
+    end.
+
+-spec calculate_rewards_metadata(
+        Start :: non_neg_integer(),
+        End :: non_neg_integer(),
+        Chain :: blockchain:blockchain() ) ->
+    {ok, Metadata :: rewards_metadata()} | {error, Error :: term()}.
+%% @doc Calculate <i>only</i> rewards metadata (do not return v2 reward records
+%% to the caller.)
+%%
+%% Keys that exist in the rewards metadata map include:
+%% <ul>
+%%    <li>poc_challenger</li>
+%%    <li>poc_witness</li>
+%%    <li>poc_challengee</li>
+%%    <li>dc_rewards</li>
+%%    <li>consensus_rewards</li>
+%%    <li>securities_rewards</li>
+%% </ul>
+%%
+%% Each of the keys is itself a map which has the shape of `#{ Entry => Amount }'
+%% where Entry is defined as a tuple of `{gateway, reward_type, Gateway}' or
+%% `{owner, reward_type, Owner}'
+%%
+%% There is an additional key `overages' which may or may not have an integer
+%% value. It represents the amount of excess fees paid in the given epoch which
+%% were used as bonus HNT rewards for the consensus members.
+%% @end
+calculate_rewards_metadata(Start, End, Chain) ->
+    {ok, Ledger} = blockchain:ledger_at(End, Chain),
+    Vars0 = get_reward_vars(Start, End, Ledger),
+    VarMap = case blockchain_hex:var_map(Ledger) of
+                 {error, _Reason} -> #{};
+                 {ok, VM} -> VM
+             end,
+
+    RegionVars = blockchain_region_v1:get_all_region_bins(Ledger),
+
+    Vars = Vars0#{ var_map => VarMap, region_vars => RegionVars},
+
+    %% Previously, if a state_channel closed in the grace blocks before an
+    %% epoch ended, then it wouldn't ever get rewarded.
+    {ok, PreviousGraceBlockDCRewards} = collect_dc_rewards_from_previous_epoch_grace(Start, End,
+                                                                                     Chain, Vars,
+                                                                                     Ledger),
+
+    %% Initialize our reward accumulator. We are going to build up a map which
+    %% will be in the shape of
+    %% #{ reward_type => #{ Entry => Amount } }
+    %%
+    %% where Entry is of the the shape
+    %% {owner, reward_type, Owner} or
+    %% {gateway, reward_type, Gateway}
+    AccInit = #{ dc_rewards => PreviousGraceBlockDCRewards,
+                 poc_challenger => #{},
+                 poc_challengee => #{},
+                 poc_witness => #{} },
+
+    try
+        %% We only want to fold over the blocks and transaction in an epoch once,
+        %% so we will do that top level work here. If we get a thrown error while
+        %% we are folding, we will abort reward calculation.
+        Me = self(),
+        PerfTab =
+            case application:get_env(blockchain, print_rewards_perf, false) of
+                true ->
+                    PT = ets:new(rwd_perf, []),
+                    erlang:put({Me, '$rwd_perf'}, PT),
+                    PT;
+                _ -> ok
+            end,
+        Results0 = fold_blocks_for_rewards(Start, End, Chain,
+                                           Vars, Ledger, AccInit),
+
+        %% Prior to HIP 28 (reward_version <6), force EpochReward amount for the CG to always
+        %% be around ElectionInterval (30 blocks) so that there is less incentive
+        %% to stay in the consensus group. With HIP 28, relax that to be up to election_interval +
+        %% election_retry_interval to allow for time for election to complete.
+        ConsensusEpochReward =
+            case maps:get(reward_version, Vars) of
+               RewardVersion when RewardVersion >= 6 ->
+                    calculate_consensus_epoch_reward(Start, End, Vars, Ledger);
+                _ ->
+                    calculate_epoch_reward(1, Start, End, Ledger)
+            end,
+
+        Vars1 = Vars#{ consensus_epoch_reward => ConsensusEpochReward },
+
+        Results = finalize_reward_calculations(Results0, Ledger, Vars1),
+        %% we are only keeping hex density calculations memoized for a single
+        %% rewards transaction calculation, then we discard that work and avoid
+        %% cache invalidation issues.
+        case application:get_env(blockchain, destroy_memo, true) of
+            true ->
+                true = blockchain_hex:destroy_memoization();
+            _ -> ok
+        end,
+        perf_report(PerfTab),
+        catch ets:delete(PerfTab),
+        erlang:erase({Me, '$rwd_perf'}),
+        {ok, Results}
+    catch
+        C:Error:Stack ->
+            lager:error("Caught ~p; couldn't calculate rewards metadata because: ~p~n~p", [C, Error, Stack]),
+            Error
+    end.
+
+perf(Tag, Time) ->
+    Me = self(),
+    case erlang:get({Me, '$rwd_perf'}) of
+        undefined ->
+            ok;
+        Tab ->
+            catch ets:update_counter(Tab, Tag, Time, {Tag, Time})
+    end.
+
+perf_report(Tab) ->
+    case application:get_env(blockchain, print_rewards_perf, false) of
+        true ->
+            Measurements = lists:reverse(lists:keysort(2, ets:tab2list(Tab))),
+            lager:info("perf report:"),
+            lists:foreach(
+              fun({K, V}) ->
+                      lager:info("txn ~p: ~pms", [K, V])
+              end,
+              Measurements);
+        false ->
+            ok
+    end.
+
+-spec print(txn_subnetwork_rewards_v1()) -> iodata().
+print(undefined) -> <<"type=rewards_v2 undefined">>;
+print(#blockchain_txn_rewards_v2_pb{start_epoch=Start,
+                                    end_epoch=End}) ->
+    io_lib:format("type=rewards_v2 start_epoch=~p end_epoch=~p",
+                  [Start, End]).
+
+json_type() ->
+    <<"subnetwork_rewards_v1">>.
+
+-spec to_json(txn_subnetwork_rewards_v1(), blockchain_json:opts()) -> blockchain_json:json_object().
+to_json(Txn, Opts) ->
+    RewardToJson =
+        fun
+            ({gateway, Type, G}, Amount, Ledger, Acc) ->
+                case blockchain_ledger_v1:find_gateway_owner(G, Ledger) of
+                    {error, _Error} ->
+                        Acc;
+                    {ok, GwOwner} ->
+                        [#{account => ?BIN_TO_B58(GwOwner),
+                           gateway => ?BIN_TO_B58(G),
+                           amount => Amount,
+                           type => Type} | Acc]
+                end;
+            ({validator, Type, V}, Amount, Ledger, Acc) ->
+                case blockchain_ledger_v1:get_validator(V, Ledger) of
+                    {error, _Error} ->
+                        Acc;
+                    {ok, Val} ->
+                        Owner = blockchain_ledger_validator_v1:owner_address(Val),
+                        [#{account => ?BIN_TO_B58(Owner),
+                           gateway => ?BIN_TO_B58(V),
+                           amount => Amount,
+                           type => Type} | Acc]
+                end;
+            ({owner, Type, O}, Amount, _Ledger, Acc) ->
+                [#{account => ?BIN_TO_B58(O),
+                   gateway => undefined,
+                   amount => Amount,
+                   type => Type} | Acc]
+        end,
+    Rewards = case lists:keyfind(chain, 1, Opts) of
+        {chain, Chain} ->
+            Start = blockchain_txn_rewards_v2:start_epoch(Txn),
+            End = ?MODULE:end_epoch(Txn),
+            {ok, Ledger} = blockchain:ledger_at(End, Chain),
+            {ok, Metadata} = case lists:keyfind(rewards_metadata, 1, Opts) of
+                                {rewards_metadata, M} -> {ok, M};
+                                _ -> ?MODULE:calculate_rewards_metadata(Start, End, Chain)
+                            end,
+            maps:fold(
+                fun(overages, Amount, Acc) ->
+                        [#{amount => Amount,
+                           type => overages} | Acc];
+                   (_RewardCategory, Rewards, Acc0) ->
+                        maps:fold(
+                        fun(Entry, Amount, Acc) ->
+                            RewardToJson(Entry, Amount, Ledger, Acc)
+                        end, Acc0, Rewards)
+                end, [], Metadata);
+        _ -> [ reward_to_json(R, []) || R <- rewards(Txn)]
+    end,
+
+    #{
+      type => ?MODULE:json_type(),
+      hash => ?BIN_TO_B64(hash(Txn)),
+      start_epoch => start_epoch(Txn),
+      end_epoch => end_epoch(Txn),
+      rewards => Rewards
+    }.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+
+
+-spec reward_to_json( Reward :: reward_v2(),
+                      Opts :: blockchain_json:opts() ) -> blockchain_json:json_object().
+reward_to_json(#blockchain_txn_reward_v2_pb{account = Account, amount = Amt}, _Opts) ->
+    #{
+      type => <<"reward_v2">>,
+      account => ?BIN_TO_B58(Account),
+      amount => Amt
+     }.
+
+-spec new_reward( Account :: libp2p_crypto:pubkey_bin(),
+                  Amount :: non_neg_integer() ) -> reward_v2().
+new_reward(Account, Amount) ->
+    #blockchain_txn_reward_v2_pb{account=Account, amount=Amount}.
+
+-spec fold_blocks_for_rewards( Current :: pos_integer(),
+                               End :: pos_integer(),
+                               Chain :: blockchain:blockchain(),
+                               Vars :: reward_vars(),
+                               Ledger :: blockchain_ledger_v1:ledger(),
+                               Acc :: rewards_share_metadata() ) -> rewards_share_metadata().
+fold_blocks_for_rewards(Current, End, _Chain, _Vars, _Ledger, Acc) when Current == End + 1 -> Acc;
+fold_blocks_for_rewards(910360, End, Chain, Vars, Ledger, Acc) ->
+    fold_blocks_for_rewards(910361, End, Chain, Vars, Ledger, Acc);
+fold_blocks_for_rewards(Current, End, Chain, Vars, Ledger, Acc) ->
+    case blockchain:get_block(Current, Chain) of
+        {error, _Reason} = Error -> throw(Error);
+        {ok, Block} ->
+            Txns = blockchain_block:transactions(Block),
+            NewAcc = lists:foldl(fun(T, A) ->
+                                         Type = blockchain_txn:type(T),
+                                         Start = erlang:monotonic_time(microsecond),
+                                         A1 = calculate_reward_for_txn(Type, T, End,
+                                                                       A, Chain, Ledger, Vars),
+                                         perf(Type, erlang:monotonic_time(microsecond) - Start),
+                                         A1
+                                 end,
+                                 Acc, Txns),
+            fold_blocks_for_rewards(Current+1, End, Chain, Vars, Ledger, NewAcc)
+    end.
+
+-spec calculate_reward_for_txn( Type :: atom(),
+                                Txn :: blockchain_txn:txn(),
+                                End :: pos_integer(),
+                                Acc :: rewards_share_metadata(),
+                                Chain :: blockchain:blockchain(),
+                                Ledger :: blockchain_ledger_v1:ledger(),
+                                Vars :: reward_vars() ) -> rewards_share_metadata().
+calculate_reward_for_txn(?MODULE, _Txn, _End, _Acc, _Chain,
+                         _Ledger, _Vars) -> throw({error, already_existing_rewards_v2});
+calculate_reward_for_txn(blockchain_txn_rewards_v1, _Txn, _End, _Acc, _Chain,
+                         _Ledger, _Vars) -> throw({error, already_existing_rewards_v1});
+calculate_reward_for_txn(blockchain_txn_poc_receipts_v1 = T, Txn, _End,
+                         #{ poc_challenger := Challenger } = Acc, Chain, Ledger, Vars) ->
+    Start = erlang:monotonic_time(microsecond),
+    Acc0 = poc_challenger_reward(Txn, Challenger, Vars),
+    Start1 = erlang:monotonic_time(microsecond),
+    perf({T, challenger}, Start1 - Start),
+    Acc1 = calculate_poc_challengee_rewards(Txn, Acc#{ poc_challenger => Acc0 }, Chain, Ledger, Vars),
+    Start2 = erlang:monotonic_time(microsecond),
+    perf({T, challengee}, Start2 - Start1),
+    Acc2 = calculate_poc_witness_rewards(Txn, Acc1, Chain, Ledger, Vars),
+    WitnessTime = erlang:monotonic_time(microsecond) - Start2,
+    perf({T, witnesses}, WitnessTime),
+    Acc2;
+calculate_reward_for_txn(blockchain_txn_poc_receipts_v2, Txn, _End,
+                         #{ poc_challenger := Challenger } = Acc, Chain, Ledger, Vars) ->
+    Acc0 = poc_challenger_reward(Txn, Challenger, Vars),
+    Acc1 = calculate_poc_challengee_rewards(Txn, Acc#{ poc_challenger => Acc0 }, Chain, Ledger, Vars),
+    calculate_poc_witness_rewards(Txn, Acc1, Chain, Ledger, Vars);
+
+calculate_reward_for_txn(blockchain_txn_state_channel_close_v1, Txn, End, Acc, Chain, Ledger, Vars) ->
+    calculate_dc_rewards(Txn, End, Acc, Chain, Ledger, Vars);
+calculate_reward_for_txn(Type, Txn, _End, Acc, _Chain, Ledger, _Vars) ->
+    consider_overage(Type, Txn, Acc, Ledger).
+
+-spec consider_overage( Type :: atom(),
+                        Txn :: blockchain_txn:txn(),
+                        Acc :: rewards_share_metadata(),
+                        Ledger :: blockchain_ledger_v1:ledger() ) -> rewards_share_metadata().
+consider_overage(Type, Txn, Acc, Ledger) ->
+    %% calculate any fee paid in excess which we will distribute as bonus HNT
+    %% to consensus members
+    try
+        Type:calculate_fee(Txn, Ledger) - Type:fee(Txn) of
+        Overage when Overage > 0 ->
+            maps:update_with(overages, fun(Overages) -> Overages + Overage end, Overage, Acc);
+        _ ->
+            Acc
+    catch
+        _:_ ->
+            Acc
+    end.
+
+-spec calculate_poc_challengee_rewards( Txn :: blockchain_txn:txn(),
+                                        Acc :: rewards_share_metadata(),
+                                        Chain :: blockchain:blockchain(),
+                                        Ledger :: blockchain_ledger_v1:ledger(),
+                                        Vars :: reward_vars() ) -> rewards_share_metadata().
+calculate_poc_challengee_rewards(Txn, #{ poc_challengee := ChallengeeMap } = Acc,
+                                 Chain, Ledger, #{ var_map := VarMap } = Vars) ->
+    TxnType = blockchain_txn:type(Txn),
+    Path = TxnType:path(Txn),
+    NewCM = poc_challengees_rewards_(Vars, Path, Path, Txn, Chain, Ledger, true, VarMap, ChallengeeMap),
+    Acc#{ poc_challengee => NewCM }.
+
+-spec calculate_poc_witness_rewards( Txn :: blockchain_txn:txn(),
+                                     Acc :: rewards_share_metadata(),
+                                     Chain :: blockchain:blockchain(),
+                                     Ledger :: blockchain_ledger_v1:ledger(),
+                                     Vars :: reward_vars() ) -> rewards_share_metadata().
+calculate_poc_witness_rewards(Txn, #{ poc_witness := WitnessMap } = Acc, Chain, Ledger, Vars) ->
+    NewWM = poc_witness_reward(Txn, WitnessMap, Chain, Ledger, Vars),
+    Acc#{ poc_witness => NewWM }.
+
+-spec calculate_dc_rewards( Txn :: blockchain_txn:txn(),
+                            End :: pos_integer(),
+                            Acc :: rewards_share_metadata(),
+                            Chain :: blockchain:blockchain(),
+                            Ledger :: blockchain_ledger_v1:ledger(),
+                            Vars :: reward_vars() ) -> rewards_share_metadata().
+calculate_dc_rewards(Txn, End, #{ dc_rewards := DCRewardMap } = Acc, _Chain, Ledger, Vars) ->
+    NewDCM = dc_reward(Txn, End, DCRewardMap, Ledger, Vars),
+    Acc#{ dc_rewards => NewDCM }.
+
+-spec finalize_reward_calculations( AccIn :: rewards_share_metadata(),
+                                    Ledger :: blockchain_ledger_v1:ledger(),
+                                    Vars :: reward_vars() ) -> rewards_metadata().
+finalize_reward_calculations(#{ dc_rewards := DCShares,
+                                poc_witness := WitnessShares,
+                                poc_challenger := ChallengerShares,
+                                poc_challengee := ChallengeeShares } = AccIn, Ledger, Vars) ->
+    SecuritiesRewards = securities_rewards(Ledger, Vars),
+    Overages = maps:get(overages, AccIn, 0),
+    ConsensusRewards = consensus_members_rewards(Ledger, Vars, Overages),
+    {DCRemainder, DCRewards} = normalize_dc_rewards(DCShares, Vars),
+    Vars0 = maps:put(dc_remainder, DCRemainder, Vars),
+
+    %% apply the DC remainder, if any to the other PoC categories pro rata
+    %%
+    %% these normalize functions take reward "shares" and convert them
+    %% into HNT payouts
+
+    #{ poc_witness => normalize_witness_rewards(WitnessShares, Vars0),
+       poc_challenger => normalize_challenger_rewards(ChallengerShares, Vars0),
+       poc_challengee => normalize_challengee_rewards(ChallengeeShares, Vars0),
+       dc_rewards => DCRewards,
+       consensus_rewards => ConsensusRewards,
+       securities_rewards => SecuritiesRewards,
+       overages => Overages }.
+
+-spec prepare_rewards_v2_txns( Results :: rewards_metadata(),
+                               Ledger :: blockchain_ledger_v1:ledger() ) -> rewards().
+prepare_rewards_v2_txns(Results, Ledger) ->
+    %% we are going to fold over a list of keys in the rewards map (Results)
+    %% and generate a new map which has _all_ the owners and the sum of
+    %% _all_ rewards types in a new map...
+    AllRewards = lists:foldl(
+      fun(RewardCategory, Rewards) ->
+              R = maps:get(RewardCategory, Results),
+              %% R is our map of rewards of the given type
+              %% and now we are going to do a maps:fold/3
+              %% over this reward category and either
+              %% add the owner and amount for the first
+              %% time or add an amount to an existing owner
+              %% in the Rewards accumulator
+
+              maps:fold(fun(Entry, Amt, Acc) ->
+                                case Entry of
+                                    {owner, _Type, O} ->
+                                        maps:update_with(O,
+                                                         fun(Balance) -> Balance + Amt end,
+                                                         Amt,
+                                                         Acc);
+                                    {gateway, _Type, G} ->
+                                        case blockchain_ledger_v1:find_gateway_owner(G, Ledger) of
+                                            {error, _Error} -> Acc;
+                                            {ok, GwOwner} ->
+                                                maps:update_with(GwOwner,
+                                                                 fun(Balance) -> Balance + Amt end,
+                                                                 Amt,
+                                                                 Acc)
+                                        end; % gw case
+                                    {validator, _Type, V} ->
+                                        case blockchain_ledger_v1:get_validator(V, Ledger) of
+                                            {error, _} -> Acc;
+                                            {ok, Val} ->
+                                                Owner = blockchain_ledger_validator_v1:owner_address(Val),
+                                                maps:update_with(Owner,
+                                                                 fun(Balance) -> Balance + Amt end,
+                                                                 Amt,
+                                                                 Acc)
+                                         end
+                                end % Entry case
+                        end, % function
+                        Rewards,
+                        maps:iterator(R)) %% bound memory size no matter size of map
+      end,
+      #{},
+      [poc_challenger, poc_challengee, poc_witness,
+       dc_rewards, consensus_rewards, securities_rewards]),
+
+    %% now we are going to fold over all rewards and construct our
+    %% transaction for the blockchain
+
+    Rewards = maps:fold(fun(Owner, 0, Acc) ->
+                                lager:debug("Dropping reward for ~p because the amount is 0",
+                                            [?BIN_TO_B58(Owner)]),
+                                Acc;
+                            (Owner, Amount, Acc) ->
+                                [ new_reward(Owner, Amount) | Acc ]
+                        end,
+              [],
+              maps:iterator(AllRewards)), %% again, bound memory no matter size of map
+
+    %% sort the rewards list before it gets returned so list ordering is deterministic
+    %% (map keys can be enumerated in any arbitrary order)
+    lists:sort(Rewards).
+
+-spec get_reward_vars(pos_integer(), pos_integer(), blockchain_ledger_v1:ledger()) -> reward_vars().
+get_reward_vars(Start, End, Ledger) ->
+    {ok, MonthlyReward} = blockchain:config(?monthly_reward, Ledger),
+    {ok, SecuritiesPercent} = blockchain:config(?securities_percent, Ledger),
+    {ok, PocChallengeesPercent} = blockchain:config(?poc_challengees_percent, Ledger),
+    {ok, PocChallengersPercent} = blockchain:config(?poc_challengers_percent, Ledger),
+    {ok, PocWitnessesPercent} = blockchain:config(?poc_witnesses_percent, Ledger),
+    {ok, ConsensusPercent} = blockchain:config(?consensus_percent, Ledger),
+    {ok, OraclePrice} = blockchain_ledger_v1:current_oracle_price(Ledger),
+    DCPercent = case blockchain:config(?dc_percent, Ledger) of
+                    {ok, R1} ->
+                        R1;
+                    _ ->
+                        0
+                end,
+    SCGrace = case blockchain:config(?sc_grace_blocks, Ledger) of
+                  {ok, R2} ->
+                      R2;
+                  _ ->
+                      0
+              end,
+    SCVersion = case blockchain:config(?sc_version, Ledger) of
+                    {ok, R3} ->
+                        R3;
+                    _ ->
+                        1
+                end,
+    SCDisputeStrategyVersion = case blockchain:config(?sc_dispute_strategy_version, Ledger) of
+                                   {ok, SCDV} -> SCDV;
+                                   _ -> 0
+                               end,
+    POCVersion = case blockchain:config(?poc_version, Ledger) of
+                     {ok, V} -> V;
+                     _ -> 1
+                 end,
+    RewardVersion = case blockchain:config(?reward_version, Ledger) of
+        {ok, R4} -> R4;
+        _ -> 1
+    end,
+
+    WitnessRedundancy = case blockchain:config(?witness_redundancy, Ledger) of
+                            {ok, WR} -> WR;
+                            _ -> undefined
+                        end,
+
+    DecayRate = case blockchain:config(?poc_reward_decay_rate, Ledger) of
+                    {ok, R} -> R;
+                    _ -> undefined
+                end,
+
+    DensityTgtRes = case blockchain:config(?density_tgt_res, Ledger) of
+                        {ok, D} -> D;
+                        _ -> undefined
+                    end,
+
+    HIP15TxRewardUnitCap = case blockchain:config(?hip15_tx_reward_unit_cap, Ledger) of
+                          {ok, Val} -> Val;
+                          _ -> undefined
+                      end,
+
+    {ok, ElectionInterval} = blockchain:config(?election_interval, Ledger),
+    {ok, ElectionRestartInterval} = blockchain:config(?election_restart_interval, Ledger),
+    {ok, BlockTime} = blockchain:config(?block_time, Ledger),
+
+    WitnessRewardDecayRate = case blockchain:config(?witness_reward_decay_rate, Ledger) of
+                                 {ok, Dec} -> Dec;
+                                 _ -> undefined
+                             end,
+
+    WitnessRewardDecayExclusion =
+        case blockchain:config(?witness_reward_decay_exclusion, Ledger) of
+            {ok, Exc} -> Exc;
+            _ -> undefined
+        end,
+
+    PocChallengerType =
+        case blockchain:config(?poc_challenger_type, Ledger) of
+            {ok, validator} -> validator;
+            _ -> gateway
+        end,
+
+    EpochReward = calculate_epoch_reward(Start, End, Ledger),
+    #{
+        monthly_reward => MonthlyReward,
+        epoch_reward => EpochReward,
+        oracle_price => OraclePrice,
+        securities_percent => SecuritiesPercent,
+        poc_challengees_percent => PocChallengeesPercent,
+        poc_challengers_percent => PocChallengersPercent,
+        poc_witnesses_percent => PocWitnessesPercent,
+        consensus_percent => ConsensusPercent,
+        dc_percent => DCPercent,
+        poc_challenger_type => PocChallengerType,
+        sc_grace_blocks => SCGrace,
+        sc_version => SCVersion,
+        sc_dispute_strategy_version => SCDisputeStrategyVersion,
+        poc_version => POCVersion,
+        reward_version => RewardVersion,
+        witness_redundancy => WitnessRedundancy,
+        poc_reward_decay_rate => DecayRate,
+        density_tgt_res => DensityTgtRes,
+        hip15_tx_reward_unit_cap => HIP15TxRewardUnitCap,
+        election_interval => ElectionInterval,
+        election_restart_interval => ElectionRestartInterval,
+        block_time => BlockTime,
+        witness_reward_decay_rate => WitnessRewardDecayRate,
+        witness_reward_decay_exclusion => WitnessRewardDecayExclusion
+    }.
+
+-spec calculate_epoch_reward(pos_integer(), pos_integer(), blockchain_ledger_v1:ledger()) -> float().
+calculate_epoch_reward(Start, End, Ledger) ->
+    Version = case blockchain:config(?reward_version, Ledger) of
+        {ok, V} -> V;
+        _ -> 1
+    end,
+    calculate_epoch_reward(Version, Start, End, Ledger).
+
+-spec calculate_epoch_reward(pos_integer(), pos_integer(), pos_integer(), blockchain_ledger_v1:ledger()) -> float().
+calculate_epoch_reward(Version, Start, End, Ledger) ->
+    {ok, ElectionInterval} = blockchain:config(?election_interval, Ledger),
+    {ok, BlockTime0} = blockchain:config(?block_time, Ledger),
+    {ok, MonthlyReward} = blockchain:config(?monthly_reward, Ledger),
+    calculate_epoch_reward(Version, Start, End, BlockTime0,
+                           ElectionInterval, MonthlyReward, Ledger).
+
+calculate_net_emissions_reward(Ledger) ->
+    case blockchain:config(?net_emissions_enabled, Ledger) of
+        {ok, true} ->
+            %% initial proposed max 34.24
+            {ok, Max} = blockchain:config(?net_emissions_max_rate, Ledger),
+            {ok, Burned} = blockchain_ledger_v1:hnt_burned(Ledger),
+            {ok, Overage} = blockchain_ledger_v1:net_overage(Ledger),
+            min(Max, Burned + Overage);
+        _ ->
+            0
+    end.
+
+-spec calculate_epoch_reward(pos_integer(), pos_integer(), pos_integer(),
+                             pos_integer(), pos_integer(), pos_integer(),
+                             blockchain_ledger_v1:ledger()) -> float().
+calculate_epoch_reward(Version, Start, End, BlockTime0, _ElectionInterval, MonthlyReward, Ledger) when Version >= 6 ->
+    BlockTime1 = (BlockTime0/1000),
+    % Convert to blocks per min
+    BlockPerMin = 60/BlockTime1,
+    % Convert to blocks per hour
+    BlockPerHour = BlockPerMin*60,
+    % Calculate election interval in blocks
+    ElectionInterval = End - Start + 1, % epoch is inclusive of start and end
+    ElectionPerHour = BlockPerHour/ElectionInterval,
+    Reward = MonthlyReward/30/24/ElectionPerHour,
+    Extra = calculate_net_emissions_reward(Ledger),
+    Reward + Extra;
+calculate_epoch_reward(Version, Start, End, BlockTime0, _ElectionInterval, MonthlyReward, Ledger) when Version >= 2 ->
+    BlockTime1 = (BlockTime0/1000),
+    % Convert to blocks per min
+    BlockPerMin = 60/BlockTime1,
+    % Convert to blocks per hour
+    BlockPerHour = BlockPerMin*60,
+    % Calculate election interval in blocks
+    ElectionInterval = End - Start,
+    ElectionPerHour = BlockPerHour/ElectionInterval,
+    Reward = MonthlyReward/30/24/ElectionPerHour,
+    Extra = calculate_net_emissions_reward(Ledger),
+    Reward + Extra;
+calculate_epoch_reward(_Version, _Start, _End, BlockTime0, ElectionInterval, MonthlyReward, Ledger) ->
+    BlockTime1 = (BlockTime0/1000),
+    % Convert to blocks per min
+    BlockPerMin = 60/BlockTime1,
+    % Convert to blocks per hour
+    BlockPerHour = BlockPerMin*60,
+    % Calculate number of elections per hour
+    ElectionPerHour = BlockPerHour/ElectionInterval,
+    Reward = MonthlyReward/30/24/ElectionPerHour,
+    Extra = calculate_net_emissions_reward(Ledger),
+    Reward + Extra.
+
+
+
+-spec calculate_consensus_epoch_reward(pos_integer(), pos_integer(),
+                                       map(), blockchain_ledger_v1:ledger()) -> float().
+calculate_consensus_epoch_reward(Start, End, Vars, Ledger) ->
+
+    #{ block_time := BlockTime0,
+       election_interval := ElectionInterval,
+       election_restart_interval := ElectionRestartInterval,
+       monthly_reward := MonthlyReward } = Vars,
+    BlockTime1 = (BlockTime0/1000),
+    % Convert to blocks per min
+    BlockPerMin = 60/BlockTime1,
+    % Convert to blocks per month
+    BlockPerMonth = BlockPerMin*60*24*30,
+    % Calculate epoch length in blocks, cap at election interval + grace period
+    EpochLength = erlang:min(End - Start + 1, ElectionInterval + ElectionRestartInterval),
+    Reward = (MonthlyReward/BlockPerMonth) * EpochLength,
+    Extra = calculate_net_emissions_reward(Ledger),
+    Reward + Extra.
+
+-spec consensus_members_rewards(blockchain_ledger_v1:ledger(),
+                                reward_vars(),
+                                non_neg_integer()) -> rewards_map().
+consensus_members_rewards(Ledger, #{consensus_epoch_reward := EpochReward,
+                                    consensus_percent := ConsensusPercent}, OverageTotal) ->
+    GwOrVal =
+        case blockchain:config(?election_version, Ledger) of
+            {ok, N} when N >= 5 ->
+                validator;
+            _ ->
+                gateway
+        end,
+    {ok, Members} = blockchain_ledger_v1:consensus_members(Ledger),
+    Count = erlang:length(Members),
+    OveragePerMember = OverageTotal div Count,
+    ConsensusReward = EpochReward * ConsensusPercent,
+    lists:foldl(
+      fun(Member, Acc) ->
+              PercentofReward = 100/Count/100,
+              Amount = erlang:round(PercentofReward*ConsensusReward),
+              %% in transitional blocks and in the last reward block of v5 it's possible to still
+              %% have gateways in who need to be rewarded, so make sure that everyone gets tagged
+              %% correctly with the proper code path
+              Actual =
+                  case GwOrVal of
+                      validator ->
+                          case blockchain_ledger_v1:get_validator(Member, Ledger) of
+                              {ok, _} -> validator;
+                              {error, not_found} -> gateway
+                          end;
+                      gateway -> gateway
+                  end,
+              maps:put({Actual, consensus, Member}, Amount+OveragePerMember, Acc)
+      end,
+      #{},
+      Members).
+
+-spec securities_rewards(blockchain_ledger_v1:ledger(),
+                         reward_vars()) -> rewards_map().
+securities_rewards(Ledger, #{epoch_reward := EpochReward,
+                             securities_percent := SecuritiesPercent}) ->
+    Securities = blockchain_ledger_v1:securities(Ledger),
+    TotalSecurities = maps:fold(
+        fun(_, Entry, Acc) ->
+            Acc + blockchain_ledger_security_entry_v1:balance(Entry)
+        end,
+        0,
+        Securities
+    ),
+    SecuritiesReward = EpochReward * SecuritiesPercent,
+    maps:fold(
+        fun(Key, Entry, Acc) ->
+            Balance = blockchain_ledger_security_entry_v1:balance(Entry),
+            PercentofReward = (Balance*100/TotalSecurities)/100,
+            Amount = erlang:round(PercentofReward*SecuritiesReward),
+            maps:put({owner, securities, Key}, Amount, Acc)
+        end,
+        #{},
+        Securities
+    ).
+
+-spec poc_challenger_reward( Txn :: blockchain_txn:txn(),
+                             Acc :: rewards_share_map(),
+                             Vars :: reward_vars() ) -> rewards_share_map().
+poc_challenger_reward(Txn, ChallengerRewards, #{poc_version := Version}) ->
+    TxnType = blockchain_txn:type(Txn),
+    Challenger = TxnType:challenger(Txn),
+    I = maps:get(Challenger, ChallengerRewards, 0),
+    case TxnType:check_path_continuation(
+           TxnType:path(Txn)) of
+        true when is_integer(Version) andalso Version > 4 ->
+            maps:put(Challenger, I+2, ChallengerRewards);
+        _ ->
+            maps:put(Challenger, I+1, ChallengerRewards)
+    end.
+
+-spec normalize_challenger_rewards( ChallengerRewards :: rewards_share_map(),
+                                    Vars :: reward_vars() ) -> rewards_map().
+normalize_challenger_rewards(ChallengerRewards,
+                             #{epoch_reward := EpochReward,
+                               poc_challengers_percent := PocChallengersPercent,
+                               poc_challenger_type := PocChallengerType}=Vars) ->
+    TotalChallenged = lists:sum(maps:values(ChallengerRewards)),
+    ShareOfDCRemainder =
+        case PocChallengerType of
+            validator ->
+                0;
+            _ ->
+                share_of_dc_rewards(poc_challengers_percent, Vars)
+        end,
+    ChallengersReward = (EpochReward * PocChallengersPercent) + ShareOfDCRemainder,
+    maps:fold(
+        fun(Challenger, Challenged, Acc) ->
+            PercentofReward = (Challenged*100/TotalChallenged)/100,
+            Amount = erlang:round(PercentofReward * ChallengersReward),
+            maps:put({PocChallengerType, poc_challengers, Challenger}, Amount, Acc)
+        end,
+        #{},
+        ChallengerRewards
+    ).
+
+-spec normalize_challengee_rewards( ChallengeeRewards :: rewards_share_map(),
+                                    Vars :: reward_vars() ) -> rewards_map().
+normalize_challengee_rewards(ChallengeeRewards, #{epoch_reward := EpochReward,
+                                                  poc_challengees_percent := PocChallengeesPercent}=Vars) ->
+    TotalChallenged = lists:sum(maps:values(ChallengeeRewards)),
+    ShareOfDCRemainder = share_of_dc_rewards(poc_challengees_percent, Vars),
+    ChallengeesReward = (EpochReward * PocChallengeesPercent) + ShareOfDCRemainder,
+    maps:fold(
+        fun(Challengee, Challenged, Acc) ->
+            PercentofReward = (Challenged*100/TotalChallenged)/100,
+            % TODO: Not sure about the all round thing...
+            Amount = erlang:round(PercentofReward*ChallengeesReward),
+            maps:put({gateway, poc_challengees, Challengee}, Amount, Acc)
+        end,
+        #{},
+        ChallengeeRewards
+    ).
+
+-spec poc_challengees_rewards_( Vars :: reward_vars(),
+                                Paths :: blockchain_poc_path_element_v1:poc_path(),
+                                StaticPath :: blockchain_poc_path_element_v1:poc_path(),
+                                Txn :: blockchain_poc_receipts_v1:txn_poc_receipts(),
+                                Chain :: blockchain:blockchain(),
+                                Ledger :: blockchain_ledger_v1:ledger(),
+                                IsFirst :: boolean(),
+                                VarMap :: blockchain_hex:var_map(),
+                                Acc0 :: rewards_share_map() ) -> rewards_share_map().
+poc_challengees_rewards_(_Vars, [], _StaticPath, _Txn, _Chain, _Ledger, _, _, Acc) ->
+    Acc;
+poc_challengees_rewards_(#{poc_version := Version}=Vars,
+                         [Elem|Path],
+                         StaticPath,
+                         Txn,
+                         Chain,
+                         Ledger,
+                         IsFirst,
+                         VarMap,
+                         Acc0) when Version >= 2 ->
+    RegionVars = maps:get(region_vars, Vars), % explode on purpose
+    TxnType = blockchain_txn:type(Txn),
+    WitnessRedundancy = maps:get(witness_redundancy, Vars, undefined),
+    DecayRate = maps:get(poc_reward_decay_rate, Vars, undefined),
+    DensityTgtRes = maps:get(density_tgt_res, Vars, undefined),
+    HIP15TxRewardUnitCap = maps:get(hip15_tx_reward_unit_cap, Vars, undefined),
+    %% check if there were any legitimate witnesses
+    WitStart = erlang:monotonic_time(microsecond),
+    Witnesses = legit_witnesses(Txn, Chain, Ledger, Elem, StaticPath, RegionVars, Version),
+    WitEnd = erlang:monotonic_time(microsecond),
+    perf({challengee, witness}, WitEnd - WitStart),
+    Challengee = blockchain_poc_path_element_v1:challengee(Elem),
+    ChallengeeLoc = case blockchain_ledger_v1:find_gateway_location(Challengee, Ledger) of
+                        {ok, CLoc} ->
+                            CLoc;
+                        _ ->
+                            undefined
+                    end,
+    I = maps:get(Challengee, Acc0, 0),
+    case blockchain_poc_path_element_v1:receipt(Elem) of
+        undefined ->
+            Acc1 = case
+                       Witnesses /= [] orelse
+                       TxnType:check_path_continuation(Path)
+                   of
+                       true when is_integer(Version), Version > 4, IsFirst == true ->
+                           %% while we don't have a receipt for this node, we do know
+                           %% there were witnesses or the path continued which means
+                           %% the challengee transmitted
+                           case poc_challengee_reward_unit(WitnessRedundancy, DecayRate, HIP15TxRewardUnitCap, Witnesses) of
+                               {error, _} ->
+                                   %% Old behavior
+                                   maps:put(Challengee, I+1, Acc0);
+                               {ok, ToAdd} ->
+                                   TxScale = maybe_calc_tx_scale(Challengee,
+                                                                 DensityTgtRes,
+                                                                 ChallengeeLoc,
+                                                                 VarMap,
+                                                                 Ledger),
+                                   maps:put(Challengee, I+(ToAdd * TxScale), Acc0)
+                           end;
+                       true when is_integer(Version), Version > 4, IsFirst == false ->
+                           %% while we don't have a receipt for this node, we do know
+                           %% there were witnesses or the path continued which means
+                           %% the challengee transmitted
+                           %% Additionally, we know this layer came in over radio so
+                           %% there's an implicit rx as well
+                           case poc_challengee_reward_unit(WitnessRedundancy, DecayRate, HIP15TxRewardUnitCap, Witnesses) of
+                               {error, _} ->
+                                   %% Old behavior
+                                   maps:put(Challengee, I+2, Acc0);
+                               {ok, ToAdd} ->
+                                   TxScale = maybe_calc_tx_scale(Challengee,
+                                                                 DensityTgtRes,
+                                                                 ChallengeeLoc,
+                                                                 VarMap,
+                                                                 Ledger),
+                                   maps:put(Challengee, I+(ToAdd * TxScale), Acc0)
+                           end;
+                       _ ->
+                           Acc0
+                   end,
+            poc_challengees_rewards_(Vars, Path, StaticPath, Txn, Chain, Ledger, false, VarMap, Acc1);
+        Receipt ->
+            case blockchain_poc_receipt_v1:origin(Receipt) of
+                radio ->
+                    Acc1 = case
+                               Witnesses /= [] orelse
+                               TxnType:check_path_continuation(Path)
+                           of
+                               true when is_integer(Version), Version > 4 ->
+                                   %% this challengee both rx'd and tx'd over radio
+                                   %% AND sent a receipt
+                                   %% so give them 3 payouts
+                                   case poc_challengee_reward_unit(WitnessRedundancy, DecayRate, HIP15TxRewardUnitCap, Witnesses) of
+                                       {error, _} ->
+                                           %% Old behavior
+                                           maps:put(Challengee, I+3, Acc0);
+                                       {ok, ToAdd} ->
+                                           TxScale = maybe_calc_tx_scale(Challengee,
+                                                                         DensityTgtRes,
+                                                                         ChallengeeLoc,
+                                                                         VarMap,
+                                                                         Ledger),
+                                           maps:put(Challengee, I+(ToAdd * TxScale), Acc0)
+                                   end;
+                               false when is_integer(Version), Version > 4 ->
+                                   %% this challengee rx'd and sent a receipt
+                                   case poc_challengee_reward_unit(WitnessRedundancy, DecayRate, HIP15TxRewardUnitCap, Witnesses) of
+                                       {error, _} ->
+                                           %% Old behavior
+                                           maps:put(Challengee, I+2, Acc0);
+                                       {ok, ToAdd} ->
+                                           TxScale = maybe_calc_tx_scale(Challengee,
+                                                                         DensityTgtRes,
+                                                                         ChallengeeLoc,
+                                                                         VarMap,
+                                                                         Ledger),
+                                           maps:put(Challengee, I+(ToAdd * TxScale), Acc0)
+                                   end;
+                               _ ->
+                                   %% Old behavior
+                                   maps:put(Challengee, I+1, Acc0)
+                           end,
+                    poc_challengees_rewards_(Vars, Path, StaticPath, Txn, Chain, Ledger, false, VarMap, Acc1);
+                p2p ->
+                    %% if there are legitimate witnesses or the path continues
+                    %% the challengee did their job
+                    Acc1 = case
+                               Witnesses /= [] orelse
+                               TxnType:check_path_continuation(Path)
+                           of
+                               false ->
+                                   %% path did not continue, this is an 'all gray' path
+                                   Acc0;
+                               true when is_integer(Version), Version > 4 ->
+                                   %% Sent a receipt and the path continued on
+                                   case poc_challengee_reward_unit(WitnessRedundancy, DecayRate, HIP15TxRewardUnitCap, Witnesses) of
+                                       {error, _} ->
+                                           %% Old behavior
+                                           maps:put(Challengee, I+2, Acc0);
+                                       {ok, ToAdd} ->
+                                           TxScale = maybe_calc_tx_scale(Challengee,
+                                                                         DensityTgtRes,
+                                                                         ChallengeeLoc,
+                                                                         VarMap,
+                                                                         Ledger),
+                                           maps:put(Challengee, I+(ToAdd * TxScale), Acc0)
+                                   end;
+                               true ->
+                                   maps:put(Challengee, I+1, Acc0)
+                           end,
+                    poc_challengees_rewards_(Vars, Path, StaticPath, Txn, Chain, Ledger, false, VarMap, Acc1)
+            end
+    end;
+poc_challengees_rewards_(Vars, [Elem|Path], StaticPath, Txn, Chain, Ledger, _IsFirst, VarMap, Acc0) ->
+    case blockchain_poc_path_element_v1:receipt(Elem) of
+        undefined ->
+            poc_challengees_rewards_(Vars, Path, StaticPath, Txn, Chain, Ledger, false, VarMap, Acc0);
+        _Receipt ->
+            Challengee = blockchain_poc_path_element_v1:challengee(Elem),
+            I = maps:get(Challengee, Acc0, 0),
+            Acc1 =  maps:put(Challengee, I+1, Acc0),
+            poc_challengees_rewards_(Vars, Path, StaticPath, Txn, Chain, Ledger, false, VarMap, Acc1)
+    end.
+
+-spec poc_challengee_reward_unit(WitnessRedundancy :: undefined | pos_integer(),
+                                 DecayRate :: undefined | float(),
+                                 HIP15TxRewardUnitCap :: undefined | float(),
+                                 Witnesses :: blockchain_poc_witness_v1:poc_witnesses()) -> {error, any()} | {ok, float()}.
+poc_challengee_reward_unit(WitnessRedundancy, DecayRate, HIP15TxRewardUnitCap, Witnesses) ->
+    case {WitnessRedundancy, DecayRate} of
+        {undefined, _} -> {error, witness_redundancy_undefined};
+        {_, undefined} -> {error, poc_reward_decay_rate_undefined};
+        {N, R} ->
+            W = length(Witnesses),
+            Unit = poc_reward_tx_unit(R, W, N),
+            NUnit = normalize_reward_unit(HIP15TxRewardUnitCap, Unit),
+            {ok, NUnit}
+    end.
+
+-spec normalize_reward_unit(HIP15TxRewardUnitCap :: undefined | float(), Unit :: float()) -> float().
+normalize_reward_unit(undefined, Unit) when Unit > 1.0 -> 1.0;
+normalize_reward_unit(undefined, Unit) -> Unit;
+normalize_reward_unit(HIP15TxRewardUnitCap, Unit) when Unit >= HIP15TxRewardUnitCap -> HIP15TxRewardUnitCap;
+normalize_reward_unit(_TxRewardUnitCap, Unit) -> Unit.
+
+-spec normalize_reward_unit(Unit :: float()) -> float().
+normalize_reward_unit(Unit) when Unit > 1.0 -> 1.0;
+normalize_reward_unit(Unit) -> Unit.
+
+-spec poc_witness_reward( Txn :: blockchain_txn_poc_receipts_v1:txn_poc_receipts() |
+                                 blockchain_txn_poc_receipts_v2:txn_poc_receipts(),
+                          AccIn :: rewards_share_map(),
+                          Chain :: blockchain:blockchain(),
+                          Ledger :: blockchain_ledger_v1:ledger(),
+                          Vars :: reward_vars() ) -> rewards_share_map().
+poc_witness_reward(Txn, AccIn,
+                   Chain, Ledger,
+                   #{ poc_version := POCVersion,
+                      var_map := VarMap } = Vars) when is_integer(POCVersion)
+                                                       andalso POCVersion >= 9 ->
+    TxnType = blockchain_txn:type(Txn),
+    WitnessRedundancy = maps:get(witness_redundancy, Vars, undefined),
+    DecayRate = maps:get(poc_reward_decay_rate, Vars, undefined),
+    DensityTgtRes = maps:get(density_tgt_res, Vars, undefined),
+    RegionVars = maps:get(region_vars, Vars), % explode on purpose
+    KeyHash = TxnType:onion_key_hash(Txn),
+
+    try
+        %% Get channels without validation
+        {ok, Channels} = TxnType:get_channels(Txn, POCVersion, RegionVars, Chain),
+        Path = TxnType:path(Txn),
+
+        %% Do the new thing for witness filtering
+        lists:foldl(
+                fun(Elem, Acc1) ->
+                        ElemPos = blockchain_utils:index_of(Elem, Path),
+                        WitnessChannel = lists:nth(ElemPos, Channels),
+                        WitStart = erlang:monotonic_time(microsecond),
+                        ElemHash = erlang:phash2(Elem),
+                        ValidWitnesses =
+                            case get({KeyHash, ElemHash}) of
+                                undefined ->
+                                    VW = TxnType:valid_witnesses(Elem, WitnessChannel, RegionVars, Ledger),
+                                    put({KeyHash, ElemHash}, VW),
+                                    VW;
+                                VW -> VW
+                            end,
+                        case ValidWitnesses of
+                            [] -> Acc1;
+                            [_|_] ->
+                                %% lager:info("witness witness ~p", [erlang:phash2(ValidWitnesses)]),
+                                WitEnd = erlang:monotonic_time(microsecond),
+                                perf({witnesses, witness}, WitEnd - WitStart),
+                                %% We found some valid witnesses, we only apply
+                                %% the witness_redundancy and decay_rate if
+                                %% BOTH are set as chain variables, otherwise
+                                %% we default to the old behavior and set
+                                %% ToAdd=1
+                                %%
+                                %% If both witness_redundancy and decay_rate
+                                %% are set, we calculate a scaled rx unit (the
+                                %% value ToAdd)
+                                %%
+                                %% This is determined using the formulae
+                                %% mentioned in hip15
+                                ToAdd = case {WitnessRedundancy, DecayRate} of
+                                            {undefined, _} -> 1;
+                                            {_, undefined} -> 1;
+                                            {N, R} ->
+                                                W = length(ValidWitnesses),
+                                                poc_witness_reward_unit(R, W, N)
+                                        end,
+
+                                 case DensityTgtRes of
+                                     undefined ->
+                                         %% old (HIP15)
+                                         lists:foldl(
+                                           fun(WitnessRecord, Acc2) ->
+                                                   Witness = blockchain_poc_witness_v1:gateway(WitnessRecord),
+                                                   {C, I} = maps:get(Witness, Acc2, {0, 0}),
+                                                   maps:put(Witness, {C+1, I+(ToAdd * witness_decay(C, Vars))}, Acc2)
+                                           end,
+                                           Acc1,
+                                           ValidWitnesses);
+                                     D ->
+                                         %% new (HIP17)
+                                         lists:foldl(
+                                           fun(WitnessRecord, Acc2) ->
+                                                   Challengee = blockchain_poc_path_element_v1:challengee(Elem),
+                                                   %% This must always be {ok, ...}
+                                                   %% Challengee must have a location
+                                                   {ok, ChallengeeLoc} =
+                                                      blockchain_ledger_v1:find_gateway_location(Challengee, Ledger),
+                                                   Witness =
+                                                      blockchain_poc_witness_v1:gateway(WitnessRecord),
+                                                   %% The witnesses get scaled by the value of their transmitters
+                                                   RxScale = blockchain_utils:normalize_float(
+                                                                 blockchain_hex:scale(ChallengeeLoc,
+                                                                                      VarMap,
+                                                                                      D,
+                                                                                      Ledger)),
+                                                   Value = blockchain_utils:normalize_float(ToAdd * RxScale),
+                                                   {C, I} = maps:get(Witness, Acc2, {0, 0}),
+                                                   maps:put(Witness, {C+1, I+(Value * witness_decay(C, Vars))}, Acc2)
+                                           end,
+                                           Acc1,
+                                           ValidWitnesses)
+                                  end
+                        end
+                end,
+                AccIn,
+                Path)
+    catch
+        throw:{error, {unknown_region, Region}}:_ST ->
+            lager:error("Reported unknown_region: ~p", [Region]),
+            AccIn;
+        What:Why:ST ->
+            lager:error("failed to calculate poc_witness_rewards, error ~p:~p:~p", [What, Why, ST]),
+            AccIn
+    end;
+poc_witness_reward(Txn, AccIn, _Chain, Ledger,
+                   #{ poc_version := POCVersion } = Vars) when is_integer(POCVersion)
+                                                        andalso POCVersion > 4 ->
+    TxnType = blockchain_txn:type(Txn),
+    lists:foldl(
+      fun(Elem, A) ->
+              case TxnType:good_quality_witnesses(Elem, Ledger) of
+                  [] ->
+                      A;
+                  GoodQualityWitnesses ->
+                      lists:foldl(
+                        fun(WitnessRecord, Map) ->
+                                Witness = blockchain_poc_witness_v1:gateway(WitnessRecord),
+                                {C, I} = maps:get(Witness, Map, {0, 0}),
+                                maps:put(Witness, {C+1, I+(1 * witness_decay(C, Vars))}, Map)
+                        end,
+                        A,
+                        GoodQualityWitnesses)
+              end
+      end,
+      AccIn,
+      TxnType:path(Txn)
+     );
+poc_witness_reward(Txn, AccIn, _Chain, _Ledger, Vars) ->
+    TxnType = blockchain_txn:type(Txn),
+    lists:foldl(
+      fun(Elem, A) ->
+              lists:foldl(
+                fun(WitnessRecord, Map) ->
+                        Witness = blockchain_poc_witness_v1:gateway(WitnessRecord),
+                        {C, I} = maps:get(Witness, Map, {0, 0}),
+                        maps:put(Witness, {C+1, I+(1 * witness_decay(C, Vars))}, Map)
+                end,
+                A,
+                blockchain_poc_path_element_v1:witnesses(Elem))
+      end,
+      AccIn,
+      TxnType:path(Txn)).
+
+-spec normalize_witness_rewards( WitnessRewards :: rewards_share_map(),
+                                 Vars :: reward_vars() ) -> rewards_map().
+normalize_witness_rewards(WitnessRewards, #{epoch_reward := EpochReward,
+                                            poc_witnesses_percent := PocWitnessesPercent}=Vars) ->
+    TotalWitnesses = lists:sum(element(2, lists:unzip(maps:values(WitnessRewards)))),
+    ShareOfDCRemainder = share_of_dc_rewards(poc_witnesses_percent, Vars),
+    WitnessesReward = (EpochReward * PocWitnessesPercent) + ShareOfDCRemainder,
+    maps:fold(
+        fun(Witness, {_Count, Witnessed}, Acc) ->
+            PercentofReward = (Witnessed*100/TotalWitnesses)/100,
+            Amount = erlang:round(PercentofReward*WitnessesReward),
+            maps:put({gateway, poc_witnesses, Witness}, Amount, Acc)
+        end,
+        #{},
+        WitnessRewards
+    ).
+
+-spec collect_dc_rewards_from_previous_epoch_grace(
+        Start :: non_neg_integer(),
+        End :: non_neg_integer(),
+        Chain :: blockchain:blockchain(),
+        Vars :: reward_vars(),
+        Ledger :: blockchain_ledger_v1:ledger()) -> {ok, dc_rewards_share_map()} | {error, any()}.
+collect_dc_rewards_from_previous_epoch_grace(Start, End, Chain,
+                                             #{sc_grace_blocks := Grace,
+                                               reward_version := RV} = Vars,
+                                             Ledger) when RV > 4 ->
+    scan_grace_block(max(1, Start - Grace), Start, End, Vars, Chain, Ledger, #{});
+collect_dc_rewards_from_previous_epoch_grace(_Start, _End, _Chain, _Vars, _Ledger) -> {ok, #{}}.
+
+-spec scan_grace_block( Current :: pos_integer(),
+                        Start :: pos_integer(),
+                        End :: pos_integer(),
+                        Vars :: reward_vars(),
+                        Chain :: blockchain:blockchain(),
+                        Ledger :: blockchain_ledger_v1:ledger(),
+                        Acc :: dc_rewards_share_map() ) -> {ok, dc_rewards_share_map()} | {error, term()}.
+scan_grace_block(Current, Start, _End, _Vars, _Chain, _Ledger, Acc)
+                                           when Current == Start + 1 -> {ok, Acc};
+scan_grace_block(Current, Start, End, Vars, Chain, Ledger, Acc) ->
+    case blockchain:get_block(Current, Chain) of
+        {error, _Error} = Err ->
+            lager:error("failed to get grace block ~p ~p", [_Error, Current]),
+            Err;
+        {ok, Block} ->
+            Txns = blockchain_block:transactions(Block),
+            NewAcc = lists:foldl(fun(T, A) ->
+                                         case blockchain_txn:type(T) of
+                                             blockchain_txn_state_channel_close_v1 ->
+                                                 dc_reward(T, End, A, Ledger, Vars);
+                                             _ -> A
+                                         end
+                                 end,
+                                 Acc,
+                                 Txns),
+            scan_grace_block(Current+1, Start, End, Vars, Chain, Ledger, NewAcc)
+    end.
+
+-spec dc_reward( Txn :: blockchain_txn_state_channel_close_v1:txn_state_channel_close(),
+                 End :: pos_integer(),
+                 AccIn :: dc_rewards_share_map(),
+                 Ledger :: blockchain_ledger_v1:ledger(),
+                 Vars :: reward_vars() ) -> dc_rewards_share_map().
+dc_reward(Txn, End, AccIn, Ledger, #{ sc_grace_blocks := GraceBlocks,
+                                      sc_version := 2} = Vars) ->
+    case blockchain_txn_state_channel_close_v1:state_channel_expire_at(Txn) + GraceBlocks < End of
+        true ->
+            SCID = blockchain_txn_state_channel_close_v1:state_channel_id(Txn),
+            case lists:member(SCID, maps:get(seen, AccIn, [])) of
+                false ->
+                    %% haven't seen this state channel yet, pull the final result from the ledger
+                    case blockchain_ledger_v1:find_state_channel(
+                           blockchain_txn_state_channel_close_v1:state_channel_id(Txn),
+                           blockchain_txn_state_channel_close_v1:state_channel_owner(Txn),
+                           Ledger) of
+                        {ok, SC} ->
+                            %% check for a holdover v1 channel
+                            case blockchain_ledger_state_channel_v2:is_v2(SC) of
+                                true ->
+                                    %% pull out the final version of the state channel
+                                    FinalSC = blockchain_ledger_state_channel_v2:state_channel(SC),
+                                    RewardVersion = maps:get(reward_version, Vars, 1),
+                                    CloseState = blockchain_ledger_state_channel_v2:close_state(SC),
+                                    SCDisputeStrategy = maps:get(?sc_dispute_strategy_version, Vars, 0),
+                                    {Summaries, Bonus} =
+                                        case {SCDisputeStrategy, CloseState} of
+                                            {Ver, dispute} when Ver >= 1 ->
+                                                %% When sc_dispute_strategy_version is 1 we want to zero out as much as possible.
+                                                %% No Bonuses, no summaries. All slashed.
+                                                {[], 0};
+                                            {_, _} ->
+
+                                                InnerSummaries = case RewardVersion > 3 of
+                                                                     %% reward version 4 normalizes payouts
+                                                                     true -> blockchain_state_channel_v1:summaries(blockchain_state_channel_v1:normalize(FinalSC));
+                                                                     false -> blockchain_state_channel_v1:summaries(FinalSC)
+                                                                 end,
+
+                                                %% check the dispute status
+                                                InnerBonus = case blockchain_ledger_state_channel_v2:close_state(SC) of
+                                                                 %% Reward version 4 or higher just slashes overcommit
+                                                                 dispute when RewardVersion < 4 ->
+                                                                     %% the owner of the state channel
+                                                                     %% did a naughty thing, divide
+                                                                     %% their overcommit between the
+                                                                     %% participants
+
+                                                                     OverCommit = blockchain_ledger_state_channel_v2:amount(SC)
+                                                                         - blockchain_ledger_state_channel_v2:original(SC),
+                                                                     OverCommit div length(InnerSummaries);
+                                                                 _ ->
+                                                                     0
+                                                             end,
+                                                {InnerSummaries, InnerBonus}
+                                        end,
+
+                                    lists:foldl(fun(Summary, A) ->
+                                                        Key = blockchain_state_channel_summary_v1:client_pubkeybin(Summary),
+                                                        DCs = blockchain_state_channel_summary_v1:num_dcs(Summary) + Bonus,
+                                                        maps:update_with(Key,
+                                                                         fun(V) -> V + DCs end,
+                                                                         DCs,
+                                                                         A)
+                                                end,
+                                                maps:update_with(seen,
+                                                                 fun(Seen) -> [SCID|Seen] end,
+                                                                 [SCID],
+                                                                 AccIn),
+                                                Summaries);
+                                false ->
+                                    %% this is a v1 SC; ignore
+                                    AccIn
+                            end;
+                        {error, not_found} ->
+                            ExpireAt = blockchain_txn_state_channel_close_v1:state_channel_expire_at(Txn),
+                            lager:warning("missing scid ~p", [SCID]),
+                            lager:warning("expire ~p + grace ~p > end ~p?", [ExpireAt, GraceBlocks, End]),
+                            AccIn
+                    end;
+                true ->
+                    %% we have already seen this SCID before; ignore
+                    AccIn
+            end;
+        false ->
+            %% SC did not close in _this_ epoch; skip it
+            AccIn
+    end.
+
+-spec normalize_dc_rewards( DCRewards0 :: dc_rewards_share_map(),
+                            Vars :: reward_vars() ) -> {non_neg_integer(), rewards_map()}.
+normalize_dc_rewards(DCRewards0, #{epoch_reward := EpochReward,
+                                   dc_percent := DCPercent}=Vars) ->
+    DCRewards = maps:remove(seen, DCRewards0),
+    OraclePrice = maps:get(oracle_price, Vars, 0),
+    RewardVersion = maps:get(reward_version, Vars, 1),
+    TotalDCs = lists:sum(maps:values(DCRewards)),
+    MaxDCReward = EpochReward * DCPercent,
+    %% compute the price HNT equivalent of the DCs burned in this epoch
+    DCReward = case OraclePrice == 0 orelse RewardVersion < 3 of
+        true ->
+            %% no oracle price, or rewards =< 2
+            MaxDCReward;
+        false ->
+            {ok, DCInThisEpochAsHNT} = blockchain_ledger_v1:dc_to_hnt(TotalDCs, OraclePrice),
+            case DCInThisEpochAsHNT >= MaxDCReward of
+                true ->
+                    %% we spent enough, just allocate it proportionally
+                    MaxDCReward;
+                false ->
+                    %% we didn't spend enough this epoch, return the remainder to the pool
+                    DCInThisEpochAsHNT
+            end
+    end,
+
+    {max(0, round(MaxDCReward - DCReward)),
+     maps:fold(
+       fun(Key, NumDCs, Acc) ->
+               PercentofReward = (NumDCs*100/TotalDCs)/100,
+               Amount = erlang:round(PercentofReward*DCReward),
+               maps:put({gateway, data_credits, Key}, Amount, Acc)
+       end,
+       #{},
+       DCRewards
+      )}.
+
+-spec poc_reward_tx_unit(R :: float(),
+                         W :: pos_integer(),
+                         N :: pos_integer()) -> float().
+poc_reward_tx_unit(_R, W, N) when W =< N ->
+    blockchain_utils:normalize_float(W / N);
+poc_reward_tx_unit(R, W, N) ->
+    NoNorm = 1 + (1 - math:pow(R, (W - N))),
+    blockchain_utils:normalize_float(NoNorm).
+
+-spec poc_witness_reward_unit(R :: float(),
+                              W :: pos_integer(),
+                              N :: pos_integer()) -> float().
+poc_witness_reward_unit(_R, W, N) when W =< N ->
+    1.0;
+poc_witness_reward_unit(R, W, N) ->
+    %% It's okay to call the previously broken normalize_reward_unit here because
+    %% the value does not asympotically tend to 2.0, instead it tends to 0.0
+    normalize_reward_unit(blockchain_utils:normalize_float((N - (1 - math:pow(R, (W - N))))/W)).
+
+-spec legit_witnesses( Txn :: blockchain_txn_poc_receipts_v1:txn_poc_receipts() |
+                              blockchain_txn_poc_receipts_v2:txn_poc_receipts(),
+                       Chain :: blockchain:blockchain(),
+                       Ledger :: blockchain_ledger_v1:ledger(),
+                       Elem :: blockchain_poc_path_element_v1:poc_element(),
+                       StaticPath :: blockchain_poc_path_element_v1:poc_path(),
+                       RegionVars :: {ok, [{atom(), binary() | {error, any()}}]} | {error, any()},
+                       Version :: pos_integer()
+                     ) -> [blockchain_txn_poc_witnesses_v1:poc_witness()].
+legit_witnesses(Txn, Chain, Ledger, Elem, StaticPath, RegionVars, Version) ->
+    TxnType = blockchain_txn:type(Txn),
+    case Version of
+        V when is_integer(V), V >= 9 ->
+            try
+                %% Get channels without validation
+                {ok, Channels} = TxnType:get_channels(Txn, Version, RegionVars, Chain),
+                ElemPos = blockchain_utils:index_of(Elem, StaticPath),
+                WitnessChannel = lists:nth(ElemPos, Channels),
+                KeyHash = TxnType:onion_key_hash(Txn),
+                ElemHash = erlang:phash2(Elem),
+                ValidWitnesses =
+                    case get({KeyHash, ElemHash}) of
+                        undefined ->
+                            VW = TxnType:valid_witnesses(Elem, WitnessChannel, RegionVars, Ledger),
+                            put({KeyHash, ElemHash}, VW),
+                            VW;
+                        VW -> VW
+                    end,
+                ValidWitnesses
+            catch
+                throw:{error, {unknown_region, Region}}:_ST ->
+                    lager:error("Reported unknown_region: ~p", [Region]),
+                    [];
+                What:Why:ST ->
+                    lager:error("failed to calculate poc_challengees_rewards, error ~p:~p:~p", [What, Why, ST]),
+                    []
+            end;
+        V when is_integer(V), V > 4 ->
+            TxnType:good_quality_witnesses(Elem, Ledger);
+        _ ->
+            blockchain_poc_path_element_v1:witnesses(Elem)
+    end.
+
+maybe_calc_tx_scale(_Challengee,
+                    DensityTgtRes,
+                    ChallengeeLoc,
+                    VarMap,
+                    Ledger) ->
+    case {DensityTgtRes, ChallengeeLoc} of
+        {undefined, _} -> 1.0;
+        {_, undefined} -> 1.0;
+        {D, Loc} ->
+            TxScale = blockchain_hex:scale(Loc, VarMap, D, Ledger),
+            %% lager:info("Challengee: ~p, TxScale: ~p",
+                       %% [blockchain_utils:addr2name(Challengee), TxScale]),
+            blockchain_utils:normalize_float(TxScale)
+    end.
+
+share_of_dc_rewards(_Key, #{dc_remainder := 0}) ->
+    0;
+share_of_dc_rewards(Key, Vars=#{dc_remainder := DCRemainder,
+                                poc_challenger_type := validator}) ->
+    erlang:round(DCRemainder
+                 * ((maps:get(Key, Vars) /
+                     (maps:get(poc_challengees_percent, Vars)
+                      + maps:get(poc_witnesses_percent, Vars))))
+                );
+share_of_dc_rewards(Key, Vars=#{dc_remainder := DCRemainder}) ->
+    erlang:round(DCRemainder
+                 * ((maps:get(Key, Vars) /
+                     (maps:get(poc_challengers_percent, Vars)
+                      + maps:get(poc_challengees_percent, Vars)
+                      + maps:get(poc_witnesses_percent, Vars))))
+                ).
+
+witness_decay(Count, Vars) ->
+    case maps:find(witness_reward_decay_rate, Vars) of
+        {ok, undefined} ->
+            1;
+        {ok, DecayRate} ->
+            Exclusion = case maps:find(witness_reward_decay_exclusion, Vars) of
+                            {ok, undefined} -> 0;
+                            {ok, ExclusionValue} -> ExclusionValue
+                        end,
+            case Count < Exclusion of
+                true ->
+                    1;
+                false ->
+                    Scale = math:exp((Count - Exclusion) * -1 * DecayRate),
+                    lager:debug("scaling witness reward by ~p", [Scale]),
+                    Scale
+            end;
+        _ ->
+            1
+    end.
+
+%% ------------------------------------------------------------------
+%% EUNIT Tests
+%% ------------------------------------------------------------------
+-ifdef(TEST).
+
+%% @doc Given a list of reward_v1 txns, return the equivalent reward_v2
+%% list.
+-spec v1_to_v2( RewardsV1 :: [blockchain_txn_reward_v1:rewards()] ) -> rewards().
+v1_to_v2(RewardsV1) ->
+    R = lists:foldl(fun(R, Acc) ->
+                            Owner = blockchain_txn_reward_v1:account(R),
+                            Amt = blockchain_txn_reward_v1:amount(R),
+                            maps:update_with(Owner, fun(Balance) -> Balance + Amt end, Amt, Acc)
+                    end,
+                    #{},
+                    RewardsV1),
+    lists:sort(maps:fold(fun(_O, 0, Acc) -> Acc; %% drop any 0 amount reward, as in v2
+                             (O, A, Acc) -> [ new_reward(O, A) | Acc ] end,
+                         [],
+                         R)).
+
+new_test() ->
+    Tx = #blockchain_txn_rewards_v2_pb{start_epoch=1, end_epoch=30, rewards=[]},
+    ?assertEqual(Tx, new(1, 30, [])).
+
+start_epoch_test() ->
+    Tx = new(1, 30, []),
+    ?assertEqual(1, start_epoch(Tx)).
+
+end_epoch_test() ->
+    Tx = new(1, 30, []),
+    ?assertEqual(30, end_epoch(Tx)).
+
+rewards_test() ->
+    Tx = new(1, 30, []),
+    ?assertEqual([], rewards(Tx)).
+
+poc_challengers_rewards_2_test() ->
+    ReceiptForA = blockchain_poc_receipt_v1:new(<<"a">>, 1, 1, <<"data">>, radio),
+    ElemForA = blockchain_poc_path_element_v1:new(<<"a">>, ReceiptForA, []),
+
+    Txns = [
+        blockchain_txn_poc_receipts_v2:new(<<"a">>, <<"Secret">>, <<"OnionKeyHash">>, [], <<"BlockHash">>),
+        blockchain_txn_poc_receipts_v2:new(<<"b">>, <<"Secret">>, <<"OnionKeyHash">>, [], <<"BlockHash">>),
+        blockchain_txn_poc_receipts_v2:new(<<"c">>, <<"Secret">>, <<"OnionKeyHash">>, [ElemForA], <<"BlockHash">>)
+    ],
+    Vars = #{
+        epoch_reward => 1000,
+        poc_challengers_percent => 0.15,
+        poc_witnesses_percent => 0.0,
+        poc_challengees_percent => 0.0,
+        dc_remainder => 0,
+        poc_version => 5,
+        poc_challenger_type => validator
+    },
+    Rewards = #{
+        {validator, poc_challengers, <<"a">>} => 38,
+        {validator, poc_challengers, <<"b">>} => 38,
+        {validator, poc_challengers, <<"c">>} => 75
+    },
+    ChallengerShares = lists:foldl(fun(T, Acc) -> poc_challenger_reward(T, Acc, Vars) end, #{}, Txns),
+    ?assertEqual(Rewards, normalize_challenger_rewards(ChallengerShares, Vars)),
+
+    AltVars = Vars#{ poc_challenger_type => gateway },
+    AltRewards = #{
+        {gateway, poc_challengers, <<"a">>} => 38,
+        {gateway, poc_challengers, <<"b">>} => 38,
+        {gateway, poc_challengers, <<"c">>} => 75
+    },
+    ?assertEqual(AltRewards, normalize_challenger_rewards(ChallengerShares, AltVars)).
+
+poc_challengees_rewards_3_test() ->
+    BaseDir = test_utils:tmp_dir("poc_challengees_rewards_3_test"),
+    Block = blockchain_block:new_genesis_block([]),
+    {ok, Chain} = blockchain:new(BaseDir, Block, undefined, undefined),
+    Ledger = blockchain:ledger(Chain),
+    Ledger1 = blockchain_ledger_v1:new_context(Ledger),
+
+    Vars = #{
+        epoch_reward => 1000,
+        poc_challengees_percent => 0.35,
+        poc_witnesses_percent => 0.0,
+        poc_challengers_percent => 0.0,
+        dc_remainder => 0,
+        poc_version => 5,
+        region_vars => []
+    },
+
+    LedgerVars = maps:put(?poc_version, 5, common_poc_vars()),
+
+    ok = blockchain_ledger_v1:vars(LedgerVars, [], Ledger1),
+
+    One = 631179381270930431,
+    Two = 631196173757531135,
+    Three = 631196173214364159,
+
+    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"a">>, Ledger1),
+    ok = blockchain_ledger_v1:add_gateway_location(<<"a">>, One, 1, Ledger1),
+
+    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"b">>, Ledger1),
+    ok = blockchain_ledger_v1:add_gateway_location(<<"b">>, Two, 1, Ledger1),
+
+    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"c">>, Ledger1),
+    ok = blockchain_ledger_v1:add_gateway_location(<<"c">>, Three, 1, Ledger1),
+
+    ok = blockchain_ledger_v1:commit_context(Ledger1),
+
+    ReceiptForA = blockchain_poc_receipt_v1:new(<<"a">>, 1, -120, <<"data">>, radio),
+    WitnessForA = blockchain_poc_witness_v1:new(<<"c">>, 1, -120, <<>>),
+    ReceiptForB = blockchain_poc_receipt_v1:new(<<"b">>, 1, -70, <<"data">>, radio),
+    WitnessForB = blockchain_poc_witness_v1:new(<<"c">>, 1, -120, <<>>),
+    ReceiptForC = blockchain_poc_receipt_v1:new(<<"c">>, 1, -120, <<"data">>, radio),
+
+    ElemForA = blockchain_poc_path_element_v1:new(<<"a">>, ReceiptForA, []),
+    ElemForAWithWitness = blockchain_poc_path_element_v1:new(<<"a">>, ReceiptForA, [WitnessForA]),
+    ElemForB = blockchain_poc_path_element_v1:new(<<"b">>, undefined, []),
+    ElemForBWithWitness = blockchain_poc_path_element_v1:new(<<"b">>, ReceiptForB, [WitnessForB]),
+    ElemForC = blockchain_poc_path_element_v1:new(<<"c">>, ReceiptForC, []),
+
+    Txns = [
+        %% No rewards here, Only receipt with no witness or subsequent receipt
+        blockchain_txn_poc_receipts_v2:new(<<"X">>, <<"Secret">>, <<"OnionKeyHash">>, [ElemForB, ElemForA], <<"BlockHash">>),  %% 1, 2
+        %% Reward because of witness
+        blockchain_txn_poc_receipts_v2:new(<<"X">>, <<"Secret">>, <<"OnionKeyHash">>, [ElemForAWithWitness], <<"BlockHash">>), %% 3
+        %% Reward because of next elem has receipt
+        blockchain_txn_poc_receipts_v2:new(<<"X">>, <<"Secret">>, <<"OnionKeyHash">>, [ElemForA, ElemForB, ElemForC], <<"BlockHash">>), %% 3, 2, 2
+        %% Reward because of witness (adding to make reward 50/50)
+        blockchain_txn_poc_receipts_v2:new(<<"X">>, <<"Secret">>, <<"OnionKeyHash">>, [ElemForBWithWitness], <<"BlockHash">>) %% 3
+    ],
+    Rewards = #{
+        %% a gets 8 shares
+        {gateway, poc_challengees, <<"a">>} => 175,
+        %% b gets 6 shares
+        {gateway, poc_challengees, <<"b">>} => 131,
+        %% c gets 2 shares
+        {gateway, poc_challengees, <<"c">>} => 44
+    },
+    ChallengeeShares = lists:foldl(fun(T, Acc) ->
+                                           Path = blockchain_txn_poc_receipts_v2:path(T),
+                                           poc_challengees_rewards_(Vars, Path, Path, T, Chain, Ledger, true, #{}, Acc)
+                                   end,
+                                   #{},
+                                   Txns),
+    ?assertEqual(Rewards, normalize_challengee_rewards(ChallengeeShares, Vars)),
+    test_utils:cleanup_tmp_dir(BaseDir).
+
+poc_witnesses_rewards_test() ->
+    BaseDir = test_utils:tmp_dir("poc_witnesses_rewards_test"),
+    Block = blockchain_block:new_genesis_block([]),
+    {ok, Chain} = blockchain:new(BaseDir, Block, undefined, undefined),
+    Ledger = blockchain:ledger(Chain),
+    Ledger1 = blockchain_ledger_v1:new_context(Ledger),
+    EpochVars = #{
+      epoch_reward => 1000,
+      poc_witnesses_percent => 0.05,
+      poc_challengees_percent => 0.0,
+      poc_challengers_percent => 0.0,
+      dc_remainder => 0,
+      poc_version => 5
+     },
+
+    LedgerVars = maps:merge(common_poc_vars(), EpochVars),
+
+    ok = blockchain_ledger_v1:vars(LedgerVars, [], Ledger1),
+
+    One = 631179381270930431,
+    Two = 631196173757531135,
+    Three = 631196173214364159,
+    Four = 631179381325720575,
+    Five = 631179377081096191,
+
+    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"a">>, Ledger1),
+    ok = blockchain_ledger_v1:add_gateway_location(<<"a">>, One, 1, Ledger1),
+
+    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"b">>, Ledger1),
+    ok = blockchain_ledger_v1:add_gateway_location(<<"b">>, Two, 1, Ledger1),
+
+    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"c">>, Ledger1),
+    ok = blockchain_ledger_v1:add_gateway_location(<<"c">>, Three, 1, Ledger1),
+
+    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"d">>, Ledger1),
+    ok = blockchain_ledger_v1:add_gateway_location(<<"d">>, Four, 1, Ledger1),
+
+    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"e">>, Ledger1),
+    ok = blockchain_ledger_v1:add_gateway_location(<<"e">>, Five, 1, Ledger1),
+
+    ok = blockchain_ledger_v1:commit_context(Ledger1),
+
+    Witness1 = blockchain_poc_witness_v1:new(<<"a">>, 1, -80, <<>>),
+    Witness2 = blockchain_poc_witness_v1:new(<<"b">>, 1, -80, <<>>),
+    Elem = blockchain_poc_path_element_v1:new(<<"c">>, <<"Receipt not undefined">>, [Witness1, Witness2]),
+    Txns = [
+        blockchain_txn_poc_receipts_v2:new(<<"d">>, <<"Secret">>, <<"OnionKeyHash">>, [Elem, Elem], <<"BlockHash">>),
+        blockchain_txn_poc_receipts_v2:new(<<"e">>, <<"Secret">>, <<"OnionKeyHash">>, [Elem, Elem], <<"BlockHash">>)
+    ],
+
+    Rewards = #{{gateway,poc_witnesses,<<"a">>} => 25,
+                {gateway,poc_witnesses,<<"b">>} => 25},
+
+    WitnessShares = lists:foldl(fun(T, Acc) -> poc_witness_reward(T, Acc, Chain, Ledger, EpochVars) end,
+                                #{}, Txns),
+    ?assertEqual(Rewards, normalize_witness_rewards(WitnessShares, EpochVars)),
+    test_utils:cleanup_tmp_dir(BaseDir).
+
+dc_rewards_sc_dispute_strategy_test() ->
+    BaseDir = test_utils:tmp_dir("dc_rewards_dispute_sc_test"),
+    Ledger = blockchain_ledger_v1:new(BaseDir),
+    Ledger1 = blockchain_ledger_v1:new_context(Ledger),
+
+    Vars = #{
+        epoch_reward => 100000,
+        dc_percent => 0.3,
+        consensus_percent => 0.06 + 0.025,
+        poc_challengees_percent => 0.18,
+        poc_challengers_percent => 0.0095,
+        poc_witnesses_percent => 0.0855,
+        securities_percent => 0.34,
+        sc_version => 2,
+        sc_grace_blocks => 5,
+        reward_version => 4,
+        oracle_price => 100000000, %% 1 dollar
+        consensus_members => [<<"c">>, <<"d">>],
+        %% This is the important part of what's being tested here.
+        sc_dispute_strategy_version => 1
+    },
+
+    LedgerVars = maps:merge(#{?poc_version => 5, ?sc_version => 2, ?sc_grace_blocks => 5}, common_poc_vars()),
+    ok = blockchain_ledger_v1:vars(LedgerVars, [], Ledger1),
+
+    {SC0, _} = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>, 100, <<"blockhash">>, 10),
+    SCValid = blockchain_state_channel_v1:summaries([blockchain_state_channel_summary_v1:new(<<"a">>, 1, 1), blockchain_state_channel_summary_v1:new(<<"b">>, 2, 2)], SC0),
+    SCDispute = blockchain_state_channel_v1:summaries([blockchain_state_channel_summary_v1:new(<<"a">>, 2, 2), blockchain_state_channel_summary_v1:new(<<"b">>, 3, 3)], SC0),
+
+    ok = blockchain_ledger_v1:add_state_channel(<<"id">>, <<"owner">>, 10, 1, 100, 200, Ledger1),
+    {ok, _} = blockchain_ledger_v1:find_state_channel(<<"id">>, <<"owner">>, Ledger1),
+
+    ok = blockchain_ledger_v1:close_state_channel(<<"owner">>, <<"owner">>, SCValid, <<"id">>, false, Ledger1),
+    {ok, _} = blockchain_ledger_v1:find_state_channel(<<"id">>, <<"owner">>, Ledger1),
+
+    ok = blockchain_ledger_v1:close_state_channel(<<"owner">>, <<"a">>, SCDispute, <<"id">>, true, Ledger1),
+
+    SCClose = blockchain_txn_state_channel_close_v1:new(SCValid, <<"owner">>),
+    {ok, _DCsInEpochAsHNT} = blockchain_ledger_v1:dc_to_hnt(3, 100000000), %% 3 DCs burned at HNT price of 1 dollar
+
+    DCShares = dc_reward(SCClose, 100, #{}, Ledger1, Vars),
+
+    %% We only care that no rewards are generated when sc_dispute_strategy_version is active.
+    {Res, M} = normalize_dc_rewards(DCShares, Vars),
+    ?assertEqual(#{}, M, "no summaries in rewards map"),
+    ?assertEqual(30000, Res),
+    test_utils:cleanup_tmp_dir(BaseDir).
+
+dc_rewards_v3_test() ->
+    BaseDir = test_utils:tmp_dir("dc_rewards_v3_test"),
+    Ledger = blockchain_ledger_v1:new(BaseDir),
+    Ledger1 = blockchain_ledger_v1:new_context(Ledger),
+
+    Vars = #{
+        epoch_reward => 100000,
+        dc_percent => 0.3,
+        consensus_percent => 0.06 + 0.025,
+        poc_challengees_percent => 0.18,
+        poc_challengers_percent => 0.0095,
+        poc_witnesses_percent => 0.0855,
+        securities_percent => 0.34,
+        sc_version => 2,
+        sc_grace_blocks => 5,
+        sc_dispute_strategy_version => 0,
+        reward_version => 3,
+        oracle_price => 100000000, %% 1 dollar
+        consensus_members => [<<"c">>, <<"d">>]
+    },
+
+    LedgerVars = maps:merge(#{?poc_version => 5, ?sc_version => 2, ?sc_grace_blocks => 5}, common_poc_vars()),
+
+    ok = blockchain_ledger_v1:vars(LedgerVars, [], Ledger1),
+
+    {SC0, _} = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>, 100, <<"blockhash">>, 10),
+    SC = blockchain_state_channel_v1:summaries([blockchain_state_channel_summary_v1:new(<<"a">>, 1, 1), blockchain_state_channel_summary_v1:new(<<"b">>, 2, 2)], SC0),
+
+    ok = blockchain_ledger_v1:add_state_channel(<<"id">>, <<"owner">>, 10, 1, 100, 200, Ledger1),
+
+    {ok, _} = blockchain_ledger_v1:find_state_channel(<<"id">>, <<"owner">>, Ledger1),
+
+    ok = blockchain_ledger_v1:close_state_channel(<<"owner">>, <<"owner">>, SC, <<"id">>, false, Ledger1),
+
+    {ok, _} = blockchain_ledger_v1:find_state_channel(<<"id">>, <<"owner">>, Ledger1),
+
+
+    SCClose = blockchain_txn_state_channel_close_v1:new(SC, <<"owner">>),
+    {ok, DCsInEpochAsHNT} = blockchain_ledger_v1:dc_to_hnt(3, 100000000), %% 3 DCs burned at HNT price of 1 dollar
+    %% NOTE: Rewards are split 33-66%
+    Rewards = #{
+        {gateway, data_credits, <<"a">>} => round(DCsInEpochAsHNT * (1/3)),
+        {gateway, data_credits, <<"b">>} => round(DCsInEpochAsHNT * (2/3))
+    },
+    DCShares = dc_reward(SCClose, 100, #{}, Ledger1, Vars),
+    ?assertEqual({26999, Rewards}, normalize_dc_rewards(DCShares, Vars)),
+    test_utils:cleanup_tmp_dir(BaseDir).
+
+dc_rewards_v3_spillover_test() ->
+    BaseDir = test_utils:tmp_dir("dc_rewards_v3_spillover_test"),
+    Block = blockchain_block:new_genesis_block([]),
+    {ok, Chain} = blockchain:new(BaseDir, Block, undefined, undefined),
+    Ledger = blockchain:ledger(Chain),
+    Ledger1 = blockchain_ledger_v1:new_context(Ledger),
+
+    Vars = #{
+        epoch_reward => 100000,
+        dc_percent => 0.05,
+        consensus_percent => 0.1,
+        poc_challengees_percent => 0.20,
+        poc_challengers_percent => 0.15,
+        poc_witnesses_percent => 0.15,
+        securities_percent => 0.35,
+        poc_challenger_type => validator,
+        sc_version => 2,
+        sc_grace_blocks => 5,
+        reward_version => 3,
+        poc_version => 5,
+        dc_remainder => 0,
+        oracle_price => 100000000, %% 1 dollar
+        var_map => undefined,
+        region_vars => [],
+        consensus_members => [<<"c">>, <<"d">>]
+    },
+
+    LedgerVars = maps:merge(#{?poc_version => 5, ?sc_version => 2, ?sc_grace_blocks => 5}, common_poc_vars()),
+
+    ok = blockchain_ledger_v1:vars(LedgerVars, [], Ledger1),
+
+    One = 631179381270930431,
+    Two = 631196173757531135,
+    Three = 631196173214364159,
+
+    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"a">>, Ledger1),
+    ok = blockchain_ledger_v1:add_gateway_location(<<"a">>, One, 1, Ledger1),
+
+    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"b">>, Ledger1),
+    ok = blockchain_ledger_v1:add_gateway_location(<<"b">>, Two, 1, Ledger1),
+
+    ok = blockchain_ledger_v1:add_gateway(<<"o">>, <<"c">>, Ledger1),
+    ok = blockchain_ledger_v1:add_gateway_location(<<"c">>, Three, 1, Ledger1),
+
+    ReceiptForA = blockchain_poc_receipt_v1:new(<<"a">>, 1, -120, <<"data">>, radio),
+    WitnessForA = blockchain_poc_witness_v1:new(<<"c">>, 1, -120, <<>>),
+    ReceiptForB = blockchain_poc_receipt_v1:new(<<"b">>, 1, -70, <<"data">>, radio),
+    WitnessForB = blockchain_poc_witness_v1:new(<<"c">>, 1, -120, <<>>),
+    ReceiptForC = blockchain_poc_receipt_v1:new(<<"c">>, 1, -120, <<"data">>, radio),
+
+    ElemForA = blockchain_poc_path_element_v1:new(<<"a">>, ReceiptForA, []),
+    ElemForAWithWitness = blockchain_poc_path_element_v1:new(<<"a">>, ReceiptForA, [WitnessForA]),
+    ElemForB = blockchain_poc_path_element_v1:new(<<"b">>, undefined, []),
+    ElemForBWithWitness = blockchain_poc_path_element_v1:new(<<"b">>, ReceiptForB, [WitnessForB]),
+    ElemForC = blockchain_poc_path_element_v1:new(<<"c">>, ReceiptForC, []),
+
+    Txns = [
+        %% No rewards here, Only receipt with no witness or subsequent receipt
+        blockchain_txn_poc_receipts_v2:new(<<"X">>, <<"Secret">>, <<"OnionKeyHash">>, [ElemForB, ElemForA], <<"BlockHash">>),  %% 1, 2
+        %% Reward because of witness
+        blockchain_txn_poc_receipts_v2:new(<<"X">>, <<"Secret">>, <<"OnionKeyHash">>, [ElemForAWithWitness], <<"BlockHash">>), %% 3
+        %% Reward because of next elem has receipt
+        blockchain_txn_poc_receipts_v2:new(<<"X">>, <<"Secret">>, <<"OnionKeyHash">>, [ElemForA, ElemForB, ElemForC], <<"BlockHash">>), %% 3, 2, 2
+        %% Reward because of witness (adding to make reward 50/50)
+        blockchain_txn_poc_receipts_v2:new(<<"X">>, <<"Secret">>, <<"OnionKeyHash">>, [ElemForBWithWitness], <<"BlockHash">>) %% 3
+    ],
+
+
+    {SC0, _} = blockchain_state_channel_v1:new(<<"id">>, <<"owner">>, 100, <<"blockhash">>, 10),
+    SC = blockchain_state_channel_v1:summaries([blockchain_state_channel_summary_v1:new(<<"a">>, 1, 1), blockchain_state_channel_summary_v1:new(<<"b">>, 2, 2)], SC0),
+
+    ok = blockchain_ledger_v1:add_state_channel(<<"id">>, <<"owner">>, 10, 1, 100, 200, Ledger1),
+
+    {ok, _} = blockchain_ledger_v1:find_state_channel(<<"id">>, <<"owner">>, Ledger1),
+
+    ok = blockchain_ledger_v1:close_state_channel(<<"owner">>, <<"owner">>, SC, <<"id">>, false, Ledger1),
+
+    {ok, _} = blockchain_ledger_v1:find_state_channel(<<"id">>, <<"owner">>, Ledger1),
+
+    ok = blockchain_ledger_v1:commit_context(Ledger1),
+
+    Txns2 = [
+         blockchain_txn_state_channel_close_v1:new(SC, <<"owner">>)
+    ],
+    AllTxns = Txns ++ Txns2,
+    {ok, DCsInEpochAsHNT} = blockchain_ledger_v1:dc_to_hnt(3, 100000000), %% 3 DCs burned at HNT price of 1 dollar
+    %% NOTE: Rewards are split 33-66%
+    Rewards = #{
+        {gateway, data_credits, <<"a">>} => round(DCsInEpochAsHNT * (1/3)),
+        {gateway, data_credits, <<"b">>} => round(DCsInEpochAsHNT * (2/3))
+    },
+
+    RewardSharesInit = #{
+      dc_rewards => #{},
+      poc_challenger => #{},
+      poc_challengee => #{},
+      poc_witness => #{}
+     },
+
+    NoSpillover = lists:foldl(fun(T, Acc) -> calculate_reward_for_txn(
+                                               blockchain_txn:type(T), T, 100,
+                                               Acc, Chain, Ledger, Vars)
+                                    end,
+                                    RewardSharesInit,
+                                    AllTxns),
+    DCShares = maps:get(dc_rewards, NoSpillover),
+    {DCRemainder, DCRewards} = normalize_dc_rewards(DCShares, Vars),
+    DCAward = trunc(maps:get(epoch_reward, Vars) * maps:get(dc_percent, Vars)),
+    ?assertEqual({DCAward - DCsInEpochAsHNT, Rewards}, {DCRemainder, DCRewards}),
+
+    NewVars = maps:put(dc_remainder, DCRemainder, Vars),
+
+    Spillover = lists:foldl(fun(T, Acc) -> calculate_reward_for_txn(
+                                               blockchain_txn:type(T), T, 100,
+                                               Acc, Chain, Ledger, NewVars)
+                                    end,
+                                    RewardSharesInit,
+                                    AllTxns),
+
+    ChallengerShares = maps:get(poc_challenger, NoSpillover),
+    ChallengeeShares = maps:get(poc_challengee, NoSpillover),
+    WitnessShares = maps:get(poc_witness, NoSpillover),
+
+    ChallengerRewards = normalize_challenger_rewards(ChallengerShares, Vars),
+    ChallengeeRewards = normalize_challengee_rewards(ChallengeeShares, Vars),
+    WitnessRewards = normalize_witness_rewards(WitnessShares, Vars),
+
+    ChallengersAward = trunc(maps:get(epoch_reward, Vars) * maps:get(poc_challengers_percent, Vars)),
+    ?assertEqual(#{{validator,poc_challengers,<<"X">>} =>  ChallengersAward}, ChallengerRewards), %% entire 15% allocation
+    ChallengeesAward = trunc(maps:get(epoch_reward, Vars) * maps:get(poc_challengees_percent, Vars)),
+    ?assertEqual(#{{gateway,poc_challengees,<<"a">>} => trunc(ChallengeesAward * 4/8), %% 4 of 8 shares of 20% allocation
+                   {gateway,poc_challengees,<<"b">>} => trunc(ChallengeesAward * 3/8), %% 3 shares
+                   {gateway,poc_challengees,<<"c">>} => trunc(ChallengeesAward * 1/8)}, %% 1 share
+                 ChallengeeRewards),
+    WitnessesAward = trunc(maps:get(epoch_reward, Vars) * maps:get(poc_witnesses_percent, Vars)),
+    ?assertEqual(#{{gateway,poc_witnesses,<<"c">>} => WitnessesAward}, %% entire 15% allocation
+                 WitnessRewards),
+
+
+    %% apply the DC remainder, if any to the other PoC categories pro rata
+    SpilloverChallengerShares = maps:get(poc_challenger, Spillover),
+    SpilloverChallengeeShares = maps:get(poc_challengee, Spillover),
+    SpilloverWitnessShares = maps:get(poc_witness, Spillover),
+
+    SpilloverChallengerRewards = normalize_challenger_rewards(SpilloverChallengerShares, NewVars),
+    SpilloverChallengeeRewards = normalize_challengee_rewards(SpilloverChallengeeShares, NewVars),
+    SpilloverWitnessRewards = normalize_witness_rewards(SpilloverWitnessShares, NewVars),
+
+    ChallengerSpilloverAward = 0,
+
+    ?assertEqual(#{{validator,poc_challengers,<<"X">>} =>  ChallengersAward + ChallengerSpilloverAward}, SpilloverChallengerRewards), %% entire 15% allocation
+    ChallengeeSpilloverAward = erlang:round(DCRemainder * ((maps:get(poc_challengees_percent, Vars) / (maps:get(poc_challengees_percent, Vars) +
+                                                                                                       maps:get(poc_witnesses_percent, Vars))))),
+    ?assertEqual(#{{gateway,poc_challengees,<<"a">>} => trunc((ChallengeesAward + ChallengeeSpilloverAward) * 4/8), %% 4 of 8 shares of 20% allocation
+                   {gateway,poc_challengees,<<"b">>} => trunc((ChallengeesAward + ChallengeeSpilloverAward) * 3/8), %% 3 shares
+                   {gateway,poc_challengees,<<"c">>} => round((ChallengeesAward + ChallengeeSpilloverAward) * 1/8)}, %% 1 share
+                 SpilloverChallengeeRewards),
+    WitnessesSpilloverAward = erlang:round(DCRemainder * ((maps:get(poc_witnesses_percent, Vars) / (maps:get(poc_challengees_percent, Vars) +
+                                                                                                       maps:get(poc_witnesses_percent, Vars))))),
+    ?assertEqual(#{{gateway,poc_witnesses,<<"c">>} => WitnessesAward + WitnessesSpilloverAward}, %% entire 15% allocation
+                 SpilloverWitnessRewards),
+    test_utils:cleanup_tmp_dir(BaseDir).
+
+to_json_test() ->
+    Tx = #blockchain_txn_rewards_v2_pb{start_epoch=1, end_epoch=30, rewards=[]},
+    Json = to_json(Tx, []),
+    ?assert(lists:all(fun(K) -> maps:is_key(K, Json) end,
+                      [type, start_epoch, end_epoch, rewards])).
+
+
+fixed_normalize_reward_unit_test() ->
+    Rewards = [0.1, 0.9, 1.0, 1.8, 2.5, 2000, 0],
+
+    %% Expectation: reward should get capped at 2.0
+    Correct = lists:foldl(
+                fun(Reward, Acc) ->
+                        %% Set cap=2.0
+                        maps:put(Reward, normalize_reward_unit(2.0, Reward), Acc)
+                end, #{}, Rewards),
+
+    Incorrect = lists:foldl(
+                  fun(Reward, Acc) ->
+                          %% Set cap=undefined (old behavior)
+                          maps:put(Reward, normalize_reward_unit(undefined, Reward), Acc)
+                  end, #{}, Rewards),
+
+    ?assertEqual(1.8, maps:get(1.8, Correct)),          %% 1.8 -> 1.8
+    ?assertEqual(0.1, maps:get(0.1, Correct)),          %% 0.1 -> 0.1
+    ?assertEqual(0.9, maps:get(0.9, Correct)),          %% 0.9 -> 0.9
+    ?assertEqual(2.0, maps:get(2.5, Correct)),          %% 2.5 -> 2.0
+    ?assertEqual(1.0, maps:get(2.5, Incorrect)),        %% 2.5 -> 1.0 (incorrect)
+    ?assertEqual(1.0, maps:get(1.8, Incorrect)),        %% 1.8 -> 1.0 (incorrect)
+    ?assertEqual(0.1, maps:get(0.1, Incorrect)),        %% 0.1 -> 0.1
+    ?assertEqual(0.9, maps:get(0.9, Incorrect)),        %% 0.9 -> 0.9
+
+    ok.
+
+common_poc_vars() ->
+    #{
+        ?poc_v4_exclusion_cells => 10,
+        ?poc_v4_parent_res => 11,
+        ?poc_v4_prob_bad_rssi => 0.01,
+        ?poc_v4_prob_count_wt => 0.3,
+        ?poc_v4_prob_good_rssi => 1.0,
+        ?poc_v4_prob_no_rssi => 0.5,
+        ?poc_v4_prob_rssi_wt => 0.3,
+        ?poc_v4_prob_time_wt => 0.3,
+        ?poc_v4_randomness_wt => 0.1,
+        ?poc_v4_target_challenge_age => 300,
+        ?poc_v4_target_exclusion_cells => 6000,
+        ?poc_v4_target_prob_edge_wt => 0.2,
+        ?poc_v4_target_prob_score_wt => 0.8,
+        ?poc_v4_target_score_curve => 5,
+        ?poc_v5_target_prob_randomness_wt => 0.0
+    }.
+
+
+hip28_calc_test() ->
+    {timeout, 30000,
+     fun() ->
+             meck:new(blockchain_ledger_v1, [passthrough]),
+             meck:expect(blockchain_ledger_v1, hnt_burned,
+                         fun(_Ledger) ->
+                                 0
+                         end),
+             meck:expect(blockchain_ledger_v1, net_overage,
+                         fun(_Ledger) ->
+                                 0
+                         end),
+             meck:expect(blockchain_ledger_v1, config,
+                         fun(_, _Ledger) ->
+                                 0
+                         end),
+
+                                                % set test vars such that rewards are 1 per block
+             Vars = #{ block_time => 60000,
+                       election_interval => 30,
+                       election_restart_interval => 5,
+                       monthly_reward => 43200,
+                       reward_version => 6 },
+             ?assertEqual(30.0, calculate_consensus_epoch_reward(1, 30, Vars, ledger)),
+             ?assertEqual(35.0, calculate_consensus_epoch_reward(1, 50, Vars, ledger)),
+             meck:unload(blockchain_ledger_v1),
+             ok
+     end}.
+
+consensus_epoch_reward_test() ->
+    {timeout, 30000,
+     fun() ->
+             meck:new(blockchain_ledger_v1, [passthrough]),
+             meck:expect(blockchain_ledger_v1, hnt_burned,
+                         fun(_Ledger) ->
+                                 0
+                         end),
+             meck:expect(blockchain_ledger_v1, net_overage,
+                         fun(_Ledger) ->
+                                 0
+                         end),
+             meck:expect(blockchain_ledger_v1, config,
+                         fun(_, _Ledger) ->
+                                 0
+                         end),
+
+             %% using test values such that reward is 1 per block
+             %% should always return the election interval as the answer
+             ?assertEqual(30.0,calculate_epoch_reward(1, 1, 25, 60000, 30, 43200, ledger)),
+
+             %% more than 30 blocks should return 30
+             ?assertEqual(30.0,calculate_epoch_reward(1, 1, 50, 60000, 30, 43200, ledger)),
+             meck:unload(blockchain_ledger_v1)
+     end}.
+
+-endif.

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1234,12 +1234,12 @@ validate_var(?enable_balance_clearing, Value) ->
         _ -> throw({error, {invalid_enable_balance_clearing, Value}})
     end;
 
-validate_var(?allowed_reward_server_key_length, Value) ->
+validate_var(?allowed_num_reward_server_keys, Value) ->
     case Value of
         N when N == 1 ->
             %% only supported one reward server for now
             ok;
-        _ -> throw({error, {invalid_allowed_reward_server_key_length, Value}})
+        _ -> throw({error, {invalid_allowed_num_reward_server_keys, Value}})
     end;
 
 %% general txn vars

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1234,6 +1234,12 @@ validate_var(?enable_balance_clearing, Value) ->
         _ -> throw({error, {invalid_enable_balance_clearing, Value}})
     end;
 
+validate_var(?allow_multiple_reward_server_keys, Value) ->
+    case Value of
+        Val when is_boolean(Val) -> ok;
+        _ -> throw({error, {invalid_allow_multiple_reward_server_keys, Value}})
+    end;
+
 %% general txn vars
 
 validate_var(?txn_field_validation_version, Value) ->

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1234,10 +1234,12 @@ validate_var(?enable_balance_clearing, Value) ->
         _ -> throw({error, {invalid_enable_balance_clearing, Value}})
     end;
 
-validate_var(?allow_multiple_reward_server_keys, Value) ->
+validate_var(?allowed_reward_server_key_length, Value) ->
     case Value of
-        Val when is_boolean(Val) -> ok;
-        _ -> throw({error, {invalid_allow_multiple_reward_server_keys, Value}})
+        N when N == 1 ->
+            %% only supported one reward server for now
+            ok;
+        _ -> throw({error, {invalid_allowed_reward_server_key_length, Value}})
     end;
 
 %% general txn vars

--- a/test/blockchain_subnetwork_SUITE.erl
+++ b/test/blockchain_subnetwork_SUITE.erl
@@ -136,9 +136,6 @@ add_subnetwork_test(Config) ->
 
     NetworkSigfun = libp2p_crypto:mk_sig_fun(NetworkPriv),
 
-    ct:pal("subnetwork_sigfun: ~p", [SubnetworkSigFun]),
-    ct:pal("network_sigfun: ~p", [NetworkSigfun]),
-
     TT = mobile,
     Premine = 5000,
     T = blockchain_txn_add_subnetwork_v1:new(
@@ -159,7 +156,13 @@ add_subnetwork_test(Config) ->
 
     ?assertEqual({ok, Block}, blockchain:get_block(2, Chain)),
 
-    ct:pal("subnetworks: ~p", [blockchain_ledger_v1:subnetworks_v1(Ledger)]),
+    LedgerSubnetworks = blockchain_ledger_v1:subnetworks_v1(Ledger),
+    LedgerSubnetwork = maps:get(mobile, LedgerSubnetworks),
+    ?assertEqual(mobile, blockchain_ledger_subnetwork_v1:type(LedgerSubnetwork)),
+    ?assertEqual(Premine, blockchain_ledger_subnetwork_v1:premine(LedgerSubnetwork)),
+    ?assertEqual([RewardServerPubkeyBin], blockchain_ledger_subnetwork_v1:reward_server_keys(LedgerSubnetwork)),
+    ?assertEqual(0, blockchain_ledger_subnetwork_v1:hnt_treasury(LedgerSubnetwork)),
+    ?assertEqual(0, blockchain_ledger_subnetwork_v1:nonce(LedgerSubnetwork)),
 
     ok.
 

--- a/test/blockchain_subnetwork_SUITE.erl
+++ b/test/blockchain_subnetwork_SUITE.erl
@@ -159,7 +159,7 @@ add_subnetwork_test(Config) ->
     LedgerSubnetworks = blockchain_ledger_v1:subnetworks_v1(Ledger),
     LedgerSubnetwork = maps:get(mobile, LedgerSubnetworks),
     ?assertEqual(mobile, blockchain_ledger_subnetwork_v1:type(LedgerSubnetwork)),
-    ?assertEqual(Premine, blockchain_ledger_subnetwork_v1:premine(LedgerSubnetwork)),
+    ?assertEqual(Premine, blockchain_ledger_subnetwork_v1:token_treasury(LedgerSubnetwork)),
     ?assertEqual([RewardServerPubkeyBin], blockchain_ledger_subnetwork_v1:reward_server_keys(LedgerSubnetwork)),
     ?assertEqual(0, blockchain_ledger_subnetwork_v1:hnt_treasury(LedgerSubnetwork)),
     ?assertEqual(0, blockchain_ledger_subnetwork_v1:nonce(LedgerSubnetwork)),

--- a/test/blockchain_subnetwork_SUITE.erl
+++ b/test/blockchain_subnetwork_SUITE.erl
@@ -211,7 +211,7 @@ failing_subnetwork_test(Config) ->
 %%--------------------------------------------------------------------
 
 extra_vars(_) ->
-    #{?allowed_reward_server_key_length => 1}.
+    #{?allowed_num_reward_server_keys => 1}.
 
 token_allocations(_, Config) ->
     HNTBal = ?config(hnt_bal, Config),

--- a/test/blockchain_subnetwork_SUITE.erl
+++ b/test/blockchain_subnetwork_SUITE.erl
@@ -1,0 +1,176 @@
+-module(blockchain_subnetwork_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include("blockchain_vars.hrl").
+
+-export([all/0, init_per_testcase/2, end_per_testcase/2]).
+
+-export([
+    add_subnetwork_test/1
+]).
+
+%%--------------------------------------------------------------------
+%% COMMON TEST CALLBACK FUNCTIONS
+%%--------------------------------------------------------------------
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%%   Running tests for this suite
+%% @end
+%%--------------------------------------------------------------------
+all() ->
+    [
+        add_subnetwork_test
+    ].
+
+%%--------------------------------------------------------------------
+%% TEST CASE SETUP
+%%--------------------------------------------------------------------
+
+init_per_testcase(TestCase, Config) ->
+    Config0 = blockchain_ct_utils:init_base_dir_config(?MODULE, TestCase, Config),
+
+    HNTBal = 50000,
+    HSTBal = 10000,
+    MobileBal = 1000,
+    IOTBal = 100,
+
+    Config1 = [
+        {hnt_bal, HNTBal},
+        {hst_bal, HSTBal},
+        {mobile_bal, MobileBal},
+        {iot_bal, IOTBal}
+        | Config0
+    ],
+
+    {ok, Sup, {PrivKey, PubKey}, Opts} = test_utils:init(?config(base_dir, Config1)),
+
+    ExtraVars = extra_vars(TestCase),
+    TokenAllocations = token_allocations(TestCase, Config1),
+
+    {ok, GenesisMembers, _GenesisBlock, ConsensusMembers, Keys} =
+        test_utils:init_chain_with_opts(
+            #{
+                balance =>
+                    HNTBal,
+                sec_balance =>
+                    HSTBal,
+                keys =>
+                    {PrivKey, PubKey},
+                in_consensus =>
+                    false,
+                have_init_dc =>
+                    true,
+                extra_vars =>
+                    ExtraVars,
+                token_allocations =>
+                    TokenAllocations
+            }
+        ),
+
+    Chain = blockchain_worker:blockchain(),
+    Ledger = blockchain:ledger(Chain),
+    Swarm = blockchain_swarm:tid(),
+    N = length(ConsensusMembers),
+
+    {EntryMod, _} = blockchain_ledger_v1:versioned_entry_mod_and_entries_cf(Ledger),
+
+    [
+        {hnt_bal, HNTBal},
+        {hst_bal, HSTBal},
+        {mobile_bal, MobileBal},
+        {iot_bal, IOTBal},
+        {entry_mod, EntryMod},
+        {sup, Sup},
+        {pubkey, PubKey},
+        {privkey, PrivKey},
+        {opts, Opts},
+        {chain, Chain},
+        {swarm, Swarm},
+        {n, N},
+        {consensus_members, ConsensusMembers},
+        {genesis_members, GenesisMembers},
+        Keys
+        | Config1
+    ].
+
+%%--------------------------------------------------------------------
+%% TEST CASE TEARDOWN
+%%--------------------------------------------------------------------
+
+end_per_testcase(_, Config) ->
+    Sup = ?config(sup, Config),
+    meck:unload(),
+    % Make sure blockchain saved on file = in memory
+    case erlang:is_process_alive(Sup) of
+        true ->
+            true = erlang:exit(Sup, normal),
+            ok = test_utils:wait_until(fun() -> false =:= erlang:is_process_alive(Sup) end);
+        false ->
+            ok
+    end,
+    test_utils:cleanup_tmp_dir(?config(base_dir, Config)),
+    {comment, done}.
+
+%%--------------------------------------------------------------------
+%% TEST CASES
+%%--------------------------------------------------------------------
+
+add_subnetwork_test(Config) ->
+    {NetworkPriv, _} = ?config(master_key, Config),
+    Chain = ?config(chain, Config),
+    Ledger = blockchain:ledger(Chain),
+    ConsensusMembers = ?config(consensus_members, Config),
+
+    %% Generate a random subnetwork signer
+    [{SubnetworkPubkeyBin, {_SubnetworkPub, _SubnetworkPriv, SubnetworkSigFun}}] = test_utils:generate_keys(
+        1
+    ),
+
+    %% Generate a random reward server
+    [{RewardServerPubkeyBin, _}] = test_utils:generate_keys(1),
+
+    NetworkSigfun = libp2p_crypto:mk_sig_fun(NetworkPriv),
+
+    ct:pal("subnetwork_sigfun: ~p", [SubnetworkSigFun]),
+    ct:pal("network_sigfun: ~p", [NetworkSigfun]),
+
+    TT = mobile,
+    Premine = 5000,
+    T = blockchain_txn_add_subnetwork_v1:new(
+        TT, SubnetworkPubkeyBin, [RewardServerPubkeyBin], Premine
+    ),
+    ST0 = blockchain_txn_add_subnetwork_v1:sign_subnetwork(T, SubnetworkSigFun),
+    ST = blockchain_txn_add_subnetwork_v1:sign(ST0, NetworkSigfun),
+
+    IsValid = blockchain_txn:is_valid(ST, Chain),
+    ?assertEqual(ok, IsValid),
+
+    {ok, Block} = test_utils:create_block(ConsensusMembers, [ST]),
+    _ = blockchain_gossip_handler:add_block(Block, Chain, self(), blockchain_swarm:tid()),
+
+    ?assertEqual({ok, blockchain_block:hash_block(Block)}, blockchain:head_hash(Chain)),
+    ?assertEqual({ok, Block}, blockchain:head_block(Chain)),
+    ?assertEqual({ok, 2}, blockchain:height(Chain)),
+
+    ?assertEqual({ok, Block}, blockchain:get_block(2, Chain)),
+
+    ct:pal("subnetworks: ~p", [blockchain_ledger_v1:subnetworks_v1(Ledger)]),
+
+    ok.
+
+%%--------------------------------------------------------------------
+%% Helper functions
+%%--------------------------------------------------------------------
+
+extra_vars(_) ->
+    #{?allowed_reward_server_key_length => 1}.
+
+token_allocations(_, Config) ->
+    HNTBal = ?config(hnt_bal, Config),
+    HSTBal = ?config(hst_bal, Config),
+    MobileBal = ?config(mobile_bal, Config),
+    IOTBal = ?config(iot_bal, Config),
+    #{hnt => HNTBal, hst => HSTBal, mobile => MobileBal, iot => IOTBal}.

--- a/test/blockchain_subnetwork_rewards_SUITE.erl
+++ b/test/blockchain_subnetwork_rewards_SUITE.erl
@@ -249,7 +249,7 @@ basic_test(Config) ->
 %% Internal functions
 %%--------------------------------------------------------------------
 extra_vars(_) ->
-    #{?allowed_reward_server_key_length => 1, ?token_version => 2}.
+    #{?allowed_num_reward_server_keys => 1, ?token_version => 2}.
 
 token_allocations(_, Config) ->
     HNTBal = ?config(hnt_bal, Config),

--- a/test/blockchain_subnetwork_rewards_SUITE.erl
+++ b/test/blockchain_subnetwork_rewards_SUITE.erl
@@ -1,0 +1,259 @@
+-module(blockchain_subnetwork_rewards_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-include("blockchain_vars.hrl").
+
+-export([
+    all/0,
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+-export([
+    basic_test/1
+]).
+
+all() ->
+    [
+        basic_test
+    ].
+
+%%--------------------------------------------------------------------
+%% TEST SUITE SETUP
+%%--------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    {ok, StorePid} = blockchain_test_reward_store:start(),
+    [{store, StorePid} | Config].
+
+%%--------------------------------------------------------------------
+%% TEST SUITE TEARDOWN
+%%--------------------------------------------------------------------
+
+end_per_suite(_Config) ->
+    blockchain_test_reward_store:stop(),
+    ok.
+
+%%--------------------------------------------------------------------
+%% TEST CASE SETUP
+%%--------------------------------------------------------------------
+
+init_per_testcase(TestCase, Config) ->
+    Config0 = blockchain_ct_utils:init_base_dir_config(?MODULE, TestCase, Config),
+
+    HNTBal = 50000,
+    HSTBal = 10000,
+    MobileBal = 1000,
+    IOTBal = 100,
+
+    Config1 = [
+        {hnt_bal, HNTBal},
+        {hst_bal, HSTBal},
+        {mobile_bal, MobileBal},
+        {iot_bal, IOTBal}
+        | Config0
+    ],
+
+    {ok, Sup, {PrivKey, PubKey}, Opts} = test_utils:init(?config(base_dir, Config1)),
+
+    ExtraVars = extra_vars(TestCase),
+    TokenAllocations = token_allocations(TestCase, Config1),
+
+    {ok, GenesisMembers, _GenesisBlock, ConsensusMembers, Keys} =
+        test_utils:init_chain_with_opts(
+            #{
+                balance =>
+                    HNTBal,
+                sec_balance =>
+                    HSTBal,
+                keys =>
+                    {PrivKey, PubKey},
+                in_consensus =>
+                    false,
+                have_init_dc =>
+                    true,
+                extra_vars =>
+                    ExtraVars,
+                token_allocations =>
+                    TokenAllocations
+            }
+        ),
+
+    Chain = blockchain_worker:blockchain(),
+    Ledger = blockchain:ledger(Chain),
+    Swarm = blockchain_swarm:tid(),
+    N = length(ConsensusMembers),
+
+    {EntryMod, _} = blockchain_ledger_v1:versioned_entry_mod_and_entries_cf(Ledger),
+
+    [
+        {hnt_bal, HNTBal},
+        {hst_bal, HSTBal},
+        {mobile_bal, MobileBal},
+        {iot_bal, IOTBal},
+        {entry_mod, EntryMod},
+        {sup, Sup},
+        {pubkey, PubKey},
+        {privkey, PrivKey},
+        {opts, Opts},
+        {chain, Chain},
+        {swarm, Swarm},
+        {n, N},
+        {consensus_members, ConsensusMembers},
+        {genesis_members, GenesisMembers},
+        Keys
+        | Config1
+    ].
+
+%%--------------------------------------------------------------------
+%% TEST CASE TEARDOWN
+%%--------------------------------------------------------------------
+
+end_per_testcase(_TestCase, Config) ->
+    Sup = ?config(sup, Config),
+    % Make sure blockchain saved on file = in memory
+    case erlang:is_process_alive(Sup) of
+        true ->
+            true = erlang:exit(Sup, normal),
+            ok = test_utils:wait_until(fun() -> false =:= erlang:is_process_alive(Sup) end);
+        false ->
+            ok
+    end,
+    ok.
+
+%%--------------------------------------------------------------------
+%% TEST CASES
+%%--------------------------------------------------------------------
+
+basic_test(Config) ->
+    {NetworkPriv, _} = ?config(master_key, Config),
+    Chain = ?config(chain, Config),
+    Ledger = blockchain:ledger(Chain),
+    ConsensusMembers = ?config(consensus_members, Config),
+
+    %% Generate a random subnetwork signer
+    [{SubnetworkPubkeyBin, {_SubnetworkPub, _SubnetworkPriv, SubnetworkSigFun}}] = test_utils:generate_keys(
+        1
+    ),
+
+    %% Generate a random reward server
+    [{RewardServerPubkeyBin, {_, _, RewardServerSigFun}}] = test_utils:generate_keys(1),
+
+    NetworkSigfun = libp2p_crypto:mk_sig_fun(NetworkPriv),
+
+    TT = mobile,
+    Premine = 5000,
+    T = blockchain_txn_add_subnetwork_v1:new(
+        TT,
+        SubnetworkPubkeyBin,
+        [RewardServerPubkeyBin],
+        Premine
+    ),
+    ST0 = blockchain_txn_add_subnetwork_v1:sign_subnetwork(T, SubnetworkSigFun),
+    ST = blockchain_txn_add_subnetwork_v1:sign(ST0, NetworkSigfun),
+
+    IsValid = blockchain_txn:is_valid(ST, Chain),
+    ?assertEqual(ok, IsValid),
+
+    {ok, Block} = test_utils:create_block(ConsensusMembers, [ST]),
+    _ = blockchain_gossip_handler:add_block(Block, Chain, self(), blockchain_swarm:tid()),
+
+    ?assertEqual({ok, blockchain_block:hash_block(Block)}, blockchain:head_hash(Chain)),
+    ?assertEqual({ok, Block}, blockchain:head_block(Chain)),
+    ?assertEqual({ok, 2}, blockchain:height(Chain)),
+
+    ?assertEqual({ok, Block}, blockchain:get_block(2, Chain)),
+
+    LedgerSubnetworks = blockchain_ledger_v1:subnetworks_v1(Ledger),
+    LedgerSubnetwork = maps:get(mobile, LedgerSubnetworks),
+    ?assertEqual(mobile, blockchain_ledger_subnetwork_v1:type(LedgerSubnetwork)),
+    ?assertEqual(Premine, blockchain_ledger_subnetwork_v1:token_treasury(LedgerSubnetwork)),
+    ?assertEqual(
+        [RewardServerPubkeyBin],
+        blockchain_ledger_subnetwork_v1:reward_server_keys(LedgerSubnetwork)
+    ),
+    ?assertEqual(0, blockchain_ledger_subnetwork_v1:hnt_treasury(LedgerSubnetwork)),
+    ?assertEqual(0, blockchain_ledger_subnetwork_v1:nonce(LedgerSubnetwork)),
+
+    %% Generate some random addresses to reward to
+    [{Rewardee1, _}, {Rewardee2, _}] = test_utils:generate_keys(2),
+    Rewards = [
+        blockchain_txn_subnetwork_rewards_v1:new_reward(Rewardee1, 100),
+        blockchain_txn_subnetwork_rewards_v1:new_reward(Rewardee2, 200)
+    ],
+    Start = 10,
+    End = Start + 30,
+
+    %% Sign with the wrong signature
+    InvRewardsTxn1 = blockchain_txn_subnetwork_rewards_v1:new(mobile, Start, End, Rewards),
+    InvRewardsTxn2 = blockchain_txn_subnetwork_rewards_v1:sign(InvRewardsTxn1, SubnetworkSigFun),
+    {error, invalid_signature} = blockchain_txn:is_valid(InvRewardsTxn2, Chain),
+
+    %% Incorrect start-end range
+    InvRewardsTxn3 = blockchain_txn_subnetwork_rewards_v1:new(
+        mobile,
+        Start,
+        End - 30 - 11,
+        Rewards
+    ),
+    InvRewardsTxn4 = blockchain_txn_subnetwork_rewards_v1:sign(InvRewardsTxn3, RewardServerSigFun),
+    {error, {invalid_reward_range, _, _, _}} = blockchain_txn:is_valid(InvRewardsTxn4, Chain),
+
+    %% Rewarding too much
+    ExcessRewards = [
+        blockchain_txn_subnetwork_rewards_v1:new_reward(Rewardee1, 1000),
+        blockchain_txn_subnetwork_rewards_v1:new_reward(Rewardee2, 4001)
+    ],
+    InvRewardsTxn5 = blockchain_txn_subnetwork_rewards_v1:new(mobile, Start, End, ExcessRewards),
+    InvRewardsTxn6 = blockchain_txn_subnetwork_rewards_v1:sign(InvRewardsTxn5, RewardServerSigFun),
+    {error, {insufficient_tokens_to_fulfil_rewards, _, _}} = blockchain_txn:is_valid(
+        InvRewardsTxn6,
+        Chain
+    ),
+
+    RewardsTxn = blockchain_txn_subnetwork_rewards_v1:new(mobile, Start, End, Rewards),
+    SignedRewardsTxn = blockchain_txn_subnetwork_rewards_v1:sign(RewardsTxn, RewardServerSigFun),
+    %% This one should be valid
+    ok = blockchain_txn:is_valid(SignedRewardsTxn, Chain),
+
+    {ok, Block3} = test_utils:create_block(ConsensusMembers, [SignedRewardsTxn]),
+    _ = blockchain_gossip_handler:add_block(Block3, Chain, self(), blockchain_swarm:tid()),
+
+    ?assertEqual({ok, blockchain_block:hash_block(Block3)}, blockchain:head_hash(Chain)),
+    ?assertEqual({ok, Block3}, blockchain:head_block(Chain)),
+    ?assertEqual({ok, 3}, blockchain:height(Chain)),
+    ?assertEqual({ok, Block3}, blockchain:get_block(3, Chain)),
+
+    {ok, E1} = blockchain_ledger_v1:find_entry(Rewardee1, Ledger),
+    {ok, E2} = blockchain_ledger_v1:find_entry(Rewardee2, Ledger),
+    ?assertEqual(100, blockchain_ledger_entry_v2:balance(E1, mobile)),
+    ?assertEqual(200, blockchain_ledger_entry_v2:balance(E2, mobile)),
+    ?assertEqual(0, blockchain_ledger_entry_v2:balance(E1, hnt)),
+    ?assertEqual(0, blockchain_ledger_entry_v2:balance(E2, hnt)),
+    ?assertEqual(0, blockchain_ledger_entry_v2:balance(E1, iot)),
+    ?assertEqual(0, blockchain_ledger_entry_v2:balance(E2, iot)),
+    ?assertEqual(0, blockchain_ledger_entry_v2:balance(E1, hst)),
+    ?assertEqual(0, blockchain_ledger_entry_v2:balance(E2, hst)),
+
+    {ok, MobileLedgerSubnet} = blockchain_ledger_v1:find_subnetwork_v1(mobile, Ledger),
+    %% 5000 - (100 + 200)
+    4700 = blockchain_ledger_subnetwork_v1:token_treasury(MobileLedgerSubnet),
+
+    ok.
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+extra_vars(_) ->
+    #{?allowed_reward_server_key_length => 1, ?token_version => 2}.
+
+token_allocations(_, Config) ->
+    HNTBal = ?config(hnt_bal, Config),
+    HSTBal = ?config(hst_bal, Config),
+    MobileBal = ?config(mobile_bal, Config),
+    IOTBal = ?config(iot_bal, Config),
+    #{hnt => HNTBal, hst => HSTBal, mobile => MobileBal, iot => IOTBal}.


### PR DESCRIPTION
Summary
----
This PR primarily adds support for adding subnetworks and subnetwork rewards.

Notes
----
- Add `blockchain_ledger_subnetwork_v1` module
- Modify `blockchain_ledger_v1` to support adding, updating and finding subnetworks.
- Add support for `blockchain_txn_add_subnetwork_v1:txn_add_subnetwork_v1`, `blockchain_txn_update_subnetwork_v1:txn_update_subnetwork_v1`, `blockchain_txn_subnetwork_rewards_v1:txn_subnetwork_rewards_v1` and `blockchain_txn_token_convert_v1:txn_token_convert_v1`.
- Add `allowed_reward_server_key_length` chain var
- Add subnetwork rewards test.