### PR TITLE
Ensure that new_context cannot be called on a ledger with existing context

### DIFF
--- a/src/blockchain_worker.erl
+++ b/src/blockchain_worker.erl
@@ -835,8 +835,9 @@ integrate_genesis_block_(
             {{error, block_not_genesis}, S0};
         true ->
             ok = blockchain:integrate_genesis(GenesisBlock, Chain),
-            Ledger = blockchain:ledger(Chain),
+            Ledger = blockchain_ledger_v1:new_context(blockchain:ledger(Chain)),
             blockchain:mark_upgrades(?BC_UPGRADE_NAMES, Ledger),
+            blockchain_ledger_v1:commit_context(Ledger),
             [ConsensusAddrs] =
                 [
                     blockchain_txn_consensus_group_v1:members(T)

--- a/src/ledger/v1/blockchain_aux_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_aux_ledger_v1.erl
@@ -102,6 +102,7 @@ new(Path, Ledger) ->
         GwDenormCF,
         ValidatorsCF,
         EntriesV2CF,
+        SubnetworksV1CF,
         AuxHeightsCF,
         AuxHeightsMDCF,
         AuxHeightsDiffCF,
@@ -130,7 +131,8 @@ new(Path, Ledger) ->
                 state_channels = SCsCF,
                 h3dex = H3DexCF,
                 validators = ValidatorsCF,
-                entries_v2 = EntriesV2CF
+                entries_v2 = EntriesV2CF,
+                subnetworks_v1=SubnetworksV1CF
             }
         }
     }.

--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -526,7 +526,7 @@ unvalidated_absorb_and_commit(Block, Chain0, BeforeCommit, Rescue) ->
                      Ty == blockchain_txn_vars_v1
            end, (Transactions0)),
     Start = erlang:monotonic_time(millisecond),
-    case ?MODULE:validate(Transactions, Chain1, Rescue) of
+    case ?MODULE:validate(Transactions, Chain0, Rescue) of
         {_ValidTxns, []} ->
             End = erlang:monotonic_time(millisecond),
             telemetry:execute([blockchain, block, unvalidated_absorb], #{duration => End - Start}, #{stage => validation}),
@@ -880,7 +880,7 @@ absorb_delayed_async(Block0, Chain0) ->
     Parent = self(),
     {Pid, MonitorRef} =
     spawn_monitor(fun() ->
-                          Ledger0 = blockchain:ledger(Chain0),
+                          Ledger0 = blockchain_ledger_v1:remove_context(blockchain:ledger(Chain0)),
                           DelayedLedger0 = blockchain_ledger_v1:mode(delayed, Ledger0),
                           DelayedLedger1 = blockchain_ledger_v1:new_context(DelayedLedger0),
                           Chain1 = blockchain:ledger(DelayedLedger1, Chain0),

--- a/src/transactions/v1/blockchain_txn_reward_v1.erl
+++ b/src/transactions/v1/blockchain_txn_reward_v1.erl
@@ -115,6 +115,10 @@ is_valid(#blockchain_txn_reward_v1_pb{account=Account, gateway=Gateway,
 %%--------------------------------------------------------------------
 -spec print(reward()) -> iodata().
 print(undefined) -> <<"type=reward undefined">>;
+print(#blockchain_txn_reward_v1_pb{account=Account, gateway=undefined,
+                                   amount=Amount, type=Type}) ->
+    io_lib:format("type=reward account=~p, amount=~p, type=~p",
+                  [?TO_B58(Account), Amount, Type]);
 print(#blockchain_txn_reward_v1_pb{account=Account, gateway=Gateway,
                                    amount=Amount, type=Type}) ->
     io_lib:format("type=reward account=~p, gateway=~p, amount=~p, type=~p",

--- a/test/blockchain_snapshot_SUITE.erl
+++ b/test/blockchain_snapshot_SUITE.erl
@@ -19,9 +19,11 @@
 init_per_suite(Cfg) ->
     {ok, _} = application:ensure_all_started(lager),
     {ok, _} = application:ensure_all_started(telemetry),
+    blockchain_sup:cream_caches_init(),
     Cfg.
 
 end_per_suite(_) ->
+    blockchain_sup:cream_caches_clear(),
     ok.
 
 all() ->


### PR DESCRIPTION
Additionally, ensure that the mode cannot be changed on a ledger context
and fix some test failures.