### PR TITLE
add the grpc transaction service handler

### DIFF
--- a/config/grpc_server_gen.config
+++ b/config/grpc_server_gen.config
@@ -6,11 +6,14 @@
 
 {grpc, [
     {proto_files, [
-        "_build/default/lib/helium_proto/src/service/state_channel.proto"
+        "_build/default/lib/helium_proto/src/service/state_channel.proto",
+        "_build/default/lib/helium_proto/src/service/transaction.proto"
     ]},
     {beam_out_dir, "src/grpc/autogen/server"},
     {out_dir, "src/grpc/autogen/server"},
     {keep_beams, false},
+    {create_services, true},
+    {type, server},
     {override_gpb_defaults, true},
     {gpb_opts, [
         {rename,{msg_fqname,base_name}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -77,7 +77,7 @@
  {<<"hackney">>,{pkg,<<"hackney">>,<<"1.18.0">>},0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"90d62f8509b89d91a444333065dd582e91a0c0f9"}},
+       {ref,"94fe5c17c3df3c28c5a2f30621a9a013ddbdac52"}},
   0},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},2},
  {<<"idna">>,{pkg,<<"idna">>,<<"6.1.1">>},1},

--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -21,6 +21,7 @@
     pfind/2, pfind/3,
     pmap/2,
     addr2name/1,
+    addr2uri/1,
     distance/2,
     score_gateways/1,
     free_space_path_loss/2,
@@ -311,6 +312,91 @@ addr2name(Addr) ->
     B58Addr = libp2p_crypto:bin_to_b58(Addr),
     {ok, N} = erl_angry_purple_tiger:animal_name(B58Addr),
     N.
