### PR TITLE
Add validation for stale heartbeats

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -568,6 +568,7 @@
 -define(validator_hb_reactivation_limit, validator_hb_reactivation_limit). % addresses
 -define(validator_penalty_filter, validator_penalty_filter). % float
 -define(validator_key_check, validator_key_check). % boolean
+-define(validator_stale_heartbeat_check, validator_stale_heartbeat_check). % boolean
 -define(stake_withdrawal_cooldown, stake_withdrawal_cooldown). % blocks
 -define(stake_withdrawal_max, stake_withdrawal_max). % blocks
 %% -define(maximum_overstake, maximum_overstake). % float multiple of min stake

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1522,6 +1522,11 @@ validate_var(?validator_key_check, Value) ->
         Val when is_boolean(Val) -> ok;
         _ -> throw({error, {invalidate_validator_key_check, Value}})
     end;
+validate_var(?validator_stale_heartbeat_check, Value) ->
+    case Value of
+        Val when is_boolean(Val) -> ok;
+        _ -> throw({error, {invalid_validator_stale_heartbeat_check, Value}})
+    end;
 %% TODO fix this var
 validate_var(?stake_withdrawal_cooldown, Value) ->
     %% maybe set this in the test


### PR DESCRIPTION
This change proposes adding a new validation to validator heartbeat transactions to ensure they are not older than the heartbeat interval + grace period. This change will help ensure that 1) validators who are significantly behind the blockchain (i.e. still syncing) do not submit PoC proposals or gateway reactivations and 2) PoC public keys stored in the ledger do not outlive the private keys stored locally by the validator (and thus causing invalid PoCs).

Currently, heartbeats are validated 1) to make sure they are not ahead of the consensus group validating the transaction and 2) to make sure they are not too soon after the previous heartbeat for that validator. The proposed change in this PR adds another check to make sure that the transaction height is not too old, using the heartbeat interval + grace period as the maximum age. While the miner includes a check to not submit a heartbeat if still synching, this is not currently enforced on chain.

This is likely an edge case, as most validator heartbeats are added to the chain within 2-3 blocks (see below for stats). However, during times of heavily load or in the case of an improperly functioning validator, the difference between the heartbeat transaction height and the height at which it is absorbed, may be significant. The table below shows the count of heartbeat transactions grouped by the difference between the chain height and the heartbeat transaction height in blocks for the last 100000 heartbeats.  
```
Diff.   Count
2       45541
3       33080
4       11860
5        4341
6        1749
7         854
8         433
9         321
10        229
11-150    117
151+       94
```