### PR TITLE
Add subnetwork_mint var

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -659,3 +659,6 @@
 
 %% var to halt the chain
 -define(halt_chain, halt_chain).
+
+%% var to enable subnetwork mint without debiting token_treasury
+-define(subnetwork_mint, subnetwork_mint).

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1621,6 +1621,12 @@ validate_var(?halt_chain, Value) ->
         _ -> throw({error, {invalid_halt_chain, Value}})
     end;
 
+validate_var(?subnetwork_mint, Value) ->
+    case Value of
+        Val when is_boolean(Val) -> ok;
+        _ -> throw({error, {invalid_subnetwork_mint, Value}})
+    end;
+
 validate_var(Var, Value) ->
     %% check if these are dynamic region vars
     case atom_to_list(Var) of


### PR DESCRIPTION
This enables minting subnetwork tokens without debiting from the overall token_treasury.