### PR TITLE
Ledger lookup happens in spawn

### DIFF
--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -392,9 +392,9 @@ init(Args) ->
     case application:get_env(blockchain, disable_prewarm, false) of
         true -> ok;
         false ->
-            Ledger = blockchain:ledger(Blockchain),
             spawn(fun() ->
                           timer:sleep(90000),
+                          Ledger = blockchain:ledger(),
                           blockchain_region_v1:prewarm_cache(Ledger)
                   end)
     end,


### PR DESCRIPTION
Problem to solve: When `autoload` is set to `false` like in blockchain-etl, the call on line 394 blows up with a function clause error because the chain is still undefined.

Solution: Defer the ledger lookup until just before the cache generation happens and do it inside of the spawn, so that if it fails, it's harmless to application start up.