### PR TITLE
Use a CREAM cache for valid witnesses, not pdict

### DIFF
--- a/include/blockchain.hrl
+++ b/include/blockchain.hrl
@@ -36,6 +36,7 @@
 -define(gw_cache, gw_cache).
 -define(fp_cache, fp_cache).
 -define(routing_cache, routing_cache).
+-define(witness_cache, witness_cache).
 -define(sc_server_cache, routing_cache).
 
 -define(BC_UPGRADE_NAMES, [

--- a/src/blockchain_sup.erl
+++ b/src/blockchain_sup.erl
@@ -193,7 +193,14 @@ cream_caches_init() ->
         = cream:new(1000,
                     [{initial_capacity, 50},
                      {seconds_to_idle, 6 * 60 * 60}]),
-    persistent_term:put(?routing_cache, RoutingCache).
+    persistent_term:put(?routing_cache, RoutingCache),
+
+    {ok, WitnessCache}
+        = cream:new(20000,
+                    [{initial_capacity, 10000},
+                     {seconds_to_idle, 60 * 60}]),
+    persistent_term:put(?witness_cache, WitnessCache).
+
 
 cream_caches_clear() ->
     cream:drain(persistent_term:get(?var_cache)),
@@ -201,4 +208,5 @@ cream_caches_clear() ->
     cream:drain(persistent_term:get(?score_cache)),
     cream:drain(persistent_term:get(?fp_cache)),
     cream:drain(persistent_term:get(?sc_server_cache)),
-    cream:drain(persistent_term:get(?routing_cache)).
+    cream:drain(persistent_term:get(?routing_cache)),
+    cream:drain(persistent_term:get(?witness_cache)).

--- a/src/blockchain_sup.erl
+++ b/src/blockchain_sup.erl
@@ -196,7 +196,7 @@ cream_caches_init() ->
     persistent_term:put(?routing_cache, RoutingCache),
 
     {ok, WitnessCache}
-        = cream:new(20000,
+        = cream:new(50000,
                     [{initial_capacity, 10000},
                      {seconds_to_idle, 60 * 60}]),
     persistent_term:put(?witness_cache, WitnessCache).


### PR DESCRIPTION
CREAM will evict naturally based on idle time and size, so use it to
replace the pdict cache that was never collected and would leak memory.