### PR TITLE
Expose payment amounts when max=true

### DIFF
--- a/src/transactions/v2/blockchain_payment_v2.erl
+++ b/src/transactions/v2/blockchain_payment_v2.erl
@@ -167,10 +167,11 @@ json_type() ->
     undefined.
 
 -spec to_json(payment(), blockchain_json:opts()) -> blockchain_json:json_object().
-to_json(Payment, _Opts) ->
+to_json(Payment, Opts) ->
+    Amount = proplists:get_value(amount, Opts),
     #{
       payee => ?BIN_TO_B58(payee(Payment)),
-      amount => amount(Payment),
+      amount => Amount,
       memo => ?MAYBE_FN(fun (V) -> base64:encode(<<(V):64/unsigned-little-integer>>) end, memo(Payment)),
       max => ?MODULE:max(Payment),
       token_type => ?MAYBE_ATOM_TO_BINARY(token_type(Payment))

--- a/src/transactions/v2/blockchain_payment_v2.erl
+++ b/src/transactions/v2/blockchain_payment_v2.erl
@@ -168,7 +168,10 @@ json_type() ->
 
 -spec to_json(payment(), blockchain_json:opts()) -> blockchain_json:json_object().
 to_json(Payment, Opts) ->
-    Amount = proplists:get_value(amount, Opts),
+    Amount = case proplists:get_value(amount, Opts, undefined) of
+                 undefined -> amount(Payment);
+                 Amt -> Amt
+             end,
     #{
       payee => ?BIN_TO_B58(payee(Payment)),
       amount => Amount,


### PR DESCRIPTION
Summary
----
This PR adds amount when `max=true` for payment_v2 transactions.
It requires that `ledger` be passed in when calling `to_json` for payment_v2 transactions implying that ETL needs to be upgraded to do the same.

TODO:
- [x] Test existing stuff
- [x] Extend json test