### PR TITLE
submitting grpc txn key

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -64,7 +64,7 @@
  {<<"hackney">>,{pkg,<<"hackney">>,<<"1.18.1">>},0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"a0a58da6420b3cfb47778d549af4b0cd256e7ece"}},
+       {ref,"a9c1d484e117384c195e0980bd0225c219f78996"}},
   0},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},2},
  {<<"idna">>,{pkg,<<"idna">>,<<"6.1.1">>},1},

--- a/src/grpc/helium_transaction_service.erl
+++ b/src/grpc/helium_transaction_service.erl
@@ -15,10 +15,10 @@
 %% ------------------------------------------------------------------
 -spec submit(ctx:ctx(), transaction_pb:txn_submit_req_v1_pb()) ->
     {ok, transaction_pb:txn_submit_resp_v1_pb()} | grpcbox_stream:grpc_error_response().
-submit(Ctx, #txn_submit_req_v1_pb{txn = WrappedTxn}) ->
+submit(Ctx, #txn_submit_req_v1_pb{txn = WrappedTxn, key = Key}) ->
     Txn = blockchain_txn:unwrap_txn(WrappedTxn),
-    {ok, TxnKey, CurHeight} = blockchain_txn_mgr:grpc_submit(Txn),
-    Resp = #txn_submit_resp_v1_pb{key = TxnKey,
+    {ok, Key, CurHeight} = blockchain_txn_mgr:grpc_submit(Txn, Key),
+    Resp = #txn_submit_resp_v1_pb{key = Key,
                                   validator = routing_info(),
                                   recv_height = CurHeight,
                                   signature = <<>>},


### PR DESCRIPTION
allow submitting txns over grpc to include a txn key from the submitter to allow the submitting service to deterministically query its own transactions in the event they aren't successfully delivered for any reason