### PR TITLE
implement stream of active gateways

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -64,7 +64,7 @@
  {<<"hackney">>,{pkg,<<"hackney">>,<<"1.18.1">>},0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"b09456889e406889f4fa1ea325b9503678dc8447"}},
+       {ref,"e3a9581b5add8e0182b27232ab8727d6355d87f9"}},
   0},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},2},
  {<<"idna">>,{pkg,<<"idna">>,<<"6.1.1">>},1},

--- a/src/ledger/v1/blockchain_ledger_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_v1.erl
@@ -1279,13 +1279,13 @@ active_gateways_stream(Ledger) ->
         {error, Reason} ->
             error({active_gw_rocks_iter_make, Reason});
         {ok, Iter} ->
-            Move =
-                fun Move_ (Target) ->
+            IterStart =
+                fun IterAdvance (Target) ->
                     fun () ->
                         case rocksdb:iterator_move(Iter, Target) of
                             {ok, K, V} ->
                                 io:format(user, "some ~p", [Iter]),
-                                {some, {{K, V}, Move_(next)}};
+                                {some, {{K, V}, IterAdvance(next)}};
                             {error, invalid_iterator} ->
                                 io:format(user, "none ~p", [Iter]),
                                 ok = rocksdb:iterator_close(Iter),
@@ -1295,7 +1295,7 @@ active_gateways_stream(Ledger) ->
                         end
                     end
                 end,
-            Move(first)
+            IterStart(first)
     end.
 
 


### PR DESCRIPTION
implement a stream of records from the active gateways column family on the ledger in order to allow lazy streaming of large volumes of records out of the ledger downstream via blockchain-node or similar.