### PR TITLE
Fix subnetwork reward txn hash

### DIFF
--- a/src/transactions/v1/blockchain_txn_subnetwork_rewards_v1.erl
+++ b/src/transactions/v1/blockchain_txn_subnetwork_rewards_v1.erl
@@ -65,7 +65,7 @@ new(Type, Start, End, Rewards) ->
 
 -spec hash(txn_subnetwork_rewards_v1()) -> blockchain_txn:hash().
 hash(Txn) ->
-    EncodedTxn = blockchain_txn_subnetwork_rewards_v1_pb:encode_msg(Txn),
+    EncodedTxn = blockchain_txn_subnetwork_rewards_v1_pb:encode_msg(base(Txn)),
     crypto:hash(sha256, EncodedTxn).
 
 -spec token_type(txn_subnetwork_rewards_v1()) -> blockchain_token_v1:type().
@@ -104,8 +104,7 @@ reward_server_signature(#blockchain_txn_subnetwork_rewards_v1_pb{reward_server_s
 
 -spec sign(txn_subnetwork_rewards_v1(), libp2p_crypto:sig_fun()) -> txn_subnetwork_rewards_v1().
 sign(Txn, SigFun) ->
-    BaseTxn = Txn#blockchain_txn_subnetwork_rewards_v1_pb{reward_server_signature = <<>>},
-    EncodedTxn = blockchain_txn_subnetwork_rewards_v1_pb:encode_msg(BaseTxn),
+    EncodedTxn = blockchain_txn_subnetwork_rewards_v1_pb:encode_msg(base(Txn)),
     Txn#blockchain_txn_subnetwork_rewards_v1_pb{reward_server_signature = SigFun(EncodedTxn)}.
 
 -spec fee(txn_subnetwork_rewards_v1()) -> 0.
@@ -263,6 +262,10 @@ to_json(Txn, _Opts) ->
         end_epoch => end_epoch(Txn),
         rewards => Rewards
     }.
+
+-spec base(Txn :: txn_subnetwork_rewards_v1()) -> txn_subnetwork_rewards_v1().
+base(Txn) ->
+    Txn#blockchain_txn_subnetwork_rewards_v1_pb{reward_server_signature = <<>>}.
 
 %% ------------------------------------------------------------------
 %% EUNIT Tests

--- a/src/transactions/v1/blockchain_txn_subnetwork_rewards_v1.erl
+++ b/src/transactions/v1/blockchain_txn_subnetwork_rewards_v1.erl
@@ -263,7 +263,7 @@ to_json(Txn, _Opts) ->
         rewards => Rewards
     }.
 
--spec base(Txn :: txn_subnetwork_rewards_v1()) -> txn_subnetwork_rewards_v1().
+-spec base(Txn) -> Txn when Txn :: txn_subnetwork_rewards_v1().
 base(Txn) ->
     Txn#blockchain_txn_subnetwork_rewards_v1_pb{reward_server_signature = <<>>}.
 


### PR DESCRIPTION
Problem
----
Subnetwork reward txn hashes are not consistent because the signature field was still present when proto encoding the txn.

Solution
----
Unset the signature before calculating the txn hash.

Caveats
----
I _think_ this is largely okay and would not cause any chain related problems since we don't technically use the txn hash for any chain consistency. However, APIs may have a tough time querying the few subnetwork reward txns which are already on chain. AFAICT there's no workaround for that other than to manually fix the external database(s) where the inconsistent hashes were stored.