### PR TITLE
add per-block limit to rewards

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -638,4 +638,4 @@
 %% How many reward server keys to allow
 -define(allowed_num_reward_server_keys, allowed_num_reward_server_keys).
 %% limit per-block payout of l2 tokens
--define(limit_subnetwork_payout, limit_subnetwork_payout).
+-define(subnetwork_reward_per_block_limit, subnetwork_reward_per_block_limit).

--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -637,4 +637,5 @@
 -define(deprecate_security_exchange_v1, deprecate_security_exchange_v1).
 %% How many reward server keys to allow
 -define(allowed_num_reward_server_keys, allowed_num_reward_server_keys).
-
+%% limit per-block payout of l2 tokesn
+-define(limit_subnetwork_payout, limit_subnetwork_payout).

--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -637,5 +637,5 @@
 -define(deprecate_security_exchange_v1, deprecate_security_exchange_v1).
 %% How many reward server keys to allow
 -define(allowed_num_reward_server_keys, allowed_num_reward_server_keys).
-%% limit per-block payout of l2 tokesn
+%% limit per-block payout of l2 tokens
 -define(limit_subnetwork_payout, limit_subnetwork_payout).

--- a/src/transactions/v1/blockchain_txn_subnetwork_rewards_v1.erl
+++ b/src/transactions/v1/blockchain_txn_subnetwork_rewards_v1.erl
@@ -131,7 +131,8 @@ is_valid(Txn, Chain) ->
     TotalRewards = total_rewards(Txn),
     Tokens = blockchain_ledger_subnetwork_v1:token_treasury(Subnet),
     LastRewardedBlock = blockchain_ledger_subnetwork_v1:last_rewarded_block(Subnet),
-    {ok, BlockRewardLimit} = blockchain_ledger_v1:config(?limit_subnetwork_payout, Ledger),
+    {ok, BlockRewardLimit} =
+        blockchain_ledger_v1:config(?subnetwork_reward_per_block_limit, Ledger),
     RewardLimit = BlockRewardLimit * (End - Start),
     try
         %% this needs to somehow limit the mint here?  but if there is only premine I don't

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1260,6 +1260,9 @@ validate_var(?allowed_num_reward_server_keys, Value) ->
         _ -> throw({error, {invalid_allowed_num_reward_server_keys, Value}})
     end;
 
+validate_var(?limit_subnetwork_payout, Value) ->
+    validate_int(Value, "limit_subnetwork_payout", 0, 10_000_000, false);
+
 %% general txn vars
 
 validate_var(?txn_field_validation_version, Value) ->

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1260,8 +1260,8 @@ validate_var(?allowed_num_reward_server_keys, Value) ->
         _ -> throw({error, {invalid_allowed_num_reward_server_keys, Value}})
     end;
 
-validate_var(?limit_subnetwork_payout, Value) ->
-    validate_int(Value, "limit_subnetwork_payout", 0, 10000000, false);
+validate_var(?subnetwork_reward_per_block_limit, Value) ->
+    validate_int(Value, "subnetwork_reward_per_block_limit", 0, 10000000000000, false);
 
 %% general txn vars
 

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1261,7 +1261,7 @@ validate_var(?allowed_num_reward_server_keys, Value) ->
     end;
 
 validate_var(?limit_subnetwork_payout, Value) ->
-    validate_int(Value, "limit_subnetwork_payout", 0, 10_000_000, false);
+    validate_int(Value, "limit_subnetwork_payout", 0, 10000000, false);
 
 %% general txn vars
 

--- a/test/blockchain_subnetwork_SUITE.erl
+++ b/test/blockchain_subnetwork_SUITE.erl
@@ -212,7 +212,7 @@ failing_subnetwork_test(Config) ->
 
 extra_vars(_) ->
     #{?allowed_num_reward_server_keys => 1,
-      ?limit_subnetwork_payout => 100}.
+      ?subnetwork_reward_per_block_limit => 100}.
 
 token_allocations(_, Config) ->
     HNTBal = ?config(hnt_bal, Config),

