### PR TITLE
txn mgr logging tweaks & fix dial timeout handling

### DIFF
--- a/src/transactions/blockchain_txn_dialer.erl
+++ b/src/transactions/blockchain_txn_dialer.erl
@@ -55,7 +55,7 @@ dial(Pid) ->
 init(Args) ->
     lager:debug("blockchain_txn_dialer started with ~p", [Args]),
     [Parent, RequestType, TxnKey, Txn, Member] = Args,
-    Ref = erlang:send_after(30000, Parent, {dial_timeout, {RequestType, self(), TxnKey, Txn, Member}}),
+    Ref = erlang:send_after(30000, Parent, {dial_timeout, {RequestType, {self(), TxnKey, Txn, Member}}}),
     {ok, #state{parent=Parent, request_type = RequestType, txn_key = TxnKey, txn=Txn, member=Member, timeout=Ref}}.
 
 handle_call(_, _, State) ->


### PR DESCRIPTION
Addresses 2 issues:

1. Logging tidy up after observing the logs on etl as a result of the recent txn mgr changes relating to grpc submit and v3 dialing protocol support

2.  Fixes handling of dial_timeout msgs in txn mgr sent from the dialer.  Dialer was sending these incorrectly formatted and thus txn msg was not handling them and instead they would hit the fallback unhandled info msg handler.  Dial timeouts were not being retried