### PR TITLE
ensure after filtering we have max active gws up to limit

### DIFF
--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -124,9 +124,17 @@ shuffle_from_hash(Hash, L) ->
 shuffle(Xs) ->
     [X || {_, X} <- lists:sort([{rand:uniform(), X} || X <- Xs])].
 
--spec shuffle(rand:state(), [A]) -> [A].
-shuffle(RandState, Xs) ->
-    [X || {_, X} <- lists:sort([{rand:uniform_s(RandState), X} || X <- Xs])].
+-spec shuffle(rand:state(), list()) -> list().
+shuffle(InitialRandState, List) ->
+    {FinalRandState, TaggedList} =
+        lists:foldl(
+            fun(I, {RandStateAcc, ListAcc}) ->
+                {RandV, NewRandState} = rand:uniform_s(RandStateAcc),
+                {NewRandState, [{RandV, I} | ListAcc]}
+            end,
+        {InitialRandState, []}, List),
+    {_, FinalList} = lists:unzip(lists:keysort(1, TaggedList)),
+    {FinalRandState, FinalList}.
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/src/poc/blockchain_poc_target_v6.erl
+++ b/src/poc/blockchain_poc_target_v6.erl
@@ -241,7 +241,7 @@ limit_and_filter_gateways(ActivityFilterEnabled, MaxActivityAge, Limit, RandStat
             %% remove our current filtered GWs from the original list
             %% shuffle and then attempt to find the extra ones we need
             OrigGWs1 = GWs -- SelectedGWs1,
-            ShuffledGWs = blockchain_utils:shuffle(NewRandState, OrigGWs1),
+            {_, ShuffledGWs} = blockchain_utils:shuffle(NewRandState, OrigGWs1),
             AdditionalGWs = find_more_active_gws(ActivityFilterEnabled, MaxActivityAge,
                 ShuffledGWs, Height, Ledger, Limit - SelectedGWCount),
             SelectedGWs1 ++ AdditionalGWs;


### PR DESCRIPTION
This improves the filtering and limit application of h3dex targeting.  The problem is that we were first limiting the pool of GWs in the hex to a max count equal to chain var `poc_witness_consideration_limit` and then filting any inactives out of those.

This could result in a final pool of GWs well below the max limit value, should any inactive GWs be included in the deterministic subset result when applying the limit.

Now in this scenario if after performing the subset and filtering should the count of GWs be less than the limit value we then add additional active GWs to the subset should they be available.