### PR TITLE
don't sync forever when halted

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -1181,6 +1181,8 @@ add_block_(Block, Blockchain, Syncing) ->
                             end,
                             Error;
                         {ok, KeysPayload} ->
+                            %% we managed to sync a block, so clear the drop cache limiter if set
+                            application:unset_env(blockchain, '$drop_cache_once'),
                             run_absorb_block_hooks(Syncing, Hash, Blockchain, KeysPayload)
                     end;
                 plausible ->
@@ -1287,6 +1289,7 @@ replay_blocks(Chain, Syncing, LedgerHeight, ChainHeight) ->
                                       fun(FChain, _FHash) -> ok = run_gc_hooks(FChain, B) end,
                                       blockchain_block:is_rescue_block(B)) of
                   {ok, KeysPayload} ->
+                      application:unset_env(blockchain, '$drop_cache_once'),
                       run_absorb_block_hooks(Syncing, Hash, Chain, KeysPayload);
                   {error, Reason} ->
                       lager:error("Error absorbing transaction, "

--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -1167,8 +1167,15 @@ add_block_(Block, Blockchain, Syncing) ->
                             lager:error("Error absorbing transaction, Ignoring Hash: ~p, Reason: ~p", [blockchain_block:hash_block(Block), Reason]),
                             case application:get_env(blockchain, drop_snapshot_cache_on_absorb_failure, true) of
                                 true ->
-                                    lager:info("dropping all snapshots from cache"),
-                                    blockchain_ledger_v1:drop_snapshots(Ledger);
+                                    case application:get_env(blockchain, '$drop_cache_once', false) of
+                                        false ->
+                                            lager:info("dropping all snapshots from cache"),
+                                            blockchain_ledger_v1:drop_snapshots(Ledger),
+                                            application:set_env(blockchain, '$drop_cache_once', true);
+                                        true ->
+                                            lager:info("previous drop cache ineffective, pausing sync"),
+                                            blockchain_worker:pause_sync_cast()
+                                    end;
                                 false ->
                                     ok
                             end,


### PR DESCRIPTION
The current behavior for invalid txns is to clear the snapshot cache and retry syncing.  This is incredibly expensive, and should only be tried once, as trying repeatedly is unlikely to result in any progress.  This PR adds some sadly global state for this so that we don't keep retrying, but halt after a single try and pause syncing until action is taken.