### PR TITLE
Fix rescue block absorb on lagging ledger

### DIFF
--- a/src/transactions/blockchain_txn.erl
+++ b/src/transactions/blockchain_txn.erl
@@ -973,7 +973,7 @@ absorb_aux(Block0, Chain0) ->
     end.
 
 plain_absorb_(Block, Chain0) ->
-    case ?MODULE:absorb_block(Block, Chain0) of
+    case ?MODULE:absorb_block(Block, blockchain_block:is_rescue_block(Block), Chain0) of
         {ok, _, KeysPayload} ->
             Ledger0 = blockchain:ledger(Chain0),
             ok = blockchain_ledger_v1:maybe_gc_pocs(Chain0, Ledger0),


### PR DESCRIPTION
For historical reasons, rescue blocks have a slightly different absorb path than normal blocks. This alternate path does NOT increment the var nonce. However, due to an oversight, absorbing blocks into the lagging ledger did not track the rescue status of the block, which could lead to rescue blocks incorrectly incrementing the var nonce, thus changing the "var cache" lookup key to incorrectly return the wrong vars for verifying/absorbing transactions. This change tries to make the lagging absorb the same as the leading absorb.