### PR TITLE
update grpcbox

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -55,7 +55,7 @@
  {<<"gproc">>,{pkg,<<"gproc">>,<<"0.8.0">>},1},
  {<<"grpcbox">>,
   {git,"https://github.com/novalabsxyz/grpcbox.git",
-       {ref,"1cf5d0dd0b4073906039ad00ba5c562e7f29595b"}},
+       {ref,"e1f0bdbb5408c5d5bb68b5c848c19b89bce90c84"}},
   0},
  {<<"h3">>,
   {git,"https://github.com/helium/erlang-h3.git",


### PR DESCRIPTION
Update the fork of the grpcbox server dependency to no longer cancel the h2 stream directly when a server RPC handler returns a `{stop, State}` tuple. This has been found to prevent the server from prematurely terminating a stream when a client may still be receiving messages on the stream.

Other handler return types (those in use by the validator rpc streams) are remain unchanged.