### PR TITLE
Don't drop snapshots/checkpoints on block absorb failure

### DIFF
--- a/src/blockchain.erl
+++ b/src/blockchain.erl
@@ -1175,7 +1175,7 @@ add_block_(Block, Blockchain, Syncing) ->
                     case blockchain_txn:Fun(Block, Blockchain, BeforeCommit, IsRescue) of
                         {error, Reason}=Error ->
                             lager:error("Error absorbing transaction, Ignoring Hash: ~p, Reason: ~p", [blockchain_block:hash_block(Block), Reason]),
-                            case application:get_env(blockchain, drop_snapshot_cache_on_absorb_failure, true) of
+                            case application:get_env(blockchain, drop_snapshot_cache_on_absorb_failure, false) of
                                 true ->
                                     case application:get_env(blockchain, '$drop_cache_once', false) of
                                         false ->


### PR DESCRIPTION
This feature has outlived its usefulness and likely does more harm than good now.