+
+-spec addr2uri(libp2p_crypto:pubkey_bin() | undefined) -> binary() | undefined.
+addr2uri(undefined) -> undefined;
+addr2uri(PubKeyBin) ->
+    case check_for_public_uri(PubKeyBin) of
+        {ok, URI} -> URI;
+        {error, _} ->
+            case check_for_alias(PubKeyBin) of
+                {error, _} -> undefined;
+                {ok, IP} ->
+                    {Port, SSL} = grpc_port(PubKeyBin),
+                    format_uri(IP, SSL Port)
+            end
+    end.
+
+-spec check_for_public_uri(libp2p_crypto:pubkey_bin()) -> {ok, binary()} | {error, atom()}.
+check_for_public_uri(PubKeyBin) ->
+    SwarmTID = blockchain_swarm:tid(),
+    Peerbook = libp2p_swarm:peerbook(SwarmTID),
+    case libp2p_peerbook:get(Peerbook, PubKeyBin) of
+        {ok, Peer} ->
+            case maps:get(<<"grpc_address">>, libp2p_peer:signed_metadata(Peer), undefined) of
+                undefined ->
+                    %% sort listen addrs, ensure the public ip is at the head
+                    case libp2p_peer:cleared_listen_addrs(Peer) of
+                        [] -> {error, no_listen_addrs};
+                        ClearedListenAddrs ->
+                            case libp2p_transport:sort_addrs_with_keys(SwarmTID, ClearedListenAddrs) of
+                                [] -> {error, no_listen_addrs};
+                                [H | _] ->
+                                    case has_addr_public_ip(H) of
+                                        {error, _} = Error -> Error;
+                                        {ok, IP} ->
+                                            {Port, SSL} = grpc_port(PubKeyBin),
+                                            {ok, format_uri(IP, SSL, Port)}
+                                    end
+                            end
+                    end;
+                URI -> {ok, URI}
+            end;
+        {error, _} = Error -> Error
+    end.
+
+-spec check_for_alias(libp2p_crypto:pubkey_bin()) -> {ok, binary()} | {error, atom()}.
+check_for_alias(PubKeyBin) ->
+    SwarmTID = blockchain_swarm:tid(),
+    MAddr = libp2p_crypto:pubkey_bin_to_p2p(PubKeyBin),
+    Aliases = application:get_env(libp2p, node_aliases, []),
+    case lists:keyfind(MAddr, 1, Aliases) of
+        false -> {error, peer_not_found};
+        {MAddr, AliasAddr} ->
+            %% Assume tcp transport
+            try libp2p_transport_tcp:tcp_addr(AliasAddr) of
+                {IPTuple, _, _, _} -> {ok, list_to_binary(inet:ntoa(IPTuple))}
+            catch
+                _ -> {error, tcp_addr_not_found}
+            end
+    end.
+
+-spec has_addr_public_ip({non_neg_integer(), string()}) -> {ok, binary()} | {error, atom()}.
+has_addr_public_ip({1, Addr}) ->
+    [_, _, IP, _, _Port = re:split(Addr, "/")],
+    {ok, IP};
+has_addr_public_ip({_, _Addr}) -> {error, no_public_ip}.
+
+-spec grpc_port(libp2p_crypto:pubkey_bin()) -> {pos_integer(), boolean()}.
+grpc_port(PubKeyBin) ->
+    MAddr = libp2p_crypto:pubkey_bin_to_p2p(PubKeyBin),
+    Aliases = application:get_env(blockchain, node_grpc_port_aliases, []),
+    case lists:keyfind(MAddr, 1, Aliases) of
+        false ->
+            Port = application:get_env(blockchain, grpc_port, 8080),
+            {Port, false};
+        {MAddr, {Port, SSL}} -> {Port, SSL}
+    end.
+
+-spec format_uri(binary(), boolean(), non_neg_integer()) -> binary().
+format_uri(IP, true, Port) ->
+    Scheme = case SSL of
+                 true -> "https";
+                 false -> "http"
+             end,
+    list_to_binary(
+        uri_string:normalize(#{scheme => Scheme, port => Port, host => IP, path => ""})
+    ).
 
 -spec rand_state(Hash :: binary()) -> rand:state().
 rand_state(Hash) ->

--- a/src/grpc/helium_transaction_service.erl
+++ b/src/grpc/helium_transaction_service.erl
@@ -16,11 +16,86 @@
 %% ------------------------------------------------------------------
 -spec submit(ctx:ctx(), transaction_pb:txn_submit_req_v1_pb()) ->
     {ok, transaction_pb:txn_submit_resp_v1_pb()} | {error, grpcbox_stream:grpc_error_response()}.
-submit(_Ctx, #txn_submit_req_v1_pb{txn = WrappedTxn}) ->
+submit(Ctx, #txn_submit_req_v1_pb{txn = WrappedTxn}) ->
     Txn = blockchain_txn:unwrap_txn(WrappedTxn),
-    .
+    {ok, TxnKey} = blockchain_txn_mgr:grpc_submit(Txn),
+
+    Resp = #txn_submit_resp_v1_pb{key = TxnKey,
+                                  routing_address = RoutingAddr,
+                                  height = current_height(),
+                                  signature = <<>>},
+    SignedResp = sign_resp(Resp, txn_submit_resp_v1_pb),
+
+    {ok, Resp#txn_submit_resp_v1_pb{signature = SignedResp}, Ctx}.
 
 -spec query(ctx:ctx(), transaction_pb:txn_query_req_v1_pb()) ->
     {ok, transaction_pb:txn_query_resp_v1_pb()} | {error, grpcbox_stream:grpc_error_response()}.
-query() ->
-    .
+query(Ctx, #txn_query_req_v1_pb{key = Key}) ->
+    Resp = case blockchain_txn_mgr:txn_status(Key) of
+               {ok, pending, CacheMap} ->
+                   Acceptors = lists:map(fun(Acc) -> acceptor_to_record(Acc) end, maps:get(acceptors, CacheMap)),
+                   Rejectors = lists:map(fun(Rej) -> rejector_to_record(Rej) end, maps:get(rejectors, CacheMap)),
+                   #txn_query_resp_v1_pb{
+                       status = pending,
+                       acceptors = Acceptors,
+                       rejectors = Rejectors,
+                       %% TODO: is the details field still needed?
+                       details = <<>>,
+                       height = maps:get(recv_block_height, CacheMap),
+                       signature = <<>>
+                   };
+               {error, txn_not_found} ->
+                   %% TODO: do we even need a `pending | failed` status anymore or
+                   %% just return pending txns or else a grpcbox_stream error?
+                   #txn_query_resp_v1_pb{
+                       status = failed,
+                       acceptors = [],
+                       rejectors = [],
+                       details = <<>>,
+                       height = undefined,
+                       signature = <<>>
+                   }
+           end,
+
+    SignedResp = sign_resp(Resp, txn_query_resp_v1_pb),
+    {ok, Resp#txn_query_resp_v1_pb{signature = SignedResp}, Ctx}.
+
+%% ------------------------------------------------------------------
+%% internal functions
+%% ------------------------------------------------------------------
+-spec routing_info() -> transaction_pb:routing_address_pb().
+routing_addr() ->
+    PubKeyBin = blockchain_swarm:pubkey_bin(),
+    URI = blockchain_utils:addr2uri(PubKeyBin),
+    #routing_address_pb{pub_key = PubKeyBin, uri = URI}.
+
+-spec sign_resp(#transaction_pb:txn_submit_resp_v1_pb() |
+                #transaction_pb:txn_query_resp_v1_pb(), atom()) -> binary().
+sign_resp(Resp, Type) ->
+    {ok, _, SigFun, _} = blockchain_swarm:keys(),
+    EncodedRespBin = transaction_pb:encode_msg(Resp, Type),
+    SigFun(EncodedRespBin).
+
+-spec current_height() -> pos_integer() | undefined.
+current_height() ->
+    Chain = blockchain_worker:blockchain(),
+    try blockchain:height(Chain) of
+        {ok, Height} when is_integer(Height) -> Height
+    catch
+        %% we may have submitted a txn before the receiver has the chain
+        %% in which case the blockchain_txn_mgr has cached the txn for later submission
+        _ -> undefined
+    end
+
+-spec acceptor_to_record({Member :: libp2p_crypto:pubkey_bin(),
+                          Height :: non_neg_integer() | undefined,
+                          QueuePos :: non_neg_integer() | undefined,
+                          QueueLen :: non_neg_integer() | undefined}) -> transaction_pb:acceptor_pb().
+acceptor_to_record({Member, Height, QueuePos, QueueLen}) ->
+    #acceptor_pb{height = Height, queue_pos = QueuePos, queue_len = QueueLen, pub_key = Member}.
+
+-spec rejector_to_record({Member :: libp2p_crypto:pubkey_bin(),
+                          Height :: non_neg_integer() | undefined,
+                          RejectReason :: atom() | undefined}) -> transaction_pb:rejector_pb().
+rejector_to_reecord({Member, Height, RejectReason}) ->
+    #rejector_pb{height = Height, reason = RejectReason, pub_key = Member}.

--- a/src/grpc/helium_transaction_service.erl
+++ b/src/grpc/helium_transaction_service.erl
@@ -1,0 +1,26 @@
+%%%-------------------------------------------------------------------
+%%
+%% Handler for the transaction service's unary submit/query API/RPC
+%%
+%%%-------------------------------------------------------------------
+-module(helium_transaction_service).
+
+-behaviour(helium_transaction_bhvr).
+
+-include("grpc/autogen/server/transaction_pb.hrl").
+
+-export([submit/2, query/2]).
+
+%% ------------------------------------------------------------------
+%% helium_transaction_bhvr unary callbacks
+%% ------------------------------------------------------------------
+-spec submit(ctx:ctx(), transaction_pb:txn_submit_req_v1_pb()) ->
+    {ok, transaction_pb:txn_submit_resp_v1_pb()} | {error, grpcbox_stream:grpc_error_response()}.
+submit(_Ctx, #txn_submit_req_v1_pb{txn = WrappedTxn}) ->
+    Txn = blockchain_txn:unwrap_txn(WrappedTxn),
+    .
+
+-spec query(ctx:ctx(), transaction_pb:txn_query_req_v1_pb()) ->
+    {ok, transaction_pb:txn_query_resp_v1_pb()} | {error, grpcbox_stream:grpc_error_response()}.
+query() ->
+    .


### PR DESCRIPTION
Adds the grpc transaction service handler module as well as configures the grpcbox plugin server config file to compile the definitions in the transaction.proto file.

Also backports some helper functions originally from sibyl that are needed for providing transaction submission responses with the routing uri information for the grpc host the transaction was submitted to.