### PR TITLE
Additional bugfix for adding gw to h3dex lookup

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -224,8 +224,8 @@
 %% max number of hexes to GC in the h3dex per block: integer
 -define(h3dex_gc_width, h3dex_gc_width).
 
-%% determines whether or not to use the fix for a bug in removing gateways from h3dex : boolean
--define(h3dex_remove_gw_fix, h3dex_remove_gw_fix).
+%% determines whether or not to use the fix for a bug in adding/removing gateways from h3dex: boolean
+-define(h3dex_targeting_lookup_fix, h3dex_targeting_lookup_fix).
 
 %% the version number of poc targeting in use: integer
 %% if not set, code paths with default to 3 ( blockchain_poc_target_v3 )

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1138,7 +1138,7 @@ validate_var(?polyfill_resolution, Value) ->
     validate_int(Value, "polyfill_resolution", 0, 15, false);
 validate_var(?h3dex_gc_width, Value) ->
   validate_int(Value, "h3dex_gc_width", 1, 10000, false);
-validate_var(?h3dex_remove_gw_fix, Value) ->
+validate_var(?h3dex_targeting_lookup_fix, Value) ->
   case Value of
         Val when is_boolean(Val) -> ok;
         _ -> throw({error, {h3dex_gw_remove_fix, Value}})


### PR DESCRIPTION
This change extends the fix in #1403 to the add gateway case on top of the remove gateway case already covered in that PR. Because the chain var introduced in 1403 has not been activated, I also choose to rename and reuse that same var for this fix as to avoid more vars.

I believe this fix is necessarily for being able to re-introduce the h3dex hex targeting lookup optimizations first attempted in #1409.