### PR TITLE
Allow res5 hex garabage collection

### DIFF
--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1112,7 +1112,7 @@ validate_var(?poc_typo_fixes, Value) ->
 validate_var(?poc_target_hex_parent_res, Value) ->
     validate_int(Value, "poc_target_hex_parent_res", 3, 7, false);
 validate_var(?poc_target_hex_collection_res, Value) ->
-    validate_int(Value, "poc_target_hex_collection_res", 7, 12, false);
+    validate_int(Value, "poc_target_hex_collection_res", 5, 12, false);
 validate_var(?poc_good_bucket_low, Value) ->
     validate_int(Value, "poc_good_bucket_low", -150, -90, false);
 validate_var(?poc_good_bucket_high, Value) ->


### PR DESCRIPTION
Ideally, garbage collection of inactive gateways in the h3dex should be performed at the same resolution as targeting. This will ensure that every hex that can be targeted can also be garbage collected. Currently, targeting is performed at h3 res5 however garbage collection is performed at res7. This results in entire res7 hexes within a res5 that are never garbage collected and thus skew targeting.

This PR updates the validation in the var txn to allow the collection res to be changed from 7 to 5.

CC: @evanmcc 