### PR TITLE
Revert "Try not deleting the hex cache, just delete from pdict"

### DIFF
--- a/src/blockchain_hex.erl
+++ b/src/blockchain_hex.erl
@@ -34,6 +34,8 @@
 %% @doc This call will destroy the memoization context used during a rewards
 %% calculation.
 destroy_memoization() ->
+    try ets:delete(get(?PRE_CLIP_TBL)) catch _:_ -> true end,
+    try ets:delete(get(?PRE_UNCLIP_TBL)) catch _:_ -> true end,
     _ = erase(?PRE_CLIP_TBL),
     _ = erase(?PRE_UNCLIP_TBL),
     true.


### PR DESCRIPTION
This reverts commit 22302c97c48ea27380086dd284de268609ecce62 in attempt to fix a memory leak. While in consensus group, the memory usage for a validator groups and does not return to pre-consensus levels once elected out. I tracked this to large ETS usage after CG (e.g., 3.8 GB on a validator which had a CG run since last reboot which is 10X that of a validator that has not been in CG since reboot). Much of that space is occupied multiple copies of `__blockchain_hex_unclipped_tbl` and `__blockchain_hex_clipped_tbl` (one each per epoch in CG).

```
id                                  name                             type  size    mem     owner
 ----------------------------------------------------------------------------
#Ref<0.4233474657.597819418.185503> '__blockchain_hex_unclipped_tbl' set   2395389 23961932 miner
#Ref<0.4233474657.597819418.185504> '__blockchain_hex_clipped_tbl'   set   2395389 23961932 miner
```