### PR TITLE
Fix json encoding for token type

### DIFF
--- a/include/blockchain_json.hrl
+++ b/include/blockchain_json.hrl
@@ -10,3 +10,4 @@
 -define (MAYBE_B64(B), blockchain_json:maybe_b64((B))).
 -define (MAYBE_H3(B), blockchain_json:maybe_h3((B))).
 -define (MAYBE_LIST_TO_BINARY(L), blockchain_json:maybe_list_to_binary((L))).
+-define (MAYBE_ATOM_TO_BINARY(A), blockchain_json:maybe_atom_to_binary(A)).

--- a/src/blockchain_json.erl
+++ b/src/blockchain_json.erl
@@ -21,7 +21,8 @@
          maybe_b64/1,
          maybe_b58/1,
          maybe_h3/1,
-         maybe_list_to_binary/1
+         maybe_list_to_binary/1,
+         maybe_atom_to_binary/1
         ]).
 
 %%
@@ -67,3 +68,8 @@ maybe_list_to_binary(V) ->
                  (<<>>) -> undefined;
                  (I) when is_binary(I) -> I
              end, V).
+
+-spec maybe_atom_to_binary(undefined | atom()) -> undefined | binary().
+maybe_atom_to_binary(undefined) -> undefined;
+maybe_atom_to_binary(A) when is_atom(A) ->
+    atom_to_binary(A, utf8).

--- a/src/transactions/v1/blockchain_txn_add_subnetwork_v1.erl
+++ b/src/transactions/v1/blockchain_txn_add_subnetwork_v1.erl
@@ -198,7 +198,7 @@ to_json(Txn, _Opts) ->
     #{
         type => ?MODULE:json_type(),
         hash => ?BIN_TO_B64(hash(Txn)),
-        token_type => atom_to_binary(token_type(Txn), utf8),
+        token_type => ?MAYBE_ATOM_TO_BINARY(token_type(Txn)),
         subnetwork_key => ?BIN_TO_B58(subnetwork_key(Txn)),
         reward_server_keys => [?BIN_TO_B58(K) || K <- reward_server_keys(Txn)]
     }.
@@ -214,3 +214,19 @@ verify_key(_Artifact, _Key, <<>>) ->
     throw({error, no_signature});
 verify_key(Artifact, Key, Signature) ->
     libp2p_crypto:verify(Artifact, Signature, libp2p_crypto:bin_to_pubkey(Key)).
+
+
+%% ------------------------------------------------------------------
+%% EUNIT Tests
+%% ------------------------------------------------------------------
+-ifdef(TEST).
+
+to_json_test() ->
+    T = new(mobile, <<"subnetwork_key">>, [<<"reward_server_key">>], 10000),
+    Json = to_json(T, []),
+    ?assert(lists:all(fun(K) -> maps:is_key(K, Json) end,
+                      [type, hash, token_type, subnetwork_key, reward_server_keys])),
+    ?assertEqual(<<"mobile">>, maps:get(token_type, Json)),
+    ok.
+
+-endif.

--- a/src/transactions/v1/blockchain_txn_subnetwork_rewards_v1.erl
+++ b/src/transactions/v1/blockchain_txn_subnetwork_rewards_v1.erl
@@ -257,7 +257,7 @@ to_json(Txn, _Opts) ->
     TT = ?MODULE:token_type(Txn),
     #{
         type => ?MODULE:json_type(),
-        token_type => atom_to_binary(TT),
+        token_type => ?MAYBE_ATOM_TO_BINARY(TT),
         hash => ?BIN_TO_B64(hash(Txn)),
         start_epoch => start_epoch(Txn),
         end_epoch => end_epoch(Txn),
@@ -268,5 +268,14 @@ to_json(Txn, _Opts) ->
 %% EUNIT Tests
 %% ------------------------------------------------------------------
 -ifdef(TEST).
+
+to_json_test() ->
+
+    T = new(mobile, 1, 30, [new_reward(<<"rewardee">>, 100)]),
+    Json = to_json(T, []),
+    ?assert(lists:all(fun(K) -> maps:is_key(K, Json) end,
+                      [type, hash, token_type, start_epoch, end_epoch, rewards])),
+    ?assertEqual(<<"mobile">>, maps:get(token_type, Json)),
+    ok.
 
 -endif.

--- a/src/transactions/v2/blockchain_payment_v2.erl
+++ b/src/transactions/v2/blockchain_payment_v2.erl
@@ -173,7 +173,7 @@ to_json(Payment, _Opts) ->
       amount => amount(Payment),
       memo => ?MAYBE_FN(fun (V) -> base64:encode(<<(V):64/unsigned-little-integer>>) end, memo(Payment)),
       max => ?MODULE:max(Payment),
-      token_type => atom_to_list(token_type(Payment))
+      token_type => ?MAYBE_ATOM_TO_BINARY(token_type(Payment))
      }.
 
 %% ------------------------------------------------------------------
@@ -225,5 +225,8 @@ to_json_test() ->
     Payment = new(<<"payee">>, 100),
     Json = to_json(Payment, []),
     ?assert(lists:all(fun(K) -> maps:is_key(K, Json) end,
-                      [payee, amount, memo, max, token_type])).
+                      [payee, amount, memo, max, token_type])),
+    ?assertEqual(<<"mobile">>, maps:get(token_type, to_json(new(<<"payee">>, 200, mobile), []))),
+    ok.
+
 -endif.


### PR DESCRIPTION
Problem
----
payment v2 was encoding token type as a list, which is incorrect.

Solution
----
- Add an explicit macro `ATOM_TO_BIN` to `blockchain_json.hrl`, use it wherever token_type needs to be converted to binary.