### PR TITLE
bump grpcbox

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -51,7 +51,7 @@
  {<<"gproc">>,{pkg,<<"gproc">>,<<"0.8.0">>},1},
  {<<"grpcbox">>,
   {git,"https://github.com/novalabsxyz/grpcbox.git",
-       {ref,"3a7fe316aecd3b0c64e98cd590fa65b7c8725103"}},
+       {ref,"654c7a5d0fdf69c15e33a07d78e76867f474c6ea"}},
   0},
  {<<"h3">>,
   {git,"https://github.com/helium/erlang-h3.git",


### PR DESCRIPTION
pulls in fix to prevent leaking grpc stream processes when init crash is encountered