### PR TITLE
bugfix for removing gateway from h3dex 

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -219,6 +219,9 @@
 %% max number of hexes to GC in the h3dex per block: integer
 -define(h3dex_gc_width, h3dex_gc_width).
 
+%% determines whether or not to use the fix for a bug in removing gateways from h3dex : boolean
+-define(h3dex_remove_gw_fix, h3dex_remove_gw_fix).
+
 %% the version number of poc targeting in use: integer
 %% if not set, code paths with default to 3 ( blockchain_poc_target_v3 )
 -define(poc_targeting_version, poc_targeting_version).

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1132,6 +1132,11 @@ validate_var(?polyfill_resolution, Value) ->
     validate_int(Value, "polyfill_resolution", 0, 15, false);
 validate_var(?h3dex_gc_width, Value) ->
   validate_int(Value, "h3dex_gc_width", 1, 10000, false);
+validate_var(?h3dex_remove_gw_fix, Value) ->
+  case Value of
+        Val when is_boolean(Val) -> ok;
+        _ -> throw({error, {h3dex_gw_remove_fix, Value}})
+    end;
 validate_var(?poc_target_pool_size, Value) ->
   validate_int(Value, "poc_target_pool_size", 1, 1000000, false);
 validate_var(?poc_targeting_version, Value) ->


### PR DESCRIPTION
When a hex needs to be removed from the h3dex, it may also require rebuilding the targeting lookup for h3dex-based targeting if the parent hex (at the targeting resolution) becomes empty as well. However, due to a bug, this check may not be working as expect leaving the hex in the h3dex. The current code is checking for the count of gateways in the parent hex before removing the gateway from that hex. Instead, it should remove the gateway's hex and then check if that results in the parent hex now being empty.

This change is behind a chain var as to to allow it to be made after h3dex activation.