### PR TITLE
define custom regions

### DIFF
--- a/src/region/blockchain_region_params_v1.erl
+++ b/src/region/blockchain_region_params_v1.erl
@@ -58,14 +58,27 @@ for_region(RegionVar, Ledger) ->
 %% required for the transition period. Maybe we can remove it once a majority
 %% of the fleet has transitioned after activation of region variables on chain.
 region_param('AS923_1') -> region_as923_1_params;
+region_param('AS923_1A') -> region_as923_1a_params;
 region_param('AS923_1B') -> region_as923_1b_params;
+region_param('AS923_1C') -> region_as923_1c_params;
+region_param('AS923_1D') -> region_as923_1d_params;
+region_param('AS923_1E') -> region_as923_1e_params;
+region_param('AS923_1F') -> region_as923_1f_params;
 region_param('AS923_2') -> region_as923_2_params;
 region_param('AS923_3') -> region_as923_3_params;
 region_param('AS923_4') -> region_as923_4_params;
 region_param('AU915') -> region_au915_params;
+region_param('AU915_SB1') -> region_au915_sb1_params;
+region_param('AU915_SB2') -> region_au915_sb2_params;
 region_param('CN470') -> region_cn470_params;
 region_param('EU433') -> region_eu433_params;
 region_param('EU868') -> region_eu868_params;
+region_param('EU868_A') -> region_eu868_a_params;
+region_param('EU868_B') -> region_eu868_b_params;
+region_param('EU868_C') -> region_eu868_c_params;
+region_param('EU868_D') -> region_eu868_d_params;
+region_param('EU868_E') -> region_eu868_e_params;
+region_param('EU868_F') -> region_eu868_f_params;
 region_param('IN865') -> region_in865_params;
 region_param('KR920') -> region_kr920_params;
 region_param('RU864') -> region_ru864_params;

--- a/src/state_channel/v1/blockchain_state_channel_offer_v1.erl
+++ b/src/state_channel/v1/blockchain_state_channel_offer_v1.erl
@@ -130,14 +130,27 @@ decode(BinaryOffer) ->
 %% convert poc11 region names to protobuff enum names
 maybe_fix_region('region_us915') -> 'US915';
 maybe_fix_region('region_as923_1') -> 'AS923_1';
+maybe_fix_region('region_as923_1a') -> 'AS923_1A';
 maybe_fix_region('region_as923_1b') -> 'AS923_1B';
+maybe_fix_region('region_as923_1c') -> 'AS923_1C';
+maybe_fix_region('region_as923_1d') -> 'AS923_1D';
+maybe_fix_region('region_as923_1e') -> 'AS923_1E';
+maybe_fix_region('region_as923_1f') -> 'AS923_1F';
 maybe_fix_region('region_as923_2') -> 'AS923_2';
 maybe_fix_region('region_as923_3') -> 'AS923_3';
 maybe_fix_region('region_as923_4') -> 'AS923_4';
 maybe_fix_region('region_au915') -> 'AU915';
+maybe_fix_region('region_au915_sb1') -> 'AU915_SB1';
+maybe_fix_region('region_au915_sb2') -> 'AU915_SB2';
 maybe_fix_region('region_cn470') -> 'CN470';
 maybe_fix_region('region_eu433') -> 'EU433';
 maybe_fix_region('region_eu868') -> 'EU868';
+maybe_fix_region('region_eu868_a') -> 'EU868_A';
+maybe_fix_region('region_eu868_b') -> 'EU868_B';
+maybe_fix_region('region_eu868_c') -> 'EU868_C';
+maybe_fix_region('region_eu868_d') -> 'EU868_D';
+maybe_fix_region('region_eu868_e') -> 'EU868_E';
+maybe_fix_region('region_eu868_f') -> 'EU868_F';
 maybe_fix_region('region_in865') -> 'IN865';
 maybe_fix_region('region_kr920') -> 'KR920';
 %% pre-poc 11 these will be correct


### PR DESCRIPTION
Problem Statement:
Often a country or several countries need a custom region, which defines slightly different parameters. For example in Malaysia any frequencies in 924 Mhz are not legal.

Solution:
So we defined a new region AS923_1B which did not use frequency within 924 Mhz. Now Kenya needs this same custom region, because some of our EU868 frequencies are not legal. This will be a recurring pattern. The PR, review, commit process is painful so lets just do this once across all our repos and define EU868_A to _F and AS923_1A .. 1F

Only AS923 and EU868 will require custom regions.