### PR TITLE
Use ledger checkpoint/snapshot at currentheight - block_delay for snaps

### DIFF
--- a/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
+++ b/src/ledger/v1/blockchain_ledger_snapshot_v1.erl
@@ -166,7 +166,13 @@
     {ok, snapshot()}
     | {error, killed | snapshot_error()}.
 snapshot(Ledger0, Blocks, Infos) ->
-    snapshot(Ledger0, Blocks, Infos, delayed).
+    %% by default use the ledger height - block_delay to emulate the lagging ledger but not actually
+    %% using the lagging ledger because that has recently been found subject to corruption or lagging
+    %% too far behind. Nodes that are reliably syncing will have a rocksdb checkpoint/snapshot at this
+    %% height which is safer to use.
+    {ok, Height} = blockchain_ledger_v1:current_height(Ledger0),
+    {ok, SnapLedger} = blockchain_ledger_v1:has_snapshot(Height - blockchain_txn:block_delay(), Ledger0),
+    snapshot(SnapLedger, Blocks, Infos, active).
 
 -spec snapshot(
     blockchain_ledger_v1:ledger(),


### PR DESCRIPTION
Prior to this the default way to take a snapshot was to use the delayed ledger. However recent events has revealed delayed ledgers lagging too far behind and delayed ledger corruption. In the time since the delayed ledger was added the chain has switched to using rocksdb snapshots/checkpoints which offer a more reliable and less vulnerable to corruption source for snapshot data.