### PR TITLE
Fix h3dex GC during snapshot load

### DIFF
--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -741,6 +741,7 @@ load_blocks(Ledger0, Chain, Snapshot) ->
                       {ok, _Chain, _} = blockchain_txn:absorb_block(Block, Rescue, Chain1),
                       ok = blockchain_ledger_v1:maybe_gc_pocs(Chain1, Ledger2),
                       ok = blockchain_ledger_v1:maybe_gc_scs(Chain1, Ledger2),
+                      ok = blockchain_ledger_v1:maybe_gc_h3dex(Ledger2),
                       %% ok = blockchain_ledger_v1:refresh_gateway_witnesses(Hash, Ledger2),
                       ok = blockchain_ledger_v1:maybe_recalc_price(Chain1, Ledger2),
                       %% TODO Q: Why no match result?


### PR DESCRIPTION
This change fixes an issue that nodes are seeing with periodic invalid transactions after loading a snapshot that was created following the h3dex / targeting v6 activation. While loading blocks as part of a snapshot, garbage collection is not being called called on the h3dex. Typically, GC occurs on the h3dex with each block. The change adds the missing maybe_gc_h3dex call following block absorb for each block loaded from the snapshot.

Thanks to @mawdegroot and @BigEnigma for working through the issue on the Discord #validator-ops channel.