### PR TITLE
Add a chain var to isolate var txns to their own blockchain_vars

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -667,3 +667,6 @@
 -define(zero_reward_shares_fix, zero_reward_shares_fix).
 
 -define(increment_var_nonce_in_rescue_block, increment_var_nonce_in_rescue_block).
+
+%% whether to isolate var txns into their own block to reduce var cache related issues
+-define(isolate_var_txns, isolate_var_txns).

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1647,6 +1647,12 @@ validate_var(?increment_var_nonce_in_rescue_block, Value) ->
         _ -> throw({error, {invalid_increment_var_nonce_in_rescue_block, Value}})
     end;
 
+validate_var(?isolate_var_txns, Value) ->
+    case Value of
+        Val when is_boolean(Val) -> ok;
+        _ -> throw({error, {invalid_isolate_var_txns, Value}})
+    end;
+
 validate_var(Var, Value) ->
     %% check if these are dynamic region vars
     case atom_to_list(Var) of


### PR DESCRIPTION
Due to several observed cache issues when a var txn appears in a block with other transactions that may have been affected by the var changing, this variable has been introduced to force var txns to appear in their own block. This is done as a var so that it can only be activated once a majority of the consensus group understands the var, so a split block will not be produced.