--- a/test/blockchain_subnetwork_SUITE.erl
+++ b/test/blockchain_subnetwork_SUITE.erl
@@ -211,7 +211,8 @@ failing_subnetwork_test(Config) ->
 %%--------------------------------------------------------------------
 
 extra_vars(_) ->
-    #{?allowed_num_reward_server_keys => 1}.
+    #{?allowed_num_reward_server_keys => 1,
+      ?limit_subnetwork_payout => 100}.
 
 token_allocations(_, Config) ->
     HNTBal = ?config(hnt_bal, Config),

--- a/test/blockchain_subnetwork_rewards_SUITE.erl
+++ b/test/blockchain_subnetwork_rewards_SUITE.erl
@@ -215,10 +215,10 @@ basic_test(Config) ->
         Chain
     ),
 
-    InvRewardsTxn7 = blockchain_txn_subnetwork_rewards_v1:new(mobile, Start, End, Rewards),
-    InvRewardsTxn8 = blockchain_txn_subnetwork_rewards_v1:sign(InvRewardsTxn7, RewardServerSigFun),
+    InvRewardsTxn9 = blockchain_txn_subnetwork_rewards_v1:new(mobile, Start, End, Rewards),
+    InvRewardsTxn10 = blockchain_txn_subnetwork_rewards_v1:sign(InvRewardsTxn9, RewardServerSigFun),
     %% This one is invalid because we don't have enough blocks yet
-    {error, {invalid_end_block, End, 2}} = blockchain_txn:is_valid(InvRewardsTxn8, Chain),
+    {error, {invalid_end_block, End, 2}} = blockchain_txn:is_valid(InvRewardsTxn10, Chain),
 
     %% Add some blocks
     lists:foreach(
@@ -230,6 +230,19 @@ basic_test(Config) ->
     ),
 
     ?assertEqual({ok, 40}, blockchain:height(Chain)),
+
+    %% Rewarding too much per block
+    ExcessRewardsPerBlock = [
+        blockchain_txn_subnetwork_rewards_v1:new_reward(Rewardee1, 200),
+        blockchain_txn_subnetwork_rewards_v1:new_reward(Rewardee2, 400)
+    ],
+    InvRewardsTxn7 = blockchain_txn_subnetwork_rewards_v1:new(mobile, Start, End,
+                                                              ExcessRewardsPerBlock),
+    InvRewardsTxn8 = blockchain_txn_subnetwork_rewards_v1:sign(InvRewardsTxn7, RewardServerSigFun),
+    {error, {rewards_too_large,600,300}} = blockchain_txn:is_valid(
+        InvRewardsTxn8,
+        Chain
+    ),
 
     RewardsTxn = blockchain_txn_subnetwork_rewards_v1:new(mobile, Start, End, Rewards),
     SignedRewardsTxn = blockchain_txn_subnetwork_rewards_v1:sign(RewardsTxn, RewardServerSigFun),
@@ -265,7 +278,8 @@ basic_test(Config) ->
 %% Internal functions
 %%--------------------------------------------------------------------
 extra_vars(_) ->
-    #{?allowed_num_reward_server_keys => 1, ?token_version => 2}.
+    #{?allowed_num_reward_server_keys => 1, ?token_version => 2,
+      ?limit_subnetwork_payout => 10}.
 
 token_allocations(_, Config) ->
     HNTBal = ?config(hnt_bal, Config),

--- a/test/blockchain_subnetwork_rewards_SUITE.erl
+++ b/test/blockchain_subnetwork_rewards_SUITE.erl
@@ -279,7 +279,7 @@ basic_test(Config) ->
 %%--------------------------------------------------------------------
 extra_vars(_) ->
     #{?allowed_num_reward_server_keys => 1, ?token_version => 2,
-      ?limit_subnetwork_payout => 10}.
+      ?subnetwork_reward_per_block_limit => 10}.
 
 token_allocations(_, Config) ->
     HNTBal = ?config(hnt_bal, Config),


### PR DESCRIPTION
to limit the impact of potential reward server takeovers, add a chain var to limit the amount of rewards that can be emitted per block.