### PR TITLE
Teardown region cache on delayed ledger absorb

### DIFF
--- a/src/blockchain_utils.erl
+++ b/src/blockchain_utils.erl
@@ -63,6 +63,7 @@
     get_vars/2, get_var/2,
     var_cache_stats/0,
     teardown_var_cache/0,
+    teardown_region_cache/0,
     target_v_to_mod/1
 
 
@@ -909,6 +910,12 @@ var_cache_stats() ->
 -spec teardown_var_cache() -> ok.
 teardown_var_cache() ->
     Cache = persistent_term:get(?var_cache),
+    cream:drain(Cache),
+    ok.
+
+-spec teardown_region_cache() -> ok.
+teardown_region_cache() ->
+    Cache = persistent_term:get(?region_cache),
     cream:drain(Cache),
     ok.
 

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -617,6 +617,7 @@ delayed_absorb(Txn, Ledger) ->
             end
     end,
     blockchain_utils:teardown_var_cache(),
+    blockchain_utils:teardown_region_cache(),
     case blockchain_ledger_v1:mode(Ledger) of
         active ->
             %% we've invalidated the region cache, so prewarm it.


### PR DESCRIPTION
# Summary

Sooner rather than later we'll have to issue some more region related vars, there's already some reports of region misalignment (Kazakhstan still on EU433 for example, instead of IN865). I **think** this change will help to hopefully avoid the delayed ledger cache being inconsistent on a region var change.