### PR TITLE
Fix negative payment json

### DIFF
--- a/src/transactions/v2/blockchain_txn_payment_v2.erl
+++ b/src/transactions/v2/blockchain_txn_payment_v2.erl
@@ -702,7 +702,7 @@ payment_json(Txn, Opts) ->
                       fun(Payment) ->
                               TT = blockchain_payment_v2:token_type(Payment),
                               PayeeAmount = case blockchain_payment_v2:amount(Payment) of
-                                                0 -> maps:get(TT, MaxPaymentsMap, 0);
+                                                0 -> abs(maps:get(TT, MaxPaymentsMap, 0));
                                                 Amount when Amount > 0 -> Amount
                                             end,
                               blockchain_payment_v2:to_json(Payment, [{amount, PayeeAmount}])
@@ -712,7 +712,7 @@ payment_json(Txn, Opts) ->
                     lists:map(
                       fun(Payment) ->
                               PayeeAmount = case blockchain_payment_v2:amount(Payment) of
-                                                0 -> MaxPayment;
+                                                0 -> abs(MaxPayment);
                                                 Amount when Amount > 0 -> Amount
                                             end,
                               blockchain_payment_v2:to_json(Payment, [{amount, PayeeAmount}])


### PR DESCRIPTION
This should fix this returning payment json:

```json
"payments": [
  {
    "token_type": "hnt",
    "payee": "1bspLkazKxCiAHhwQkcrU84fm8M4DkmaYexdK1XpEz7t9RTLRsN",
    "memo": "AAAAAAAAAAA=",
    "max": true,
    "amount": -4085922
  }
],
```
