### PR TITLE
change consensus deselection weighting

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -51,6 +51,10 @@
 %% a round
 -define(election_seen_penalty, election_seen_penalty).
 
+%% percentage of previous penalties for the current group that are used
+%% when calculating score for deselecting members from current group
+-define(election_penalty_history_percentage, election_penalty_history_percentage).
+
 %%%
 %%% ledger vars
 %%%

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -895,6 +895,7 @@ validate_var(?election_version, Value) ->
         4 -> ok;
         5 -> ok;  % validator move trigger
         6 -> ok;  % move to maps
+        7 -> ok;  % group deselection score changes
         _ ->
             throw({error, {invalid_election_version, Value}})
     end;
@@ -918,6 +919,8 @@ validate_var(?election_bba_penalty, Value) ->
     validate_float(Value, "election_bba_penalty", 0.001, 0.5);
 validate_var(?election_seen_penalty, Value) ->
     validate_float(Value, "election_seen_penalty", 0.001, 0.5);
+validate_var(?election_penalty_history_percentage, Value) ->
+    validate_float(Value, "election_penalty_history_percentage", 0, 1.0);
 
 %% ledger vars
 validate_var(?var_gw_inactivity_threshold, Value) ->


### PR DESCRIPTION
This change lays the foundation for additional tunability in the election process, specifically with the goal of removing low performers more quickly from the group. This flexibility is achieved through two changes:
1. New chain var `election_penalty_history_percentage` which is used during scoring of existing group members before selecting members for removal. This value controls whether and how much the previous penalties contribute to the score: `([election_penalty_history_percentage] * [total existing penalty]) + [current epoch performance penalty] + [current epoch tenure penalty]`
2. Changes the tenure penalty from being applied at the beginning of the round to the end of the round. This makes it so that the tenure penalty for the current group is not part of the previous penalties. This is necessary because if the election_penalty_history_percentage is zero, we still want to count the current round's tenure penalty in the score for deselecting.

These changes are guarded behind election_version = 7. No changes are made in the logic for selection new validators into CG. It continues to be weighted random based on the total penalty score at time of the election.

To achieve the goal of more quickly removing low performers, I suggest that `election_penalty_history_percentage` = 0. This causes the deselection to be based entirely on performance in the existing group which in my opinion is the most important consideration for a well functioning CG. In the long-run, this will still provide equal rewards for equal performance. If all validators have perform perfectly during an epoch, the odds of being removed are equal. That said, governance processes should be used to select the value of this new var and are outside the scope of this PR.