### PR TITLE
Fix h3dex check and bootstrap during snapshot load

### DIFF
--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -499,10 +499,11 @@ handle_call({install_snapshot, Height, Hash, Snapshot, BinSnap}, _From,
 
                 %% fail into the catch if it's an older record
                 true = blockchain_ledger_snapshot_v1:is_v6(Snapshot),
-                %% fail into the catch if it's missing
-                H3dex = blockchain_ledger_snapshot_v1:get_h3dex(Snapshot),
 
-                case length(H3dex) > 0 of
+                %% fail into the catch if it's missing
+                H3dex = blockchain_ledger_v1:get_h3dex(NewLedger),
+
+                case maps:size(H3dex) > 0 of
                     true -> ok;
                     false -> throw(bootstrap) % fail into the catch it's an empty default value
                 end


### PR DESCRIPTION
In at least some cases, the snapshot load process would fail due to the new inclusion of the random hex targeting lookup in the h3dex. The check of whether the snapshot includes the h3dex was incorrectly triggering the h3dex bootstrapping, and then subsequently the bootstrap process failed because it did not handle the new "random-" and "population" keys in the h3dex used for targeting.

This change switches the check of the whether the snapshot loaded the h3dex to use the ledger_v1 vs. snapshot_v1 call as it better handles the updated h3dex. It also updates the h3dex bootstrap functions (specifically delete_h3dex) to handle the random hex targeting keys.

Thanks to @Vagabond for the assist on coming up with the solution.