### PR TITLE
Add cache cli

### DIFF
--- a/scripts/extensions/ledger
+++ b/scripts/extensions/ledger
@@ -4,7 +4,10 @@ if [ -t 0 ] ; then
     export CLIQUE_COLUMNS
 fi
 
-export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+# extend relx default timeout (60s) if it has not already been overwritten
+if [ $RELX_RPC_TIMEOUT -eq 60 ] ; then
+    export RELX_RPC_TIMEOUT=900
+fi
 
 j=1
 l=$#

--- a/scripts/extensions/peer
+++ b/scripts/extensions/peer
@@ -4,7 +4,10 @@ if [ -t 0 ] ; then
     export CLIQUE_COLUMNS
 fi
 
-export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+# extend relx default timeout (60s) if it has not already been overwritten
+if [ $RELX_RPC_TIMEOUT -eq 60 ] ; then
+    export RELX_RPC_TIMEOUT=900
+fi
 
 j=1
 l=$#

--- a/scripts/extensions/repair
+++ b/scripts/extensions/repair
@@ -4,7 +4,10 @@ if [ -t 0 ] ; then
     export CLIQUE_COLUMNS
 fi
 
-export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+# extend relx default timeout (60s) if it has not already been overwritten
+if [ $RELX_RPC_TIMEOUT -eq 60 ] ; then
+    export RELX_RPC_TIMEOUT=900
+fi
 
 j=1
 l=$#

--- a/scripts/extensions/sc
+++ b/scripts/extensions/sc
@@ -4,7 +4,10 @@ if [ -t 0 ] ; then
     export CLIQUE_COLUMNS
 fi
 
-export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+# extend relx default timeout (60s) if it has not already been overwritten
+if [ $RELX_RPC_TIMEOUT -eq 60 ] ; then
+    export RELX_RPC_TIMEOUT=900
+fi
 
 j=1
 l=$#

--- a/scripts/extensions/snapshot
+++ b/scripts/extensions/snapshot
@@ -4,7 +4,10 @@ if [ -t 0 ] ; then
     export CLIQUE_COLUMNS
 fi
 
-export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+# extend relx default timeout (60s) if it has not already been overwritten
+if [ $RELX_RPC_TIMEOUT -eq 60 ] ; then
+    export RELX_RPC_TIMEOUT=900
+fi
 
 j=1
 l=$#

--- a/scripts/extensions/trace
+++ b/scripts/extensions/trace
@@ -4,7 +4,10 @@ if [ -t 0 ] ; then
     export CLIQUE_COLUMNS
 fi
 
-export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+# extend relx default timeout (60s) if it has not already been overwritten
+if [ $RELX_RPC_TIMEOUT -eq 60 ] ; then
+    export RELX_RPC_TIMEOUT=900
+fi
 
 j=1
 l=$#

--- a/scripts/extensions/txn
+++ b/scripts/extensions/txn
@@ -4,7 +4,10 @@ if [ -t 0 ] ; then
     export CLIQUE_COLUMNS
 fi
 
-export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+# extend relx default timeout (60s) if it has not already been overwritten
+if [ $RELX_RPC_TIMEOUT -eq 60 ] ; then
+    export RELX_RPC_TIMEOUT=900
+fi
 
 j=1
 l=$#

--- a/src/region/blockchain_region_v1.erl
+++ b/src/region/blockchain_region_v1.erl
@@ -12,7 +12,8 @@
          h3_to_region/2, h3_to_region/3,
          h3_in_region/3, h3_in_region/4,
 
-         prewarm_cache/1
+         prewarm_cache/1,
+         clear_cache/0
         ]).
 
 -type regions() :: [atom()].
@@ -116,6 +117,7 @@ h3_in_region(H3, RegionVar, Ledger, RegionBins) ->
         Other -> Other
     end.
 
+
 %%--------------------------------------------------------------------
 %% helpers
 %%--------------------------------------------------------------------
@@ -169,6 +171,8 @@ polyfill_resolution(Ledger) ->
     end.
 
 prewarm_cache(Ledger) ->
+    lager:info("starting cache prewarm: ~p", [h3_to_region]),
+    Before = erlang:monotonic_time(second),
     {ok, RB} = get_all_region_bins(Ledger),
     blockchain_ledger_v1:cf_fold(
       active_gateways,
@@ -180,4 +184,11 @@ prewarm_cache(Ledger) ->
               end
       end,
       0, Ledger),
+    Duration = erlang:monotonic_time(second) - Before,
+    lager:info("completed cache prewarm in ~p seconds: ~p", [Duration, h3_to_region]),
+    ok.
+
+clear_cache() ->
+    e2qc:teardown(h3_to_region),
+    lager:info("cleared cache: ~p", [h3_to_region]),
     ok.


### PR DESCRIPTION
For validator operators who wish to control the prewarm of the cache, this change makes it easier by introducing a cli to prewarm the cache. For completeness, it also adds a clearing option too. And lastly, adds a little bit of logging around the cache functions for visibility.

Additionally, I also found an issue with the way that the default relx rpc timeout was being overwritten and put in place a new implementation to change the default to 900 seconds as originally intended by #1268. 