### PR TITLE
revert region cache changes, add prewarm

### DIFF
--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -389,6 +389,15 @@ init(Args) ->
                 gossip_ref = Ref},
     {Mode, Info} = get_sync_mode(NewState),
     SnapshotTimerRef = schedule_snapshot_timer(),
+    case application:get_env(blockchain, disable_prewarm, false) of
+        true -> ok;
+        false ->
+            Ledger = blockchain:ledger(Blockchain),
+            spawn(fun() ->
+                          timer:sleep(90000),
+                          blockchain_region_v1:prewarm_cache(Ledger)
+                  end)
+    end,
     {ok, NewState#state{snapshot_timer=SnapshotTimerRef, mode=Mode, snapshot_info=Info}}.
 
 handle_call({integrate_genesis_block_synchronously, GenesisBlock}, _From, #state{}=S0) ->

--- a/src/region/blockchain_region_v1.erl
+++ b/src/region/blockchain_region_v1.erl
@@ -38,28 +38,21 @@ get_all_regions(Ledger) ->
 -spec get_all_region_bins(Ledger :: blockchain_ledger_v1:ledger()) ->
     {ok, [{atom(), binary() | {error, any()}}]} | {error, any()}.
 get_all_region_bins(Ledger) ->
-    {ok, VarsNonce} = blockchain_ledger_v1:vars_nonce(Ledger),
-    HasAux = blockchain_ledger_v1:has_aux(Ledger),
-    e2qc:cache(
-      ?H3_TO_REGION_CACHE,
-      {region_bins, HasAux, VarsNonce},
-      fun() ->
-              case get_all_regions(Ledger) of
-                  {ok, Regions} ->
-                      Map = lists:foldl(
-                              fun(Reg, Acc) ->
-                                      case blockchain:config(Reg, Ledger) of
-                                          {ok, Bin} ->
-                                              [{Reg, Bin}|Acc];
-                                          _ ->
-                                              [{error, {region_var_not_set, Reg}}|Acc]
-                                      end
-                              end, [], Regions),
-                      {ok, lists:reverse(Map)};
-                  Error ->
-                      Error
-              end
-      end).
+    case get_all_regions(Ledger) of
+        {ok, Regions} ->
+            Map = lists:foldl(
+                    fun(Reg, Acc) ->
+                            case blockchain:config(Reg, Ledger) of
+                                {ok, Bin} ->
+                                    [{Reg, Bin}|Acc];
+                                _ ->
+                                    [{error, {region_var_not_set, Reg}}|Acc]
+                            end
+                    end, [], Regions),
+            {ok, lists:reverse(Map)};
+        Error ->
+            Error
+    end.
 
 -spec h3_to_region(H3 :: h3:h3_index(), Ledger :: blockchain_ledger_v1:ledger()) ->
     {ok, atom()} | {error, any()}.
@@ -76,33 +69,23 @@ h3_to_region(H3, Ledger, RegionBins) ->
     Res = polyfill_resolution(Ledger),
     HasAux = blockchain_ledger_v1:has_aux(Ledger),
     Parent = h3:parent(H3, Res),
-    MaybeBins =
-    case RegionBins of
-        no_prefetch -> get_all_region_bins(Ledger);
-        {error, _} = Err -> Err;
-        B -> {ok, B}
-    end,
-    case MaybeBins of
-        {error, _} = Error -> Error;
-        {ok, Bins} ->
-            %% use a hash of the region bins as the cache key
-            %% so if any region changes the lookup will be recalculated
-            %%
-            %% We can cache the hash of the bins because that
-            %% is much cheaper to recalculate if invalidated
-            Hash = e2qc:cache(?H3_TO_REGION_CACHE,
-                              {bin_hash, HasAux, VarsNonce},
-                              fun() ->
-                                      crypto:hash(sha256, term_to_binary(Bins))
-                              end),
-            e2qc:cache(
-              ?H3_TO_REGION_CACHE,
-              {HasAux, Hash, Parent},
-              fun() ->
-                      h3_to_region_(Parent, Bins)
-              end
-             )
-    end.
+    e2qc:cache(
+        ?H3_TO_REGION_CACHE,
+        {HasAux, VarsNonce, Parent},
+        fun() ->
+                MaybeBins =
+                    case RegionBins of
+                        no_prefetch -> get_all_region_bins(Ledger);
+                        {error, _} = Err -> Err;
+                        B -> {ok, B}
+                    end,
+                case MaybeBins of
+                    {ok, Bins} ->
+                        h3_to_region_(Parent, Bins);
+                    {error, _} = Error -> Error
+                end
+        end
+     ).
 
 -spec h3_in_region(
     H3 :: h3:h3_index(),

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -615,7 +615,18 @@ delayed_absorb(Txn, Ledger) ->
                 Key ->
                     ok = blockchain_ledger_v1:master_key(Key, Ledger)
             end
-    end.
+    end,
+    case blockchain_ledger_v1:mode(Ledger) of
+        active ->
+            %% we've invalidated the region cache, so prewarm it.
+            spawn(fun() ->
+                          timer:sleep(30000),
+                          blockchain_region_v1:prewarm_cache(Ledger)
+                  end);
+        _ ->
+            ok
+    end,
+    ok.
 
 sum_higher(Target, Proplist) ->
     sum_higher(Target, Proplist, 0).


### PR DESCRIPTION
the region cache getting invalidated on var transactions + the low poc rate are interacting in bad ways to make post-var rewards pretty disastrous.

in #1385 we tried a change to make this happen automatically, but it does not seem to have been effective, and is causing performance problems in normal operation.

This PR reverts #1385 and adds some region cache prewarming code that starts in the background whenever the node starts or a var transaction is absorbed on the active ledger.  While the prewarm is pretty expensive, it's cheaper than massive chain stalls caused by multi-minute rewards blocks.