### PR TITLE
sc handler optimisations

### DIFF
--- a/src/blockchain_sup.erl
+++ b/src/blockchain_sup.erl
@@ -114,7 +114,8 @@ init(Args) ->
     BWorkerOpts = [
         {port, proplists:get_value(port, Args, 0)},
         {base_dir, BaseDir},
-        {update_dir, proplists:get_value(update_dir, Args, undefined)}
+        {update_dir, proplists:get_value(update_dir, Args, undefined)},
+        {ets_cache, blockchain_worker:make_ets_table()}
     ],
 
     BEventOpts = [],

--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -15,7 +15,9 @@
 %% ------------------------------------------------------------------
 -export([
     start_link/1,
+    make_ets_table/0,
     blockchain/0, blockchain/1,
+    cached_blockchain/0,
     num_consensus_members/0,
     consensus_addrs/0,
     integrate_genesis_block/1,
@@ -78,6 +80,9 @@
 -define(WEEK_OLD_SECONDS, 7*24*60*60). %% a week's worth of seconds
 -define(MAX_ATTEMPTS, 3).
 
+-define(CACHE, worker_cache).
+-define(CHAIN, chain).
+
 -ifdef(TEST).
 -define(SYNC_TIME, 1000).
 -else.
@@ -121,7 +126,29 @@
 %% API Function Definitions
 %% ------------------------------------------------------------------
 start_link(Args) ->
-    gen_server:start_link({local, ?SERVER}, ?SERVER, Args, [{hibernate_after, 5000}]).
+    Res = server:start_link({local, ?SERVER}, ?SERVER, Args, [{hibernate_after, 5000}]),
+    case Res of
+        {ok, Pid} ->
+            %% if we have an ETS table reference, give ownership to the new process
+            %% we likely are the `heir', so we'll get it back if this process dies
+            case proplists:get_value(ets_cache, Args, not_found) of
+                not_found ->
+                    %% should ever hit here but ok....
+                    ok;
+                Tab ->
+                    true = ets:give_away(Tab, Pid, undefined)
+            end;
+        _ ->
+            ok
+    end,
+    Res.
+
+
+make_ets_table() ->
+    ets:new(?CACHE,
+            [named_table,
+             protected,
+             {heir, self(), undefined}]).
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -134,6 +161,14 @@ blockchain() ->
 -spec blockchain(blockchain:blockchain()) -> ok.
 blockchain(Chain) ->
     gen_server:call(?SERVER, {blockchain, Chain}, infinity).
+
+-spec cached_blockchain() -> blockchain:blockchain()  | undefined.
+cached_blockchain() ->
+    try ets:lookup_element(?CACHE, ?CHAIN, 2) of
+        X -> X
+    catch
+        _:_ -> undefined
+    end.
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -387,6 +422,7 @@ init(Args) ->
                      [ libp2p_swarm:listen(SwarmTID, Addr) || Addr <- ListenAddrs ]),
     NewState = #state{swarm_tid = SwarmTID, blockchain = Blockchain,
                 gossip_ref = Ref},
+    ok = ets:insert(?CACHE, {?CHAIN, Blockchain}),
     {Mode, Info} = get_sync_mode(NewState),
     SnapshotTimerRef = schedule_snapshot_timer(),
     case application:get_env(blockchain, disable_prewarm, false) of
@@ -420,6 +456,7 @@ handle_call({blockchain, NewChain}, _From, #state{swarm_tid = SwarmTID} = State)
     notify({new_chain, NewChain}),
     remove_handlers(SwarmTID),
     {ok, GossipRef} = add_handlers(SwarmTID, NewChain),
+    ok = ets:insert(?CACHE, {?CHAIN, NewChain}),
     {reply, ok, State#state{blockchain = NewChain, gossip_ref = GossipRef}};
 handle_call({new_ledger, Dir}, _From, #state{blockchain=Chain}=State) ->
     %% We do this here so the same process that normally owns the ledger
@@ -486,6 +523,7 @@ handle_call({install_snapshot, Height, Hash, Snapshot, BinSnap}, _From,
                     set_resyncing(ChainHeight, LedgerHeight, NewChain)
             end,
             blockchain_lock:release(),
+            ok = ets:insert(?CACHE, {?CHAIN, NewChain}),
             {reply, ok, maybe_sync(State#state{mode = normal, sync_paused = false,
                                                blockchain = NewChain, gossip_ref = GossipRef})};
         true ->
@@ -506,6 +544,7 @@ handle_call({install_aux_snapshot, Snapshot}, _From,
     {ok, GossipRef} = add_handlers(SwarmTID, NewChain),
     notify({new_chain, NewChain}),
     blockchain_lock:release(),
+    ok = ets:insert(?CACHE, {?CHAIN, NewChain}),
     {reply, ok, maybe_sync(State#state{mode = normal, sync_paused = false,
                                        blockchain = NewChain, gossip_ref = GossipRef})};
 
@@ -538,16 +577,19 @@ handle_call({add_commit_hook, CF, HookIncFun, HookEndFun} , _From, #state{blockc
     Ledger = blockchain:ledger(Chain),
     {Ref, Ledger1} = blockchain_ledger_v1:add_commit_hook(CF, HookIncFun, HookEndFun, Ledger),
     Chain1 = blockchain:ledger(Ledger1, Chain),
+    ok = ets:insert(?CACHE, {?CHAIN, Chain1}),
     {reply, Ref, State#state{blockchain = Chain1}};
 handle_call({add_commit_hook, CF, HookIncFun, HookEndFun, Pred} , _From, #state{blockchain = Chain} = State) ->
     Ledger = blockchain:ledger(Chain),
     {Ref, Ledger1} = blockchain_ledger_v1:add_commit_hook(CF, HookIncFun, HookEndFun, Pred, Ledger),
     Chain1 = blockchain:ledger(Ledger1, Chain),
+    ok = ets:insert(?CACHE, {?CHAIN, Chain1}),
     {reply, Ref, State#state{blockchain = Chain1}};
 handle_call({remove_commit_hook, RefOrCF} , _From, #state{blockchain = Chain} = State) ->
     Ledger = blockchain:ledger(Chain),
     Ledger1 = blockchain_ledger_v1:remove_commit_hook(RefOrCF, Ledger),
     Chain1 = blockchain:ledger(Ledger1, Chain),
+    ok = ets:insert(?CACHE, {?CHAIN, Chain1}),
     {reply, ok, State#state{blockchain = Chain1}};
 
 handle_call(_Msg, _From, State) ->
@@ -557,6 +599,7 @@ handle_call(_Msg, _From, State) ->
 handle_cast({load, BaseDir, GenDir}, #state{blockchain=undefined}=State) ->
     {Blockchain, Ref} = load_chain(State#state.swarm_tid, BaseDir, GenDir),
     {Mode, Info} = get_sync_mode(State#state{blockchain=Blockchain, gossip_ref=Ref}),
+    ok = ets:insert(?CACHE, {?CHAIN, Blockchain}),
     NewState = State#state{blockchain = Blockchain, gossip_ref = Ref, mode=Mode, snapshot_info=Info},
     notify({new_chain, Blockchain}),
     {noreply, NewState};
@@ -743,6 +786,7 @@ handle_info({'DOWN', RocksGCRef, process, RocksGCPid, Reason},
     {noreply, State#state{rocksdb_gc_mref = undefined}};
 
 handle_info({blockchain_event, {new_chain, NC}}, State) ->
+    ok = ets:insert(?CACHE, {?CHAIN, NC}),
     {noreply, State#state{blockchain = NC}};
 handle_info(_Msg, State) ->
     lager:warning("rcvd unknown info msg: ~p", [_Msg]),
@@ -805,6 +849,7 @@ integrate_genesis_block_(
                     blockchain = Chain,
                     gossip_ref = GossipRef
                 },
+            ok = ets:insert(?CACHE, {?CHAIN, Chain}),
             {Mode, SyncInfo} = get_sync_mode(S1),
             {ok, S1#state{mode=Mode, snapshot_info=SyncInfo}}
     end;

--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -148,6 +148,7 @@ make_ets_table() ->
     ets:new(?CACHE,
             [named_table,
              public,  %% public as ?MODULE:init needs to write chain to the table. TODO: move chain load out of init and make this table protected
+             {read_concurrency, true},
              {heir, self(), undefined}]).
 
 %%--------------------------------------------------------------------

--- a/src/grpc/blockchain_grpc_sc_server_handler.erl
+++ b/src/grpc/blockchain_grpc_sc_server_handler.erl
@@ -32,39 +32,11 @@ close(_HandlerPid)->
 -spec init(atom(), grpcbox_stream:t()) -> grpcbox_stream:t().
 init(_RPC, StreamState)->
     lager:debug("initiating grpc state channel server handler with state ~p", [StreamState]),
-    HandlerMod = application:get_env(blockchain, sc_packet_handler, undefined),
-    OfferLimit = application:get_env(blockchain, sc_pending_offer_limit, 5),
-    Blockchain = blockchain_worker:blockchain(),
-    Ledger = blockchain:ledger(Blockchain),
-    Self = self(),
-    case blockchain:config(?sc_version, Ledger) of
-        %% In this case only sc_version=2 is handling banners
-        %% version 1 never had them and banner will be removed form future versions
-        {ok, 2} ->
-            ActiveSCs =
-                e2qc:cache(
-                    ?MODULE,
-                    active_list,
-                    10,
-                    fun() -> maps:to_list(blockchain_state_channels_server:get_actives()) end
-                ),
-            case ActiveSCs of
-                [] ->
-                    SCBanner = blockchain_state_channel_banner_v1:new(),
-                    lager:debug("blockchain_grpc_sc_server_handler, empty banner: ~p", [SCBanner]),
-                    Self ! {send_banner, SCBanner};
-                ActiveSCs ->
-                    [{_SCID, {ActiveSC, _, _}}|_] = ActiveSCs,
-                    SCBanner = blockchain_state_channel_banner_v1:new(ActiveSC),
-                    Self ! {send_banner, SCBanner}
-            end;
-        _ ->
-            noop
-    end,
-    HandlerState = blockchain_state_channel_common:new_handler_state(Blockchain, Ledger, #{}, [], HandlerMod,OfferLimit, false),
+    HandlerState = grpcbox_stream:stream_handler_state(StreamState),
+    NewHandlerState = maybe_initialize_state(HandlerState),
     grpcbox_stream:stream_handler_state(
         StreamState,
-        HandlerState
+        NewHandlerState
     ).
 
 -spec msg(blockchain_state_channel_v1:message(), grpcbox_stream:t()) -> grpcbox_stream:t().
@@ -133,3 +105,42 @@ is_chain_ready(undefined) ->
     false;
 is_chain_ready(_Chain) ->
     true.
+
+%% handler state if not initialized will be undefined otherwise will be a record
+-spec maybe_initialize_state(
+    blockchain_state_channel_common:handler_state() | undefined) ->
+    blockchain_state_channel_common:handler_state().
+maybe_initialize_state(undefined) ->
+    HandlerMod = application:get_env(blockchain, sc_packet_handler, undefined),
+    OfferLimit = application:get_env(blockchain, sc_pending_offer_limit, 5),
+    Blockchain = blockchain_worker:cached_blockchain(),
+    Ledger = blockchain:ledger(Blockchain),
+    Self = self(),
+    case blockchain:config(?sc_version, Ledger) of
+        %% In this case only sc_version=2 is handling banners
+        %% version 1 never had them and banner will be removed form future versions
+        {ok, 2} ->
+            ActiveSCs =
+                e2qc:cache(
+                    ?MODULE,
+                    active_list,
+                   30,
+                    fun() -> maps:to_list(blockchain_state_channels_server:get_actives()) end
+                ),
+            case ActiveSCs of
+                [] ->
+                    SCBanner = blockchain_state_channel_banner_v1:new(),
+                    lager:debug("blockchain_grpc_sc_server_handler, empty banner: ~p", [SCBanner]),
+                    Self ! {send_banner, SCBanner};
+                ActiveSCs ->
+                    [{_SCID, {ActiveSC, _, _}}|_] = ActiveSCs,
+                    SCBanner = blockchain_state_channel_banner_v1:new(ActiveSC),
+                    Self ! {send_banner, SCBanner}
+            end;
+        _ ->
+            noop
+    end,
+    blockchain_state_channel_common:new_handler_state(Blockchain, Ledger, #{}, [], HandlerMod,OfferLimit, false);
+maybe_initialize_state(HandlerState) ->
+    HandlerState.
+

--- a/src/state_channel/blockchain_state_channel_common.erl
+++ b/src/state_channel/blockchain_state_channel_common.erl
@@ -11,6 +11,7 @@
     handler_mod/1, handler_mod/2,
     pending_offer_limit/1, pending_offer_limit/2,
     chain/1, chain/2,
+    streaming_initialized/1, streaming_initialized/2,
     encode_pb/1, encode_pb/2,
     state_channel/1, state_channel/2
 ]).
@@ -33,6 +34,7 @@
 ]).
 
 -record(handler_state, {
+    streaming_initialized :: boolean(),
     chain :: undefined | blockchain:blockchain(),
     ledger :: undefined | blockchain_ledger_v1:ledger(),
     pending_packet_offers = #{} :: #{binary() => {blockchain_state_channel_packet_offer_v1:offer(), pos_integer()}},
@@ -60,6 +62,7 @@ new_handler_state()->
     ) -> handler_state().
 new_handler_state(Chain, Ledger, PendingPacketOffers, OfferQueue, HandlerMod, PendingOfferLimit, EncodePB)->
     #handler_state{
+        streaming_initialized = true,
         chain = Chain,
         ledger = Ledger,
         pending_packet_offers = PendingPacketOffers,
@@ -75,6 +78,10 @@ new_handler_state(Chain, Ledger, PendingPacketOffers, OfferQueue, HandlerMod, Pe
 %%
 -spec chain(handler_state()) -> undefined | blockchain:blockchain().
 chain(#handler_state{chain=V}) ->
+    V.
+
+-spec streaming_initialized(handler_state()) -> undefined | boolean().
+streaming_initialized(#handler_state{streaming_initialized=V}) ->
     V.
 
 -spec ledger(handler_state()) -> undefined | blockchain_ledger_v1:ledger().
@@ -111,6 +118,10 @@ state_channel(#handler_state{state_channel=V}) ->
 -spec chain(blockchain:blockchain(), handler_state()) -> handler_state().
 chain(NewV, HandlerState) ->
     HandlerState#handler_state{chain=NewV}.
+
+-spec streaming_initialized(boolean(), handler_state()) -> handler_state().
+streaming_initialized(NewV, HandlerState) ->
+    HandlerState#handler_state{streaming_initialized=NewV}.
 
 -spec ledger(blockchain_ledger_v1:ledger(), handler_state()) -> handler_state().
 ledger(NewV, HandlerState) ->

--- a/src/state_channel/blockchain_state_channel_handler.erl
+++ b/src/state_channel/blockchain_state_channel_handler.erl
@@ -60,8 +60,8 @@ init(server, _Conn, [_Path, Blockchain]) ->
     Ledger = blockchain:ledger(Blockchain),
     HandlerMod = application:get_env(blockchain, sc_packet_handler, undefined),
     OfferLimit = application:get_env(blockchain, sc_pending_offer_limit, 5),
-    HandlerState = blockchain_state_channel_common:new_handler_state(Blockchain, Ledger, #{}, [], HandlerMod, OfferLimit, true),
-    case blockchain:config(?sc_version, Ledger) of
+    HandlerState = blockchain_state_channel_common:new_handler_state(#{}, [], HandlerMod, OfferLimit, true),
+    case blockchain_ledger_v1:config(?sc_version, Ledger) of
         %% In this case only sc_version=2 is handling banners
         %% version 1 never had them and banner will be removed form future versions
         {ok, 2} ->
@@ -99,18 +99,9 @@ init(server, _Conn, [_Path, Blockchain]) ->
     HandlerState :: any()
 ) -> libp2p_framed_stream:handle_data_result().
 handle_data(client, Data, HandlerState) ->
+    Chain = blockchain_worker:cached_blockchain(),
+    Ledger = blockchain:ledger(Chain),
     %% get ledger if we don't yet have one
-    Ledger = 
-        case blockchain_state_channel_common:ledger(HandlerState) of
-            undefined ->
-                case blockchain_worker:blockchain() of
-                    undefined ->
-                        undefined;
-                    Chain ->
-                        blockchain:ledger(Chain)
-                end;
-            L -> L
-        end,
     case blockchain_state_channel_message_v1:decode(Data) of
         {banner, Banner} ->
             case blockchain_state_channel_banner_v1:sc(Banner) of
@@ -146,9 +137,10 @@ handle_data(client, Data, HandlerState) ->
             lager:debug("sc_handler client got response: ~p", [Resp]),
             blockchain_state_channels_client:response(Resp)
     end,
-    NewHandlerState = blockchain_state_channel_common:ledger(Ledger, HandlerState),
-    {noreply, NewHandlerState};
+    {noreply, HandlerState};
 handle_data(server, Data, HandlerState) ->
+    Chain = blockchain_worker:cached_blockchain(),
+    Ledger = blockchain:ledger(Chain),
     PendingOffers = blockchain_state_channel_common:pending_packet_offers(HandlerState),
     PendingOfferLimit = blockchain_state_channel_common:pending_offer_limit(HandlerState),
     Time = erlang:system_time(millisecond),
@@ -165,7 +157,6 @@ handle_data(server, Data, HandlerState) ->
             NewHandlerState = blockchain_state_channel_common:offer_queue(CurOfferQueue ++ [{Offer, Time}], HandlerState),
             {noreply, NewHandlerState};
         {packet, Packet} ->
-            Ledger = blockchain_state_channel_common:ledger(HandlerState),
             PacketHash = blockchain_helium_packet_v1:packet_hash(blockchain_state_channel_packet_v1:packet(Packet)),
             case maps:get(PacketHash, PendingOffers, undefined) of
                 undefined ->


### PR DESCRIPTION
Provides optimisations/improvements of the state channel GRPC handler and the shared `blockchain_state_channel_common` module.  This mod is shared across both grpc and libp2p transport layers for state channel requests.

Optimisation/improvements include:

- Remove cached versions of the `blockchain` and `ledger` in the state channel handler state
- Add a simple ETS cache to blockchain_worker to hold the current blockchain.  Avoids blocking calls to the worker by spawned grpc handlers.  
