### PR TITLE
Bypass token treasury amount if var is set to true

### DIFF
--- a/include/blockchain_vars.hrl
+++ b/include/blockchain_vars.hrl
@@ -670,3 +670,6 @@
 
 %% whether to isolate var txns into their own block to reduce var cache related issues
 -define(isolate_var_txns, isolate_var_txns).
+
+%% whether to bypass token treasury amount when validating subnetwork_rewards_v1 txn
+-define(bypass_token_treasury, bypass_token_treasury).

--- a/src/transactions/v1/blockchain_txn_subnetwork_rewards_v1.erl
+++ b/src/transactions/v1/blockchain_txn_subnetwork_rewards_v1.erl
@@ -134,9 +134,13 @@ is_valid(Txn, Chain) ->
     try
         %% this needs to somehow limit the mint here?  but if there is only premine I don't
         %% understand how we do that.
-        case TotalRewards =< blockchain_ledger_subnetwork_v1:token_treasury(Subnet) of
-            true -> ok;
-            false -> throw({insufficient_tokens_to_fulfil_rewards, Tokens, TotalRewards})
+        case ?get_var(?bypass_token_treasury, Ledger) of
+            {ok, true} -> ok;
+            _ ->
+                case TotalRewards =< blockchain_ledger_subnetwork_v1:token_treasury(Subnet) of
+                    true -> ok;
+                    false -> throw({insufficient_tokens_to_fulfil_rewards, Tokens, TotalRewards})
+                end
         end,
         BaseTxn = Txn#blockchain_txn_subnetwork_rewards_v1_pb{reward_server_signature = <<>>},
         Artifact = blockchain_txn_subnetwork_rewards_v1_pb:encode_msg(BaseTxn),

--- a/src/transactions/v1/blockchain_txn_vars_v1.erl
+++ b/src/transactions/v1/blockchain_txn_vars_v1.erl
@@ -1653,6 +1653,12 @@ validate_var(?isolate_var_txns, Value) ->
         _ -> throw({error, {invalid_isolate_var_txns, Value}})
     end;
 
+validate_var(?bypass_token_treasury, Value) ->
+    case Value of
+        Val when is_boolean(Val) -> ok;
+        _ -> throw({error, {invalid_bypass_token_treasury, Value}})
+    end;
+
 validate_var(Var, Value) ->
     %% check if these are dynamic region vars
     case atom_to_list(Var) of


### PR DESCRIPTION
Add a new var `bypass_token_treasury` (bool) which would not check whether the total rewards is <= token_treasury amt in the ledger if the var is set to true.